### PR TITLE
Protect object creation from dropping referenced objects

### DIFF
--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -26,6 +26,7 @@
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
+#include "catalog/pg_ts_parser.h"
 #include "commands/extension.h"
 #include "miscadmin.h"
 #include "storage/lmgr.h"
@@ -837,6 +838,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case ProcedureRelationId:
 			cacheId = PROCOID;
 			objName = "procedure";
+			break;
+		case TSParserRelationId:
+			cacheId = TSPARSEROID;
+			objName = "text search parser";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -92,6 +92,10 @@ recordMultipleDependencies(const ObjectAddress *depender,
 		 */
 		if (!isObjectPinned(referenced, dependDesc))
 		{
+			/*
+			 * Lock the referenced object to protect it from dropping by
+			 * another transaction.
+			 */
 			if (behavior == DEPENDENCY_NORMAL)
 				LockDatabaseObject(referenced->classId,
 								   referenced->objectId,

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -24,6 +24,7 @@
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
 #include "catalog/pg_foreign_data_wrapper.h"
+#include "catalog/pg_foreign_server.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
@@ -852,6 +853,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case ForeignDataWrapperRelationId:
 			cacheId = FOREIGNDATAWRAPPEROID;
 			objName = "foreign data wrapper";
+			break;
+		case ForeignServerRelationId:
+			cacheId = FOREIGNSERVEROID;
+			objName = "server";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -821,15 +821,6 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case OCLASS_TYPE:
 			cacheId = TYPEOID;
 			objName = "type";
-
-			/*
-			 * Type can be not defined, when we define the I/O procs for a new
-			 * type. Do not lock in this case.
-			 */
-			if (!SearchSysCacheExists1(cacheId,
-									 ObjectIdGetDatum(referenced->objectId)))
-				return;
-
 			break;
 		case OCLASS_COLLATION:
 			cacheId = COLLOID;
@@ -878,13 +869,6 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case OCLASS_OPFAMILY:
 			cacheId = OPFAMILYOID;
 			objName = "operator family";
-			/*
-			 * Op family can be not defined yet, if the op class was created
-			 * without specification of a family.
-			 */
-			if (!SearchSysCacheExists1(cacheId,
-									 ObjectIdGetDatum(referenced->objectId)))
-				return;
 			break;
 		default:
 			break;
@@ -892,13 +876,26 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 
 	if (cacheId >= 0)
 	{
+		/*
+		 * Type and op family can be not defined at this point. It is normal
+		 * situation. Type can be not defined, if we define the I/O procs for
+		 * a new type. Op family can be not defined yet, if the op class is
+		 * created without specification of a family. We do not lock in this
+		 * case.
+		 */
+		if ((cacheId == TYPEOID || cacheId == OPFAMILYOID) &&
+			!SearchSysCacheExists1(cacheId,
+								   ObjectIdGetDatum(referenced->objectId)))
+			return;
+
 		/* AccessShareLock should be OK, since we are not modifying the object */
 		LockDatabaseObject(referenced->classId,
 						   referenced->objectId,
 						   referenced->objectSubId,
 						   AccessShareLock);
 
-		if (!SearchSysCacheExists1(cacheId, ObjectIdGetDatum(referenced->objectId)))
+		if (!SearchSysCacheExists1(cacheId,
+								   ObjectIdGetDatum(referenced->objectId)))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("%s %u was concurrently dropped",

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -875,43 +875,41 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 			{
 				cacheId = RELOID;
 				objName = "sequence";
+				break;
 			}
-			break;
-		default:
-			break;
-	}
-
-	if (cacheId >= 0)
-	{
-		/*
-		 * Type and op family can be not defined at this point. It is normal
-		 * situation. Type can be not defined, if we define the I/O procs for
-		 * a new type. Op family can be not defined yet, if the op class is
-		 * created without specification of a family. We do not lock in this
-		 * case.
-		 */
-		if ((cacheId == TYPEOID || cacheId == OPFAMILYOID) &&
-			!SearchSysCacheExists1(cacheId,
-								   ObjectIdGetDatum(referenced->objectId)))
 			return;
-
-		/*
-		 * AccessShareLock should be OK, since we are not modifying the
-		 * object.
-		 */
-		if (cacheId == RELOID)
-			LockRelationOid(referenced->objectId, AccessShareLock);
-		else
-			LockDatabaseObject(referenced->classId,
-							   referenced->objectId,
-							   referenced->objectSubId,
-							   AccessShareLock);
-
-		if (!SearchSysCacheExists1(cacheId,
-								   ObjectIdGetDatum(referenced->objectId)))
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_OBJECT),
-					 errmsg("%s %u was concurrently dropped",
-							objName, referenced->objectId)));
+		default:
+			return;
 	}
+
+	Assert(cacheId >= 0);
+
+	/*
+	 * Type and op family can be not defined at this point. It is normal
+	 * situation. Type can be not defined, if we define the I/O procs for a
+	 * new type. Op family can be not defined yet, if the op class is created
+	 * without specification of a family. We do not lock in this case.
+	 */
+	if ((cacheId == TYPEOID || cacheId == OPFAMILYOID) &&
+		!SearchSysCacheExists1(cacheId,
+							   ObjectIdGetDatum(referenced->objectId)))
+		return;
+
+	/*
+	 * AccessShareLock should be OK, since we are not modifying the object.
+	 */
+	if (cacheId == RELOID)
+		LockRelationOid(referenced->objectId, AccessShareLock);
+	else
+		LockDatabaseObject(referenced->classId,
+						   referenced->objectId,
+						   referenced->objectSubId,
+						   AccessShareLock);
+
+	if (!SearchSysCacheExists1(cacheId,
+							   ObjectIdGetDatum(referenced->objectId)))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("%s %u was concurrently dropped",
+						objName, referenced->objectId)));
 }

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -887,6 +887,7 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 				return;
 			break;
 		default:
+			break;
 	}
 
 	if (cacheId >= 0)

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -23,6 +23,7 @@
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
+#include "catalog/pg_extprotocol.h"
 #include "catalog/pg_foreign_data_wrapper.h"
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_language.h"
@@ -857,6 +858,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case ForeignServerRelationId:
 			cacheId = FOREIGNSERVEROID;
 			objName = "server";
+			break;
+		case ExtprotocolRelationId:
+			cacheId = EXTPROTOCOLOID;
+			objName = "protocol";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -871,8 +871,11 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 			objName = "operator family";
 			break;
 		case OCLASS_CLASS:
-			cacheId = RELOID;
-			objName = "relation";
+			if (get_rel_relkind(referenced->objectId) == RELKIND_SEQUENCE)
+			{
+				cacheId = RELOID;
+				objName = "sequence";
+			}
 			break;
 		default:
 			break;

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -98,7 +98,7 @@ recordMultipleDependencies(const ObjectAddress *depender,
 			 * Lock the referenced object to protect it from dropping by
 			 * another transaction.
 			 */
-			if (behavior == DEPENDENCY_NORMAL)
+			if (behavior == DEPENDENCY_NORMAL || behavior == DEPENDENCY_AUTO)
 				depLockAndCheckObject(referenced);
 
 			/*
@@ -874,6 +874,17 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case OCLASS_OPCLASS:
 			cacheId = CLAOID;
 			objName = "operator class";
+			break;
+		case OCLASS_OPFAMILY:
+			cacheId = OPFAMILYOID;
+			objName = "operator family";
+			/*
+			 * Op family can be not defined yet, if the op class was created
+			 * without specification of a family.
+			 */
+			if (!SearchSysCacheExists1(cacheId,
+									 ObjectIdGetDatum(referenced->objectId)))
+				return;
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -19,12 +19,17 @@
 #include "access/htup_details.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/pg_collation.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
+#include "catalog/pg_language.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
 #include "commands/extension.h"
 #include "miscadmin.h"
 #include "storage/lmgr.h"
+#include "utils/syscache.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -32,6 +37,7 @@
 
 
 static bool isObjectPinned(const ObjectAddress *object, Relation rel);
+static void depLockAndCheckObject(const ObjectAddress *referenced);
 
 
 /*
@@ -97,10 +103,7 @@ recordMultipleDependencies(const ObjectAddress *depender,
 			 * another transaction.
 			 */
 			if (behavior == DEPENDENCY_NORMAL)
-				LockDatabaseObject(referenced->classId,
-								   referenced->objectId,
-								   referenced->objectSubId,
-								   AccessShareLock);
+				depLockAndCheckObject(referenced);
 
 			/*
 			 * Record the Dependency.  Note we don't bother to check for
@@ -797,4 +800,59 @@ get_index_constraint(Oid indexId)
 	heap_close(depRel, AccessShareLock);
 
 	return constraintId;
+}
+
+/*
+ * depLockAndCheckObject
+ *
+ * Lock the object that we are about to record a dependency on.
+ * After it's locked, verify that it hasn't been dropped while we
+ * weren't looking.  If the object has been dropped, this function
+ * does not return!
+ */
+static void
+depLockAndCheckObject(const ObjectAddress *referenced)
+{
+	int			cacheId = -1;
+	char	   *objName;
+
+	switch (referenced->classId)
+	{
+		case NamespaceRelationId:
+			cacheId = NAMESPACEOID;
+			objName = "namespace";
+			break;
+		case TypeRelationId:
+			cacheId = TYPEOID;
+			objName = "type";
+			break;
+		case CollationRelationId:
+			cacheId = COLLOID;
+			objName = "collation";
+			break;
+		case LanguageRelationId:
+			cacheId = LANGOID;
+			objName = "language";
+			break;
+		case ProcedureRelationId:
+			cacheId = PROCOID;
+			objName = "procedure";
+			break;
+		default:
+	}
+
+	if (cacheId >= 0)
+	{
+		/* AccessShareLock should be OK, since we are not modifying the object */
+		LockDatabaseObject(referenced->classId,
+						   referenced->objectId,
+						   referenced->objectSubId,
+						   AccessShareLock);
+
+		if (!SearchSysCacheExists1(cacheId, ObjectIdGetDatum(referenced->objectId)))
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("%s %u was concurrently dropped",
+							objName, referenced->objectId)));
+	}
 }

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -28,6 +28,7 @@
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_opclass.h"
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_ts_dict.h"
@@ -872,6 +873,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case OperatorRelationId:
 			cacheId = OPEROID;
 			objName = "operator";
+			break;
+		case OperatorClassRelationId:
+			cacheId = CLAOID;
+			objName = "operator class";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -24,6 +24,7 @@
 #include "catalog/pg_extension.h"
 #include "commands/extension.h"
 #include "miscadmin.h"
+#include "storage/lmgr.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -91,6 +92,12 @@ recordMultipleDependencies(const ObjectAddress *depender,
 		 */
 		if (!isObjectPinned(referenced, dependDesc))
 		{
+			if (behavior == DEPENDENCY_NORMAL)
+				LockDatabaseObject(referenced->classId,
+								   referenced->objectId,
+								   referenced->objectSubId,
+								   AccessShareLock);
+
 			/*
 			 * Record the Dependency.  Note we don't bother to check for
 			 * duplicate dependencies; there's no harm in them.

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -809,8 +809,8 @@ get_index_constraint(Oid indexId)
 static void
 depLockAndCheckObject(const ObjectAddress *referenced)
 {
-	int			cacheId = -1;
-	char	   *objName;
+	enum SysCacheIdentifier cacheId;
+	const char *objName;
 
 	switch (getObjectClass(referenced))
 	{
@@ -881,8 +881,6 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		default:
 			return;
 	}
-
-	Assert(cacheId >= 0);
 
 	/*
 	 * Type and op family can be not defined at this point. It is normal

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -28,6 +28,7 @@
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_ts_dict.h"
 #include "catalog/pg_ts_parser.h"
@@ -867,6 +868,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case TSDictionaryRelationId:
 			cacheId = TSDICTOID;
 			objName = "text search dictionary";
+			break;
+		case OperatorRelationId:
+			cacheId = OPEROID;
+			objName = "operator";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -821,6 +821,15 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case OCLASS_TYPE:
 			cacheId = TYPEOID;
 			objName = "type";
+
+			/*
+			 * Type can be not defined, when we define the I/O procs for a new
+			 * type. Do not lock in this case.
+			 */
+			if (!SearchSysCacheExists1(cacheId,
+									 ObjectIdGetDatum(referenced->objectId)))
+				return;
+
 			break;
 		case OCLASS_COLLATION:
 			cacheId = COLLOID;

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -23,6 +23,7 @@
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
+#include "catalog/pg_foreign_data_wrapper.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
@@ -847,6 +848,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case TSTemplateRelationId:
 			cacheId = TSTEMPLATEOID;
 			objName = "text search template";
+			break;
+		case ForeignDataWrapperRelationId:
+			cacheId = FOREIGNDATAWRAPPEROID;
+			objName = "foreign data wrapper";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -870,6 +870,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 			cacheId = OPFAMILYOID;
 			objName = "operator family";
 			break;
+		case OCLASS_CLASS:
+			cacheId = RELOID;
+			objName = "relation";
+			break;
 		default:
 			break;
 	}
@@ -888,11 +892,17 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 								   ObjectIdGetDatum(referenced->objectId)))
 			return;
 
-		/* AccessShareLock should be OK, since we are not modifying the object */
-		LockDatabaseObject(referenced->classId,
-						   referenced->objectId,
-						   referenced->objectSubId,
-						   AccessShareLock);
+		/*
+		 * AccessShareLock should be OK, since we are not modifying the
+		 * object.
+		 */
+		if (cacheId == RELOID)
+			LockRelationOid(referenced->objectId, AccessShareLock);
+		else
+			LockDatabaseObject(referenced->classId,
+							   referenced->objectId,
+							   referenced->objectSubId,
+							   AccessShareLock);
 
 		if (!SearchSysCacheExists1(cacheId,
 								   ObjectIdGetDatum(referenced->objectId)))

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -19,21 +19,9 @@
 #include "access/htup_details.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
-#include "catalog/pg_collation.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
-#include "catalog/pg_extprotocol.h"
-#include "catalog/pg_foreign_data_wrapper.h"
-#include "catalog/pg_foreign_server.h"
-#include "catalog/pg_language.h"
-#include "catalog/pg_namespace.h"
-#include "catalog/pg_opclass.h"
-#include "catalog/pg_operator.h"
-#include "catalog/pg_proc.h"
-#include "catalog/pg_ts_dict.h"
-#include "catalog/pg_ts_parser.h"
-#include "catalog/pg_ts_template.h"
 #include "commands/extension.h"
 #include "miscadmin.h"
 #include "storage/lmgr.h"
@@ -824,57 +812,57 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 	int			cacheId = -1;
 	char	   *objName;
 
-	switch (referenced->classId)
+	switch (getObjectClass(referenced))
 	{
-		case NamespaceRelationId:
+		case OCLASS_SCHEMA:
 			cacheId = NAMESPACEOID;
 			objName = "namespace";
 			break;
-		case TypeRelationId:
+		case OCLASS_TYPE:
 			cacheId = TYPEOID;
 			objName = "type";
 			break;
-		case CollationRelationId:
+		case OCLASS_COLLATION:
 			cacheId = COLLOID;
 			objName = "collation";
 			break;
-		case LanguageRelationId:
+		case OCLASS_LANGUAGE:
 			cacheId = LANGOID;
 			objName = "language";
 			break;
-		case ProcedureRelationId:
+		case OCLASS_PROC:
 			cacheId = PROCOID;
 			objName = "procedure";
 			break;
-		case TSParserRelationId:
+		case OCLASS_TSPARSER:
 			cacheId = TSPARSEROID;
 			objName = "text search parser";
 			break;
-		case TSTemplateRelationId:
+		case OCLASS_TSTEMPLATE:
 			cacheId = TSTEMPLATEOID;
 			objName = "text search template";
 			break;
-		case ForeignDataWrapperRelationId:
+		case OCLASS_FDW:
 			cacheId = FOREIGNDATAWRAPPEROID;
 			objName = "foreign data wrapper";
 			break;
-		case ForeignServerRelationId:
+		case OCLASS_FOREIGN_SERVER:
 			cacheId = FOREIGNSERVEROID;
 			objName = "server";
 			break;
-		case ExtprotocolRelationId:
+		case OCLASS_EXTPROTOCOL:
 			cacheId = EXTPROTOCOLOID;
 			objName = "protocol";
 			break;
-		case TSDictionaryRelationId:
+		case OCLASS_TSDICT:
 			cacheId = TSDICTOID;
 			objName = "text search dictionary";
 			break;
-		case OperatorRelationId:
+		case OCLASS_OPERATOR:
 			cacheId = OPEROID;
 			objName = "operator";
 			break;
-		case OperatorClassRelationId:
+		case OCLASS_OPCLASS:
 			cacheId = CLAOID;
 			objName = "operator class";
 			break;

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -27,6 +27,7 @@
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_ts_parser.h"
+#include "catalog/pg_ts_template.h"
 #include "commands/extension.h"
 #include "miscadmin.h"
 #include "storage/lmgr.h"
@@ -842,6 +843,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case TSParserRelationId:
 			cacheId = TSPARSEROID;
 			objName = "text search parser";
+			break;
+		case TSTemplateRelationId:
+			cacheId = TSTEMPLATEOID;
+			objName = "text search template";
 			break;
 		default:
 	}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -29,6 +29,7 @@
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
+#include "catalog/pg_ts_dict.h"
 #include "catalog/pg_ts_parser.h"
 #include "catalog/pg_ts_template.h"
 #include "commands/extension.h"
@@ -862,6 +863,10 @@ depLockAndCheckObject(const ObjectAddress *referenced)
 		case ExtprotocolRelationId:
 			cacheId = EXTPROTOCOLOID;
 			objName = "protocol";
+			break;
+		case TSDictionaryRelationId:
+			cacheId = TSDICTOID;
+			objName = "text search dictionary";
 			break;
 		default:
 	}

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -748,10 +748,10 @@ drop function test_15_function(text, text);
 DROP
 
 -- Case 16. Index dependency on the operator class.
-create function test_16_eq(int, int) returns int as $$ begin return 1;  /**/ end;  /**/ $$ language plpgsql immutable;
+create function test_16_idx_func(int, int) returns int as $$ begin return $1 - $2;  /**/ end;  /**/ $$ language plpgsql immutable;
 CREATE
 
-create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_eq(int, int);
+create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_idx_func(int, int);
 CREATE
 
 create table test_16_table(a int);
@@ -772,20 +772,16 @@ ERROR:  cannot drop operator class test_16_op_class for access method btree beca
 DETAIL:  index idx_test_16_table depends on operator class test_16_op_class for access method btree
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 
-1: explain (costs off) select * from test_16_table where a = 1;
- QUERY PLAN                                                
------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)                  
-   ->  Index Scan using idx_test_16_table on test_16_table 
-         Index Cond: (a = 1)                               
- Optimizer: Pivotal Optimizer (GPORCA)                     
-(4 rows)
+1: select * from test_16_table where a = 0;
+ a 
+---
+(0 rows)
 
 drop operator class test_16_op_class using btree cascade;
 DROP
 
 -- Check if dependency is dropped before the creation of the dependent object.
-create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_eq(int, int);
+create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_idx_func(int, int);
 CREATE
 
 1: begin;
@@ -803,7 +799,7 @@ ERROR:  operator class ##### was concurrently dropped
 1: end;
 END
 
-drop function test_16_eq(int, int);
+drop function test_16_idx_func(int, int);
 DROP
 drop table test_16_table;
 DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -12,7 +12,7 @@ CREATE
 
 -- Check that we didn't add extra locks. Here we lock only namespace, so the count is 1.
 -- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
-1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object') select count(1), gp_segment_id from pg_locks where classid in (select classid from cte) and objid in (select objid from cte) group by gp_segment_id order by gp_segment_id;
+1:  select count(1), l.gp_segment_id from pg_locks l join pg_locks r using (locktype, classid, objid) where r.pid = pg_backend_pid() and r.locktype = 'object' group by 2 order by 2;
  count | gp_segment_id 
 -------+---------------
  1     | -1            
@@ -69,7 +69,7 @@ CREATE
 
 -- Check that we didn't add extra locks. Here we lock namespace ('public') and type, so the count is 2.
 -- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
-1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object') select count(1), gp_segment_id from pg_locks where classid in (select classid from cte) and objid in (select objid from cte) group by gp_segment_id order by gp_segment_id;
+1:  select count(1), l.gp_segment_id from pg_locks l join pg_locks r using (locktype, classid, objid) where r.pid = pg_backend_pid() and r.locktype = 'object' group by 2 order by 2;
  count | gp_segment_id 
 -------+---------------
  2     | -1            

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1022,6 +1022,59 @@ ERROR:  type ##### was concurrently dropped
 1: end;
 END
 
+-- Case 21. Rule dependency on the table.
+create table test_21_table_1(a int);
+CREATE
+create table test_21_table_2(a int);
+CREATE
+
+1: begin;
+BEGIN
+1: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);
+CREATE
+
+2&: drop table test_21_table_2;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop table test_21_table_2 because other objects depend on it
+DETAIL:  rule test_21_rule on table test_21_table_1 depends on table test_21_table_2
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_21_table_1 values (0);
+INSERT 1
+1: select * from test_21_table_2;
+ a 
+---
+ 1 
+(1 row)
+
+drop rule test_21_rule on test_21_table_1;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop table test_21_table_2;
+DROP
+1&: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  relation "test_21_table_2" does not exist
+LINE 1: ... insert to test_21_table_1 do instead insert into test_21_ta...
+                                                             ^
+1: end;
+END
+
+drop table test_21_table_1;
+DROP
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 CREATE

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -875,3 +875,30 @@ END
 
 drop function test_17_eq(int, int);
 DROP
+
+-- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
+create schema test_schema;
+CREATE
+create type test_type as enum ('one', 'two');
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+2: drop type test_type;
+DROP
+1&: create function test_schema.test_function(a test_type) returns text as $$ select 'Return ' || a;  /**/ $$ language sql;  <waiting ...>
+2&: drop schema test_schema;  <waiting ...>
+
+
+1: rollback;
+ROLLBACK
+2: rollback;
+ROLLBACK
+
+drop schema test_schema;
+DROP
+drop type test_type;
+DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -10,6 +10,17 @@ BEGIN
 1: create function test_1_schema.test_1_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
 CREATE
 
+-- Check that we didn't add extra locks. Here we lock only namespace, so the count is 1.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object') select count(1), gp_segment_id from pg_locks where classid in (select classid from cte) and objid in (select objid from cte) group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 1     | -1            
+ 1     | 0             
+ 1     | 1             
+ 1     | 2             
+(4 rows)
+
 2&: drop schema test_1_schema;  <waiting ...>
 
 1: commit;
@@ -55,6 +66,17 @@ CREATE
 BEGIN
 1: create function test_2_function() returns setof test_2_type as $$ select i from generate_series(1,5)i; /**/ $$ language sql;
 CREATE
+
+-- Check that we didn't add extra locks. Here we lock namespace ('public') and type, so the count is 2.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object') select count(1), gp_segment_id from pg_locks where classid in (select classid from cte) and objid in (select objid from cte) group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+ 2     | -1            
+ 2     | 0             
+ 2     | 1             
+ 2     | 2             
+(4 rows)
 
 2&: drop type test_2_type;  <waiting ...>
 

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -579,3 +579,67 @@ END
 
 drop foreign data wrapper test_12_fdw;
 DROP
+
+-- Case 13. External table dependency on the protocol.
+create or replace function write_to_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_export' language c stable no sql;
+CREATE
+create or replace function read_from_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_import' language c stable no sql;
+CREATE
+
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE
+! echo 1 > /tmp/test_13.txt;
+
+
+1: begin;
+BEGIN
+1: create readable external table test_13_ext_table(a int) location('demoprot:///tmp/test_13.txt') format 'text';
+CREATE
+
+2&: drop protocol demoprot;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop protocol demoprot because other objects depend on it
+DETAIL:  external table test_13_ext_table depends on protocol demoprot
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_13_ext_table;
+ a 
+---
+ 1 
+ 1 
+ 1 
+(3 rows)
+
+! rm /tmp/test_13.txt;
+
+
+drop protocol demoprot cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop protocol demoprot;
+DROP
+1&: create readable external table test_13_ext_table(a int) location('demoprot://test.txt') format 'text';  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  protocol ##### was concurrently dropped
+1: end;
+END
+
+drop function write_to_file();
+DROP
+drop function read_from_file();
+DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1117,7 +1117,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  relation ##### was concurrently dropped
+ERROR:  sequence ##### was concurrently dropped
 1: end;
 END
 

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -876,6 +876,53 @@ END
 drop function test_17_eq(int, int);
 DROP
 
+-- Case 18. View dependency on the function.
+create function test_18_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+1: create view test_18_view as select test_18_function();
+CREATE
+
+2&: drop function test_18_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test_18_function() because other objects depend on it
+DETAIL:  view test_18_view depends on function test_18_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_18_view;
+ test_18_function 
+------------------
+ test             
+(1 row)
+
+drop function test_18_function()cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_18_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test_18_function();
+DROP
+1&: create view test_18_view as select test_18_function();  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  procedure ##### was concurrently dropped
+1: end;
+END
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 CREATE

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1075,6 +1075,52 @@ END
 drop table test_21_table_1;
 DROP
 
+-- Case 22. Table dependency on the sequence.
+create sequence test_22_seq;
+CREATE
+
+1: begin;
+BEGIN
+1: create table test_22_table(id int default nextval('test_22_seq'));
+CREATE
+
+2&: drop sequence test_22_seq;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop sequence test_22_seq because other objects depend on it
+DETAIL:  default for table test_22_table column id depends on sequence test_22_seq
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_22_table default values;
+INSERT 1
+
+drop sequence test_22_seq cascade;
+DROP
+drop table test_22_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create sequence test_22_seq;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop sequence test_22_seq;
+DROP
+1&: create table test_22_table(id int default nextval('test_22_seq'));  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  relation ##### was concurrently dropped
+1: end;
+END
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 CREATE

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -807,3 +807,53 @@ drop function test_16_eq(int, int);
 DROP
 drop table test_16_table;
 DROP
+
+-- Case 17. Operator class dependency on the operator family.
+create function test_17_eq(int, int) returns int as $$ begin return 1;  /**/ end;  /**/ $$ language plpgsql immutable;
+CREATE
+
+create operator family test_17_op_family using btree;
+CREATE
+
+1: begin;
+BEGIN
+1: create operator class test_17_op_class for type int using btree family test_17_op_family as operator 1 =(int, int), function 1 test_17_eq(int, int);
+CREATE
+
+2&: drop operator family test_17_op_family using btree;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+DROP
+
+-- Count below should be 0, as 'drop operator family' automatically drops
+-- all its operator classes.
+1: select count(*) from pg_opclass where opcname = 'test_17_op_class';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator family test_17_op_family using btree;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop operator family test_17_op_family using btree;
+DROP
+1&: create operator class test_17_op_class for type int using btree family test_17_op_family as operator 1 =(int, int), function 1 test_17_eq(int, int);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  operator family ##### was concurrently dropped
+1: end;
+END
+
+drop function test_17_eq(int, int);
+DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -643,3 +643,54 @@ drop function write_to_file();
 DROP
 drop function read_from_file();
 DROP
+
+-- Case 14. Text search configuration dependency on the text search dictionary
+create text search dictionary test_14_dict ( template = simple );
+CREATE
+
+1: begin;
+BEGIN
+1: create text search configuration test_14_config (parser = default);
+CREATE
+1: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;
+ALTER
+
+2&: drop text search dictionary test_14_dict;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop text search dictionary test_14_dict because other objects depend on it
+DETAIL:  text search configuration test_14_config depends on text search dictionary test_14_dict
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select count(1) from ts_debug('public.test_14_config', 'test');
+ count 
+-------
+ 1     
+(1 row)
+
+drop text search dictionary test_14_dict cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search dictionary test_14_dict ( template = simple );
+CREATE
+
+1: begin;
+BEGIN
+1: create text search configuration test_14_config (parser = default);
+CREATE
+2: begin;
+BEGIN
+2: drop text search dictionary test_14_dict;
+DROP
+1&: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  text search dictionary ##### was concurrently dropped
+1: end;
+END

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -433,3 +433,50 @@ COMMIT
 ERROR:  text search parser ##### was concurrently dropped
 1: end;
 END
+
+-- Case 10. Text search dictionary dependency on the template.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+CREATE
+
+1: begin;
+BEGIN
+1: create text search dictionary test_10_dictionary(template = test_10_template);
+CREATE
+
+2&: drop text search template test_10_template;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop text search template test_10_template because other objects depend on it
+DETAIL:  text search dictionary test_10_dictionary depends on text search template test_10_template
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select ts_lexize('public.test_10_dictionary', 'test');
+ ts_lexize 
+-----------
+ {test}    
+(1 row)
+
+drop text search template test_10_template cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop text search template test_10_template;
+DROP
+1&: create text search dictionary test_10_dictionary(template = test_10_template);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  text search template ##### was concurrently dropped
+1: end;
+END

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -524,3 +524,58 @@ COMMIT
 ERROR:  foreign data wrapper ##### was concurrently dropped
 1: end;
 END
+
+-- Case 12. User mapping dependency on the server.
+create foreign data wrapper test_12_fdw;
+CREATE
+create server test_12_server foreign data wrapper test_12_fdw;
+CREATE
+
+1: begin;
+BEGIN
+1: create user mapping for public server test_12_server;
+CREATE
+
+2&: drop server test_12_server;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop server test_12_server because other objects depend on it
+DETAIL:  user mapping for public on server test_12_server depends on server test_12_server
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+! psql isolation2test -c '\deu';
+   List of user mappings
+     Server     | User name 
+----------------+-----------
+ test_12_server | public
+(1 row)
+
+
+
+drop server test_12_server cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create server test_12_server foreign data wrapper test_12_fdw;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop server test_12_server;
+DROP
+1&: create user mapping for public server test_12_server;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  server ##### was concurrently dropped
+1: end;
+END
+
+drop foreign data wrapper test_12_fdw;
+DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -480,3 +480,47 @@ COMMIT
 ERROR:  text search template ##### was concurrently dropped
 1: end;
 END
+
+-- Case 11. Server dependency on the foreigh data wrapper.
+create foreign data wrapper test_11_fdw;
+CREATE
+
+1: begin;
+BEGIN
+1: create server test_11_server foreign data wrapper test_11_fdw;
+CREATE
+
+2&: drop foreign data wrapper test_11_fdw;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop foreign-data wrapper test_11_fdw because other objects depend on it
+DETAIL:  server test_11_server depends on foreign-data wrapper test_11_fdw
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: alter server test_11_server options (servername 'test_server');
+ALTER
+
+drop foreign data wrapper test_11_fdw cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create foreign data wrapper test_11_fdw;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop foreign data wrapper test_11_fdw;
+DROP
+1&: create server test_11_server foreign data wrapper test_11_fdw;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  foreign data wrapper ##### was concurrently dropped
+1: end;
+END

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1,0 +1,411 @@
+-- Test different cases when a parallel transaction drops a dependency object
+-- before current transaction is committed.
+
+-- start_matchsubs
+-- m/cache lookup failed for type \d+/
+-- s/cache lookup failed for type \d+/cache lookup failed for type XXXXX/
+-- m/cache lookup failed for language \d+/
+-- s/cache lookup failed for language \d+/cache lookup failed for language XXXXX/
+-- m/cache lookup failed for function \d+/
+-- s/cache lookup failed for function \d+/cache lookup failed for function XXXXX/
+-- m/format_type.c:\d+/
+-- s/format_type.c:\d+/format_type.c:XXX/
+-- m/lsyscache.c:\d+/
+-- s/lsyscache.c:\d+/lsyscache.c:XXX/
+-- m/fmgr.c:\d+/
+-- s/fmgr.c:\d+/fmgr.c:XXX/
+-- m/ruleutils.c:\d+/
+-- s/ruleutils.c:\d+/ruleutils.c:XXX/
+-- end_matchsubs
+
+-- Case 1. Dependency on the schema.
+create schema test_1_schema;
+CREATE
+
+1: begin;
+BEGIN
+1: create function test_1_schema.test_1_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE
+
+2&: drop schema test_1_schema;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop schema test_1_schema because other objects depend on it
+DETAIL:  function test_1_schema.test_1_function() depends on schema test_1_schema
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_1_schema.test_1_function();
+ test_1_function 
+-----------------
+ test            
+(1 row)
+
+drop schema test_1_schema cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create schema test_1_schema;
+CREATE
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop schema test_1_schema;
+DROP
+1&: create function test_1_schema.test_1_function() returns text as $$ select 'test'::text; /**/ $$ language sql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  schema "test_1_schema" does not exist  (seg0 127.0.1.1:6002 pid=2715327)
+1: end;
+END
+
+-- Case 2. Dependency on the return type.
+create type test_2_type as (a int);
+CREATE
+
+1: begin;
+BEGIN
+1: create function test_2_function() returns setof test_2_type as $$ select i from generate_series(1,5)i; /**/ $$ language sql;
+CREATE
+
+2&: drop type test_2_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_2_type because other objects depend on it
+DETAIL:  function test_2_function() depends on type test_2_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_2_function();
+ test_2_function 
+-----------------
+ (1)             
+ (2)             
+ (3)             
+ (4)             
+ (5)             
+(5 rows)
+
+drop type test_2_type cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_2_type as (a int);
+CREATE
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_2_type;
+DROP
+1&: create function test_2_function() returns setof test_2_type as $$ select i from generate_series(1,5)i; /**/ $$ language sql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  cache lookup failed for type XXXXX (format_type.c:XXX)
+CONTEXT:  SQL function "test_2_function"
+1: end;
+END
+
+-- Case 3. Dependency on the parameter type.
+create type test_3_type as enum ('one', 'two');
+CREATE
+
+1: begin;
+BEGIN
+1: create function test_3_function(a test_3_type) returns text as $$ select 'Return ' || a; /**/ $$ language sql;
+CREATE
+
+2&: drop type test_3_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_3_type because other objects depend on it
+DETAIL:  function test_3_function(test_3_type) depends on type test_3_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_3_function('one');
+ test_3_function 
+-----------------
+ Return one      
+(1 row)
+
+drop type test_3_type cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_3_type as enum ('one', 'two');
+CREATE
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_3_type;
+DROP
+1&: create function test_3_function(a test_3_type) returns text as $$ select 'Return ' || a; /**/ $$ language sql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  cache lookup failed for type XXXXX (lsyscache.c:XXX)
+CONTEXT:  SQL function "test_3_function"
+1: end;
+END
+
+-- Case 4. Dependency on the language.
+-- start_ignore
+create or replace language plpythonu;
+CREATE
+-- end_ignore
+
+1: begin;
+BEGIN
+1: create function test_4_function() returns text as $$ return "test" $$ language plpythonu;
+CREATE
+
+2&: drop language plpythonu;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop language plpythonu because other objects depend on it
+DETAIL:  function test_4_function() depends on language plpythonu
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_4_function();
+ test_4_function 
+-----------------
+ test            
+(1 row)
+
+drop language plpythonu cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+-- start_ignore
+create or replace language plpythonu;
+CREATE
+-- end_ignore
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop language plpythonu;
+DROP
+1&: create function test_4_function() returns text as $$ return "test" $$ language plpythonu;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  cache lookup failed for language XXXXX (fmgr.c:XXX)
+1: end;
+END
+
+-- Case 5. Dependency on the parameter default expression.
+create function test5_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+1: create function test_5_function(a text default test5_default_value_function()) returns text as $$ begin return a; /**/ end $$ language plpgsql;
+CREATE
+
+2&: drop function test5_default_value_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test5_default_value_function() because other objects depend on it
+DETAIL:  function test_5_function(text) depends on function test5_default_value_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_5_function();
+ test_5_function 
+-----------------
+ test            
+(1 row)
+
+drop function test5_default_value_function() cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test5_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test5_default_value_function();
+DROP
+1&: create function test_5_function(a text default test5_default_value_function()) returns text as $$ begin return a; /**/ end $$ language plpgsql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  function test5_default_value_function() does not exist  (seg0 127.0.1.1:6002 pid=2718914)
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+1: end;
+END
+
+-- Case 6. Dependency on the column default expression.
+create function test_6_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+1: create table test_6_table(a text default test_6_default_value_function());
+CREATE
+
+2&: drop function test_6_default_value_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test_6_default_value_function() because other objects depend on it
+DETAIL:  default for table test_6_table column a depends on function test_6_default_value_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_6_table default values;
+INSERT 1
+1: select * from test_6_table;
+ a    
+------
+ test 
+(1 row)
+
+drop function test_6_default_value_function() cascade;
+DROP
+drop table test_6_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_6_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test_6_default_value_function();
+DROP
+1&: create table test_6_table(a text default test_6_default_value_function());  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  cache lookup failed for function XXXXX (ruleutils.c:10062)  (seg2 127.0.1.1:6004 pid=2718915) (ruleutils.c:10062)
+1: end;
+END
+
+-- Case 7. Dependency on the column type.
+create type test_7_type as enum ('one', 'two');
+CREATE
+
+1: begin;
+BEGIN
+1: create table test_7_table(a test_7_type);
+CREATE
+
+2&: drop type test_7_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_7_type because other objects depend on it
+DETAIL:  table test_7_table column a depends on type test_7_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_7_table;
+ a 
+---
+(0 rows)
+
+drop type test_7_type cascade;
+DROP
+drop table test_7_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_7_type as enum ('one', 'two');
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_7_type;
+DROP
+1&: create table test_7_table(a test_7_type);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type "test_7_type" does not exist  (seg0 127.0.1.1:6002 pid=2718914)
+1: end;
+END
+
+-- Case 8. Table dependency on the collation.
+create collation test_8_collation (locale="en_US.utf8");
+CREATE
+
+1: begin;
+BEGIN
+1: create table test_8_table(a text collate test_8_collation);
+CREATE
+1: insert into test_8_table values('data');
+INSERT 1
+
+2&: drop collation test_8_collation;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop collation test_8_collation because other objects depend on it
+DETAIL:  table test_8_table column a depends on collation test_8_collation
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_8_table where a < 'test';
+ a    
+------
+ data 
+(1 row)
+
+drop collation test_8_collation cascade;
+DROP
+drop table test_8_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create collation test_8_collation (locale="en_US.utf8");
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop collation test_8_collation;
+DROP
+1&: create table test_8_table(a text collate test_8_collation);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  collation "test_8_collation" for encoding "UTF8" does not exist  (seg0 127.0.1.1:6002 pid=2718914)
+1: end;
+END

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1121,6 +1121,60 @@ ERROR:  relation ##### was concurrently dropped
 1: end;
 END
 
+-- Case 23. Table dependency on the column type with REPEATABLE READ isolation level.
+create type test_23_type as enum ('one', 'two');
+CREATE
+
+1: begin;
+BEGIN
+1: set transaction isolation level repeatable read;
+SET
+1: create table test_23_table(a test_23_type);
+CREATE
+
+2&: drop type test_23_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_23_type because other objects depend on it
+DETAIL:  table test_23_table column a depends on type test_23_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_23_table;
+ a 
+---
+(0 rows)
+
+drop type test_23_type cascade;
+DROP
+drop table test_23_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_23_type as enum ('one', 'two');
+CREATE
+
+1: begin;
+BEGIN
+1: set transaction isolation level repeatable read;
+SET
+2: begin;
+BEGIN
+2: set transaction isolation level repeatable read;
+SET
+2: drop type test_23_type;
+DROP
+1&: create table test_23_table(a test_23_type);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+END
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 CREATE

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -694,3 +694,55 @@ COMMIT
 ERROR:  text search dictionary ##### was concurrently dropped
 1: end;
 END
+
+-- Case 15. Table dependency on the operator.
+create function test_15_function(text, text) returns text as $$ begin return $1 || $2;  /**/ end;  /**/ $$ language plpgsql;
+CREATE
+
+create operator ~*~ ( procedure = test_15_function, leftarg = text, rightarg = text, commutator = ~*~ );
+CREATE
+
+1: begin;
+BEGIN
+1: create table test_15_table(a text default 'a' ~*~ 'b');
+CREATE
+
+2&: drop operator ~*~ (text, text);  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop operator ~*~(text,text) because other objects depend on it
+DETAIL:  default for table test_15_table column a depends on operator ~*~(text,text)
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_15_table values (default);
+INSERT 1
+
+drop operator ~*~ (text, text) cascade;
+DROP
+drop table test_15_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator ~*~ ( procedure = test_15_function, leftarg = text, rightarg = text, commutator = ~*~ );
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop operator ~*~ (text, text);
+DROP
+1&: create table test_15_table(a text default 'a' ~*~ 'b');  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  operator ##### was concurrently dropped
+1: end;
+END
+
+drop function test_15_function(text, text);
+DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -970,6 +970,58 @@ ERROR:  procedure ##### was concurrently dropped
 1: end;
 END
 
+-- Case 20. Table dependency on the column type (with ALTER COLUMN).
+create type test_20_type as enum ('one', 'two');
+CREATE
+create table test_20_table(a text);
+CREATE
+
+1: begin;
+BEGIN
+1: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;
+ALTER
+
+2&: drop type test_20_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_20_type because other objects depend on it
+DETAIL:  table test_20_table column a depends on type test_20_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_20_table;
+ a 
+---
+(0 rows)
+
+drop type test_20_type cascade;
+DROP
+drop table test_20_table;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_20_type as enum ('one', 'two');
+CREATE
+create table test_20_table(a text);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_20_type;
+DROP
+1&: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+END
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 CREATE

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -503,7 +503,7 @@ ERROR:  text search template ##### was concurrently dropped
 1: end;
 END
 
--- Case 11. Server dependency on the foreigh data wrapper.
+-- Case 11. Server dependency on the foreign data wrapper.
 create foreign data wrapper test_11_fdw;
 CREATE
 

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -746,3 +746,64 @@ END
 
 drop function test_15_function(text, text);
 DROP
+
+-- Case 16. Index dependency on the operator class.
+create function test_16_eq(int, int) returns int as $$ begin return 1;  /**/ end;  /**/ $$ language plpgsql immutable;
+CREATE
+
+create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_eq(int, int);
+CREATE
+
+create table test_16_table(a int);
+CREATE
+
+1: begin;
+BEGIN
+1: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);
+CREATE
+
+2&: drop operator class test_16_op_class using btree;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop operator class test_16_op_class for access method btree because other objects depend on it
+DETAIL:  index idx_test_16_table depends on operator class test_16_op_class for access method btree
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: explain (costs off) select * from test_16_table where a = 1;
+ QUERY PLAN                                                
+-----------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)                  
+   ->  Index Scan using idx_test_16_table on test_16_table 
+         Index Cond: (a = 1)                               
+ Optimizer: Pivotal Optimizer (GPORCA)                     
+(4 rows)
+
+drop operator class test_16_op_class using btree cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_eq(int, int);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop operator class test_16_op_class using btree;
+DROP
+1&: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  operator class ##### was concurrently dropped
+1: end;
+END
+
+drop function test_16_eq(int, int);
+DROP
+drop table test_16_table;
+DROP

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -163,10 +163,8 @@ CONTEXT:  SQL function "test_3_function"
 END
 
 -- Case 4. Dependency on the language.
--- start_ignore
-create or replace language plpythonu;
+create language plpythonu;
 CREATE
--- end_ignore
 
 1: begin;
 BEGIN
@@ -193,10 +191,9 @@ drop language plpythonu cascade;
 DROP
 
 -- Check if dependency is dropped before the creation of the dependent object.
--- start_ignore
-create or replace language plpythonu;
+create language plpythonu;
 CREATE
--- end_ignore
+
 1: begin;
 BEGIN
 2: begin;

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1,5 +1,5 @@
--- Test different cases when a parallel transaction drops a dependency object
--- before current transaction is committed.
+-- Test cases when a parallel transaction drops a dependency object
+-- while current transaction is yet not committed.
 
 -- start_matchsubs
 -- m/cache lookup failed for type \d+/
@@ -18,7 +18,7 @@
 -- s/ruleutils.c:\d+/ruleutils.c:XXX/
 -- end_matchsubs
 
--- Case 1. Dependency on the schema.
+-- Case 1. Function dependency on the schema.
 create schema test_1_schema;
 CREATE
 
@@ -64,7 +64,7 @@ ERROR:  schema "test_1_schema" does not exist  (seg0 127.0.1.1:6002 pid=2715327)
 1: end;
 END
 
--- Case 2. Dependency on the return type.
+-- Case 2. Function dependency on the return type.
 create type test_2_type as (a int);
 CREATE
 
@@ -115,7 +115,7 @@ CONTEXT:  SQL function "test_2_function"
 1: end;
 END
 
--- Case 3. Dependency on the parameter type.
+-- Case 3. Function dependency on the parameter type.
 create type test_3_type as enum ('one', 'two');
 CREATE
 
@@ -162,7 +162,7 @@ CONTEXT:  SQL function "test_3_function"
 1: end;
 END
 
--- Case 4. Dependency on the language.
+-- Case 4. Function dependency on the language.
 create language plpythonu;
 CREATE
 
@@ -209,7 +209,7 @@ ERROR:  cache lookup failed for language XXXXX (fmgr.c:XXX)
 1: end;
 END
 
--- Case 5. Dependency on the parameter default expression.
+-- Case 5. Function dependency on the parameter default expression.
 create function test5_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
 CREATE
 
@@ -257,7 +257,7 @@ HINT:  No function matches the given name and argument types. You might need to 
 1: end;
 END
 
--- Case 6. Dependency on the column default expression.
+-- Case 6. Table dependency on the column default expression.
 create function test_6_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
 CREATE
 
@@ -308,7 +308,7 @@ ERROR:  cache lookup failed for function XXXXX (ruleutils.c:10062)  (seg2 127.0.
 1: end;
 END
 
--- Case 7. Dependency on the column type.
+-- Case 7. Table dependency on the column type.
 create type test_7_type as enum ('one', 'two');
 CREATE
 

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -901,7 +901,7 @@ HINT:  Use DROP ... CASCADE to drop the dependent objects too.
  test             
 (1 row)
 
-drop function test_18_function()cascade;
+drop function test_18_function() cascade;
 DROP
 
 -- Check if dependency is dropped before the creation of the dependent object.
@@ -915,6 +915,53 @@ BEGIN
 2: drop function test_18_function();
 DROP
 1&: create view test_18_view as select test_18_function();  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  procedure ##### was concurrently dropped
+1: end;
+END
+
+-- Case 19. Materialized view dependency on the function.
+create function test_19_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+1: create materialized view test_19_view as select test_19_function();
+CREATE 1
+
+2&: drop function test_19_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test_19_function() because other objects depend on it
+DETAIL:  materialized view test_19_view depends on function test_19_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_19_view;
+ test_19_function 
+------------------
+ test             
+(1 row)
+
+drop function test_19_function() cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_19_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test_19_function();
+DROP
+1&: create materialized view test_19_view as select test_19_function();  <waiting ...>
 
 2: commit;
 COMMIT

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -386,3 +386,50 @@ COMMIT
 ERROR:  collation ##### was concurrently dropped
 1: end;
 END
+
+-- Case 9. Text search configuration dependency on the parser.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+CREATE
+
+1: begin;
+BEGIN
+1: create text search configuration test_9_configuration(parser = test_9_parser);
+CREATE
+
+2&: drop text search parser test_9_parser;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop text search parser test_9_parser because other objects depend on it
+DETAIL:  text search configuration test_9_configuration depends on text search parser test_9_parser
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select count(1) from ts_debug('public.test_9_configuration', 'test');
+ count 
+-------
+ 1     
+(1 row)
+
+drop text search parser test_9_parser cascade;
+DROP
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+CREATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop text search parser test_9_parser;
+DROP
+1&: create text search configuration test_9_configuration(parser = test_9_parser);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  text search parser ##### was concurrently dropped
+1: end;
+END

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1,23 +1,6 @@
 -- Test cases when a parallel transaction drops a dependency object
 -- while current transaction is yet not committed.
 
--- start_matchsubs
--- m/cache lookup failed for type \d+/
--- s/cache lookup failed for type \d+/cache lookup failed for type XXXXX/
--- m/cache lookup failed for language \d+/
--- s/cache lookup failed for language \d+/cache lookup failed for language XXXXX/
--- m/cache lookup failed for function \d+/
--- s/cache lookup failed for function \d+/cache lookup failed for function XXXXX/
--- m/format_type.c:\d+/
--- s/format_type.c:\d+/format_type.c:XXX/
--- m/lsyscache.c:\d+/
--- s/lsyscache.c:\d+/lsyscache.c:XXX/
--- m/fmgr.c:\d+/
--- s/fmgr.c:\d+/fmgr.c:XXX/
--- m/ruleutils.c:\d+/
--- s/ruleutils.c:\d+/ruleutils.c:XXX/
--- end_matchsubs
-
 -- Case 1. Function dependency on the schema.
 create schema test_1_schema;
 CREATE
@@ -60,7 +43,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  schema "test_1_schema" does not exist  (seg0 127.0.1.1:6002 pid=2715327)
+ERROR:  namespace ##### was concurrently dropped
 1: end;
 END
 
@@ -110,8 +93,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  cache lookup failed for type XXXXX (format_type.c:XXX)
-CONTEXT:  SQL function "test_2_function"
+ERROR:  type ##### was concurrently dropped
 1: end;
 END
 
@@ -157,8 +139,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  cache lookup failed for type XXXXX (lsyscache.c:XXX)
-CONTEXT:  SQL function "test_3_function"
+ERROR:  type ##### was concurrently dropped
 1: end;
 END
 
@@ -205,7 +186,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  cache lookup failed for language XXXXX (fmgr.c:XXX)
+ERROR:  language ##### was concurrently dropped
 1: end;
 END
 
@@ -252,8 +233,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  function test5_default_value_function() does not exist  (seg0 127.0.1.1:6002 pid=2718914)
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  procedure ##### was concurrently dropped
 1: end;
 END
 
@@ -304,7 +284,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  cache lookup failed for function XXXXX (ruleutils.c:10062)  (seg2 127.0.1.1:6004 pid=2718915) (ruleutils.c:10062)
+ERROR:  procedure ##### was concurrently dropped
 1: end;
 END
 
@@ -352,7 +332,7 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  type "test_7_type" does not exist  (seg0 127.0.1.1:6002 pid=2718914)
+ERROR:  type ##### was concurrently dropped
 1: end;
 END
 
@@ -403,6 +383,6 @@ DROP
 2: commit;
 COMMIT
 1<:  <... completed>
-ERROR:  collation "test_8_collation" for encoding "UTF8" does not exist  (seg0 127.0.1.1:6002 pid=2718914)
+ERROR:  collation ##### was concurrently dropped
 1: end;
 END

--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -568,14 +568,11 @@ ERROR:  cannot drop server test_12_server because other objects depend on it
 DETAIL:  user mapping for public on server test_12_server depends on server test_12_server
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 
-! psql isolation2test -c '\deu';
-   List of user mappings
-     Server     | User name 
-----------------+-----------
- test_12_server | public
+SELECT srvname, usename FROM pg_user_mappings ORDER BY 1, 2;
+ srvname        | usename 
+----------------+---------
+ test_12_server | public  
 (1 row)
-
-
 
 drop server test_12_server cascade;
 DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -358,3 +358,4 @@ test: copy_interrupt
 
 # test pg_locks view and pg_lock_status() function
 test: lock_status
+test: dependency

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -589,3 +589,27 @@ create operator family test_17_op_family using btree;
 1: end;
 
 drop function test_17_eq(int, int);
+
+-- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
+create schema test_schema;
+create type test_type as enum ('one', 'two');
+
+1: begin;
+2: begin;
+
+2: drop type test_type;
+1&: create function test_schema.test_function(a test_type) returns text as $$
+    select 'Return ' || a;  /**/
+$$ language sql;
+2&: drop schema test_schema;
+
+-- start_ignore
+1<:
+2<:
+-- end_ignore
+
+1: rollback;
+2: rollback;
+
+drop schema test_schema;
+drop type test_type;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -377,7 +377,7 @@ create server test_12_server foreign data wrapper test_12_fdw;
 
 2<:
 
-! psql isolation2test -c '\deu';
+SELECT srvname, usename FROM pg_user_mappings ORDER BY 1, 2;
 
 drop server test_12_server cascade;
 

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -654,6 +654,37 @@ $$ language sql;
 1<:
 1: end;
 
+-- Case 20. Table dependency on the column type (with ALTER COLUMN).
+create type test_20_type as enum ('one', 'two');
+create table test_20_table(a text);
+
+1: begin;
+1: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;
+
+2&: drop type test_20_type;
+
+1: commit;
+
+2<:
+
+1: select * from test_20_table;
+
+drop type test_20_type cascade;
+drop table test_20_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_20_type as enum ('one', 'two');
+create table test_20_table(a text);
+
+1: begin;
+2: begin;
+2: drop type test_20_type;
+1&: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;
+
+2: commit;
+1<:
+1: end;
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 create type test_type as enum ('one', 'two');

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -415,3 +415,33 @@ create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_fil
 
 drop function write_to_file();
 drop function read_from_file();
+
+-- Case 14. Text search configuration dependency on the text search dictionary
+create text search dictionary test_14_dict ( template = simple );
+
+1: begin;
+1: create text search configuration test_14_config (parser = default);
+1: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;
+
+2&: drop text search dictionary test_14_dict;
+
+1: commit;
+
+2<:
+
+1: select count(1) from ts_debug('public.test_14_config', 'test');
+
+drop text search dictionary test_14_dict cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search dictionary test_14_dict ( template = simple );
+
+1: begin;
+1: create text search configuration test_14_config (parser = default);
+2: begin;
+2: drop text search dictionary test_14_dict;
+1&: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;
+
+2: commit;
+1<:
+1: end;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -494,15 +494,15 @@ create operator ~*~ (
 drop function test_15_function(text, text);
 
 -- Case 16. Index dependency on the operator class.
-create function test_16_eq(int, int) returns int as $$
+create function test_16_idx_func(int, int) returns int as $$
 begin
-    return 1;  /**/
+    return $1 - $2;  /**/
 end;  /**/
 $$ language plpgsql immutable;
 
 create operator class test_16_op_class for type int using btree as
     operator 1 =(int, int),
-    function 1 test_16_eq(int, int);
+    function 1 test_16_idx_func(int, int);
 
 create table test_16_table(a int);
 
@@ -515,14 +515,14 @@ create table test_16_table(a int);
 
 2<:
 
-1: explain (costs off) select * from test_16_table where a = 1;
+1: select * from test_16_table where a = 0;
 
 drop operator class test_16_op_class using btree cascade;
 
 -- Check if dependency is dropped before the creation of the dependent object.
 create operator class test_16_op_class for type int using btree as
     operator 1 =(int, int),
-    function 1 test_16_eq(int, int);
+    function 1 test_16_idx_func(int, int);
 
 1: begin;
 2: begin;
@@ -533,7 +533,7 @@ create operator class test_16_op_class for type int using btree as
 1<:
 1: end;
 
-drop function test_16_eq(int, int);
+drop function test_16_idx_func(int, int);
 drop table test_16_table;
 
 -- Case 17. Operator class dependency on the operator family.

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -113,8 +113,9 @@ $$ language sql;
 
 -- Case 4. Dependency on the language.
 -- start_ignore
-create or replace language plpythonu;
+drop language if exists plpythonu cascade;
 -- end_ignore
+create language plpythonu;
 
 1: begin;
 1: create function test_4_function() returns text as $$
@@ -132,9 +133,8 @@ $$ language plpythonu;
 drop language plpythonu cascade;
 
 -- Check if dependency is dropped before the creation of the dependent object.
--- start_ignore
-create or replace language plpythonu;
--- end_ignore
+create language plpythonu;
+
 1: begin;
 2: begin;
 2: drop language plpythonu;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -319,3 +319,31 @@ create text search template test_10_template(init = dsimple_init, lexize = dsimp
 2: commit;
 1<:
 1: end;
+
+-- Case 11. Server dependency on the foreigh data wrapper.
+create foreign data wrapper test_11_fdw;
+
+1: begin;
+1: create server test_11_server foreign data wrapper test_11_fdw;
+
+2&: drop foreign data wrapper test_11_fdw;
+
+1: commit;
+
+2<:
+
+1: alter server test_11_server options (servername 'test_server');
+
+drop foreign data wrapper test_11_fdw cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create foreign data wrapper test_11_fdw;
+
+1: begin;
+2: begin;
+2: drop foreign data wrapper test_11_fdw;
+1&: create server test_11_server foreign data wrapper test_11_fdw;
+
+2: commit;
+1<:
+1: end;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -9,6 +9,13 @@ create schema test_1_schema;
     select 'test'::text; /**/
 $$ language sql;
 
+-- Check that we didn't add extra locks. Here we lock only namespace, so the count is 1.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object')
+select count(1), gp_segment_id from pg_locks
+where classid in (select classid from cte) and objid in (select objid from cte)
+group by gp_segment_id order by gp_segment_id;
+
 2&: drop schema test_1_schema;
 
 1: commit;
@@ -39,6 +46,13 @@ create type test_2_type as (a int);
 1: create function test_2_function() returns setof test_2_type as $$
     select i from generate_series(1,5)i; /**/
 $$ language sql;
+
+-- Check that we didn't add extra locks. Here we lock namespace ('public') and type, so the count is 2.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object')
+select count(1), gp_segment_id from pg_locks
+where classid in (select classid from cte) and objid in (select objid from cte)
+group by gp_segment_id order by gp_segment_id;
 
 2&: drop type test_2_type;
 

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -744,6 +744,38 @@ create sequence test_22_seq;
 1<:
 1: end;
 
+-- Case 23. Table dependency on the column type with REPEATABLE READ isolation level.
+create type test_23_type as enum ('one', 'two');
+
+1: begin;
+1: set transaction isolation level repeatable read;
+1: create table test_23_table(a test_23_type);
+
+2&: drop type test_23_type;
+
+1: commit;
+
+2<:
+
+1: select * from test_23_table;
+
+drop type test_23_type cascade;
+drop table test_23_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_23_type as enum ('one', 'two');
+
+1: begin;
+1: set transaction isolation level repeatable read;
+2: begin;
+2: set transaction isolation level repeatable read;
+2: drop type test_23_type;
+1&: create table test_23_table(a test_23_type);
+
+2: commit;
+1<:
+1: end;
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 create type test_type as enum ('one', 'two');

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -685,6 +685,36 @@ create table test_20_table(a text);
 1<:
 1: end;
 
+-- Case 21. Rule dependency on the table.
+create table test_21_table_1(a int);
+create table test_21_table_2(a int);
+
+1: begin;
+1: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);
+
+2&: drop table test_21_table_2;
+
+1: commit;
+
+2<:
+
+1: insert into test_21_table_1 values (0);
+1: select * from test_21_table_2;
+
+drop rule test_21_rule on test_21_table_1;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+1: begin;
+2: begin;
+2: drop table test_21_table_2;
+1&: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);
+
+2: commit;
+1<:
+1: end;
+
+drop table test_21_table_1;
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 create type test_type as enum ('one', 'two');

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -263,3 +263,31 @@ create collation test_8_collation (locale="en_US.utf8");
 2: commit;
 1<:
 1: end;
+
+-- Case 9. Text search configuration dependency on the parser.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+
+1: begin;
+1: create text search configuration test_9_configuration(parser = test_9_parser);
+
+2&: drop text search parser test_9_parser;
+
+1: commit;
+
+2<:
+
+1: select count(1) from ts_debug('public.test_9_configuration', 'test');
+
+drop text search parser test_9_parser cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+
+1: begin;
+2: begin;
+2: drop text search parser test_9_parser;
+1&: create text search configuration test_9_configuration(parser = test_9_parser);
+
+2: commit;
+1<:
+1: end;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -715,6 +715,35 @@ drop rule test_21_rule on test_21_table_1;
 
 drop table test_21_table_1;
 
+-- Case 22. Table dependency on the sequence.
+create sequence test_22_seq;
+
+1: begin;
+1: create table test_22_table(id int default nextval('test_22_seq'));
+
+2&: drop sequence test_22_seq;
+
+1: commit;
+
+2<:
+
+1: insert into test_22_table default values;
+
+drop sequence test_22_seq cascade;
+drop table test_22_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create sequence test_22_seq;
+
+1: begin;
+2: begin;
+2: drop sequence test_22_seq;
+1&: create table test_22_table(id int default nextval('test_22_seq'));
+
+2: commit;
+1<:
+1: end;
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 create type test_type as enum ('one', 'two');

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -1,0 +1,282 @@
+-- Test different cases when a parallel transaction drops a dependency object
+-- before current transaction is committed.
+
+-- start_matchsubs
+-- m/cache lookup failed for type \d+/
+-- s/cache lookup failed for type \d+/cache lookup failed for type XXXXX/
+-- m/cache lookup failed for language \d+/
+-- s/cache lookup failed for language \d+/cache lookup failed for language XXXXX/
+-- m/cache lookup failed for function \d+/
+-- s/cache lookup failed for function \d+/cache lookup failed for function XXXXX/
+-- m/format_type.c:\d+/
+-- s/format_type.c:\d+/format_type.c:XXX/
+-- m/lsyscache.c:\d+/
+-- s/lsyscache.c:\d+/lsyscache.c:XXX/
+-- m/fmgr.c:\d+/
+-- s/fmgr.c:\d+/fmgr.c:XXX/
+-- m/ruleutils.c:\d+/
+-- s/ruleutils.c:\d+/ruleutils.c:XXX/
+-- end_matchsubs
+
+-- Case 1. Dependency on the schema.
+create schema test_1_schema;
+
+1: begin;
+1: create function test_1_schema.test_1_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+2&: drop schema test_1_schema;
+
+1: commit;
+
+2<:
+
+1: select test_1_schema.test_1_function();
+
+drop schema test_1_schema cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create schema test_1_schema;
+1: begin;
+2: begin;
+2: drop schema test_1_schema;
+1&: create function test_1_schema.test_1_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 2. Dependency on the return type.
+create type test_2_type as (a int);
+
+1: begin;
+1: create function test_2_function() returns setof test_2_type as $$
+    select i from generate_series(1,5)i; /**/
+$$ language sql;
+
+2&: drop type test_2_type;
+
+1: commit;
+
+2<:
+
+1: select test_2_function();
+
+drop type test_2_type cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_2_type as (a int);
+1: begin;
+2: begin;
+2: drop type test_2_type;
+1&: create function test_2_function() returns setof test_2_type as $$
+    select i from generate_series(1,5)i; /**/
+$$ language sql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 3. Dependency on the parameter type.
+create type test_3_type as enum ('one', 'two');
+
+1: begin;
+1: create function test_3_function(a test_3_type) returns text as $$
+    select 'Return ' || a; /**/
+$$ language sql;
+
+2&: drop type test_3_type;
+
+1: commit;
+
+2<:
+
+1: select test_3_function('one');
+
+drop type test_3_type cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_3_type as enum ('one', 'two');
+1: begin;
+2: begin;
+2: drop type test_3_type;
+1&: create function test_3_function(a test_3_type) returns text as $$
+    select 'Return ' || a; /**/
+$$ language sql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 4. Dependency on the language.
+-- start_ignore
+create or replace language plpythonu;
+-- end_ignore
+
+1: begin;
+1: create function test_4_function() returns text as $$
+	return "test"
+$$ language plpythonu;
+
+2&: drop language plpythonu;
+
+1: commit;
+
+2<:
+
+1: select test_4_function();
+
+drop language plpythonu cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+-- start_ignore
+create or replace language plpythonu;
+-- end_ignore
+1: begin;
+2: begin;
+2: drop language plpythonu;
+1&: create function test_4_function() returns text as $$
+	return "test"
+$$ language plpythonu;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 5. Dependency on the parameter default expression.
+create function test5_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+1: create function test_5_function(a text default test5_default_value_function()) returns text as
+$$
+begin
+	return a; /**/
+end
+$$ language plpgsql;
+
+2&: drop function test5_default_value_function();
+
+1: commit;
+
+2<:
+
+1: select test_5_function();
+
+drop function test5_default_value_function() cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test5_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test5_default_value_function();
+1&: create function test_5_function(a text default test5_default_value_function()) returns text as
+$$
+begin
+	return a; /**/
+end
+$$ language plpgsql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 6. Dependency on the column default expression.
+create function test_6_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+1: create table test_6_table(a text default test_6_default_value_function());
+
+2&: drop function test_6_default_value_function();
+
+1: commit;
+
+2<:
+
+1: insert into test_6_table default values;
+1: select * from test_6_table;
+
+drop function test_6_default_value_function() cascade;
+drop table test_6_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_6_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test_6_default_value_function();
+1&: create table test_6_table(a text default test_6_default_value_function());
+
+2: commit;
+1<:
+1: end;
+
+-- Case 7. Dependency on the column type.
+create type test_7_type as enum ('one', 'two');
+
+1: begin;
+1: create table test_7_table(a test_7_type);
+
+2&: drop type test_7_type;
+
+1: commit;
+
+2<:
+
+1: select * from test_7_table;
+
+drop type test_7_type cascade;
+drop table test_7_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_7_type as enum ('one', 'two');
+
+1: begin;
+2: begin;
+2: drop type test_7_type;
+1&: create table test_7_table(a test_7_type);
+
+2: commit;
+1<:
+1: end;
+
+-- Case 8. Table dependency on the collation.
+create collation test_8_collation (locale="en_US.utf8");
+
+1: begin;
+1: create table test_8_table(a text collate test_8_collation);
+1: insert into test_8_table values('data');
+
+2&: drop collation test_8_collation;
+
+1: commit;
+
+2<:
+
+1: select * from test_8_table where a < 'test';
+
+drop collation test_8_collation cascade;
+drop table test_8_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create collation test_8_collation (locale="en_US.utf8");
+
+1: begin;
+2: begin;
+2: drop collation test_8_collation;
+1&: create table test_8_table(a text collate test_8_collation);
+
+2: commit;
+1<:
+1: end;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -347,3 +347,34 @@ create foreign data wrapper test_11_fdw;
 2: commit;
 1<:
 1: end;
+
+-- Case 12. User mapping dependency on the server.
+create foreign data wrapper test_12_fdw;
+create server test_12_server foreign data wrapper test_12_fdw;
+
+1: begin;
+1: create user mapping for public server test_12_server;
+
+2&: drop server test_12_server;
+
+1: commit;
+
+2<:
+
+! psql isolation2test -c '\deu';
+
+drop server test_12_server cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create server test_12_server foreign data wrapper test_12_fdw;
+
+1: begin;
+2: begin;
+2: drop server test_12_server;
+1&: create user mapping for public server test_12_server;
+
+2: commit;
+1<:
+1: end;
+
+drop foreign data wrapper test_12_fdw;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -1,5 +1,5 @@
--- Test different cases when a parallel transaction drops a dependency object
--- before current transaction is committed.
+-- Test cases when a parallel transaction drops a dependency object
+-- while current transaction is yet not committed.
 
 -- start_matchsubs
 -- m/cache lookup failed for type \d+/
@@ -18,7 +18,7 @@
 -- s/ruleutils.c:\d+/ruleutils.c:XXX/
 -- end_matchsubs
 
--- Case 1. Dependency on the schema.
+-- Case 1. Function dependency on the schema.
 create schema test_1_schema;
 
 1: begin;
@@ -49,7 +49,7 @@ $$ language sql;
 1<:
 1: end;
 
--- Case 2. Dependency on the return type.
+-- Case 2. Function dependency on the return type.
 create type test_2_type as (a int);
 
 1: begin;
@@ -80,7 +80,7 @@ $$ language sql;
 1<:
 1: end;
 
--- Case 3. Dependency on the parameter type.
+-- Case 3. Function dependency on the parameter type.
 create type test_3_type as enum ('one', 'two');
 
 1: begin;
@@ -111,7 +111,7 @@ $$ language sql;
 1<:
 1: end;
 
--- Case 4. Dependency on the language.
+-- Case 4. Function dependency on the language.
 -- start_ignore
 drop language if exists plpythonu cascade;
 -- end_ignore
@@ -146,7 +146,7 @@ $$ language plpythonu;
 1<:
 1: end;
 
--- Case 5. Dependency on the parameter default expression.
+-- Case 5. Function dependency on the parameter default expression.
 create function test5_default_value_function() returns text as $$
     select 'test'::text; /**/
 $$ language sql;
@@ -188,7 +188,7 @@ $$ language plpgsql;
 1<:
 1: end;
 
--- Case 6. Dependency on the column default expression.
+-- Case 6. Table dependency on the column default expression.
 create function test_6_default_value_function() returns text as $$
     select 'test'::text; /**/
 $$ language sql;
@@ -222,7 +222,7 @@ $$ language sql;
 1<:
 1: end;
 
--- Case 7. Dependency on the column type.
+-- Case 7. Table dependency on the column type.
 create type test_7_type as enum ('one', 'two');
 
 1: begin;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -590,6 +590,38 @@ create operator family test_17_op_family using btree;
 
 drop function test_17_eq(int, int);
 
+-- Case 18. View dependency on the function.
+create function test_18_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+1: create view test_18_view as select test_18_function();
+
+2&: drop function test_18_function();
+
+1: commit;
+
+2<:
+
+1: select * from test_18_view;
+
+drop function test_18_function()cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_18_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test_18_function();
+1&: create view test_18_view as select test_18_function();
+
+2: commit;
+1<:
+1: end;
+
 -- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
 create schema test_schema;
 create type test_type as enum ('one', 'two');

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -492,3 +492,46 @@ create operator ~*~ (
 1: end;
 
 drop function test_15_function(text, text);
+
+-- Case 16. Index dependency on the operator class.
+create function test_16_eq(int, int) returns int as $$
+begin
+    return 1;  /**/
+end;  /**/
+$$ language plpgsql immutable;
+
+create operator class test_16_op_class for type int using btree as
+    operator 1 =(int, int),
+    function 1 test_16_eq(int, int);
+
+create table test_16_table(a int);
+
+1: begin;
+1: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);
+
+2&: drop operator class test_16_op_class using btree;
+
+1: commit;
+
+2<:
+
+1: explain (costs off) select * from test_16_table where a = 1;
+
+drop operator class test_16_op_class using btree cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator class test_16_op_class for type int using btree as
+    operator 1 =(int, int),
+    function 1 test_16_eq(int, int);
+
+1: begin;
+2: begin;
+2: drop operator class test_16_op_class using btree;
+1&: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);
+
+2: commit;
+1<:
+1: end;
+
+drop function test_16_eq(int, int);
+drop table test_16_table;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -336,7 +336,7 @@ create text search template test_10_template(init = dsimple_init, lexize = dsimp
 1<:
 1: end;
 
--- Case 11. Server dependency on the foreigh data wrapper.
+-- Case 11. Server dependency on the foreign data wrapper.
 create foreign data wrapper test_11_fdw;
 
 1: begin;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -378,3 +378,40 @@ create server test_12_server foreign data wrapper test_12_fdw;
 1: end;
 
 drop foreign data wrapper test_12_fdw;
+
+-- Case 13. External table dependency on the protocol.
+create or replace function write_to_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_export' language c stable no sql;
+create or replace function read_from_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_import' language c stable no sql;
+
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+! echo 1 > /tmp/test_13.txt;
+
+1: begin;
+1: create readable external table test_13_ext_table(a int) location('demoprot:///tmp/test_13.txt') format 'text';
+
+2&: drop protocol demoprot;
+
+1: commit;
+
+2<:
+
+1: select * from test_13_ext_table;
+
+! rm /tmp/test_13.txt;
+
+drop protocol demoprot cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+
+1: begin;
+2: begin;
+2: drop protocol demoprot;
+1&: create readable external table test_13_ext_table(a int) location('demoprot://test.txt') format 'text';
+
+2: commit;
+1<:
+1: end;
+
+drop function write_to_file();
+drop function read_from_file();

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -606,7 +606,7 @@ $$ language sql;
 
 1: select * from test_18_view;
 
-drop function test_18_function()cascade;
+drop function test_18_function() cascade;
 
 -- Check if dependency is dropped before the creation of the dependent object.
 create function test_18_function() returns text as $$
@@ -617,6 +617,38 @@ $$ language sql;
 2: begin;
 2: drop function test_18_function();
 1&: create view test_18_view as select test_18_function();
+
+2: commit;
+1<:
+1: end;
+
+-- Case 19. Materialized view dependency on the function.
+create function test_19_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+1: create materialized view test_19_view as select test_19_function();
+
+2&: drop function test_19_function();
+
+1: commit;
+
+2<:
+
+1: select * from test_19_view;
+
+drop function test_19_function() cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_19_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test_19_function();
+1&: create materialized view test_19_view as select test_19_function();
 
 2: commit;
 1<:

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -445,3 +445,50 @@ create text search dictionary test_14_dict ( template = simple );
 2: commit;
 1<:
 1: end;
+
+-- Case 15. Table dependency on the operator.
+create function test_15_function(text, text) returns text as $$
+begin
+	return $1 || $2;  /**/
+end;  /**/
+$$ language plpgsql;
+
+create operator ~*~ (
+    procedure = test_15_function,
+    leftarg = text,
+    rightarg = text,
+    commutator = ~*~
+);
+
+1: begin;
+1: create table test_15_table(a text default 'a' ~*~ 'b');
+
+2&: drop operator ~*~ (text, text);
+
+1: commit;
+
+2<:
+
+1: insert into test_15_table values (default);
+
+drop operator ~*~ (text, text) cascade;
+drop table test_15_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator ~*~ (
+    procedure = test_15_function,
+    leftarg = text,
+    rightarg = text,
+    commutator = ~*~
+);
+
+1: begin;
+2: begin;
+2: drop operator ~*~ (text, text);
+1&: create table test_15_table(a text default 'a' ~*~ 'b');
+
+2: commit;
+1<:
+1: end;
+
+drop function test_15_function(text, text);

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -535,3 +535,43 @@ create operator class test_16_op_class for type int using btree as
 
 drop function test_16_eq(int, int);
 drop table test_16_table;
+
+-- Case 17. Operator class dependency on the operator family.
+create function test_17_eq(int, int) returns int as $$
+begin
+    return 1;  /**/
+end;  /**/
+$$ language plpgsql immutable;
+
+create operator family test_17_op_family using btree;
+
+1: begin;
+1: create operator class test_17_op_class for type int using btree family test_17_op_family as
+    operator 1 =(int, int),
+    function 1 test_17_eq(int, int);
+
+2&: drop operator family test_17_op_family using btree;
+
+1: commit;
+
+2<:
+
+-- Count below should be 0, as 'drop operator family' automatically drops
+-- all its operator classes.
+1: select count(*) from pg_opclass where opcname = 'test_17_op_class';
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator family test_17_op_family using btree;
+
+1: begin;
+2: begin;
+2: drop operator family test_17_op_family using btree;
+1&: create operator class test_17_op_class for type int using btree family test_17_op_family as
+    operator 1 =(int, int),
+    function 1 test_17_eq(int, int);
+
+2: commit;
+1<:
+1: end;
+
+drop function test_17_eq(int, int);

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -291,3 +291,31 @@ create text search parser test_9_parser(start = prsd_start, gettoken = prsd_next
 2: commit;
 1<:
 1: end;
+
+-- Case 10. Text search dictionary dependency on the template.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+
+1: begin;
+1: create text search dictionary test_10_dictionary(template = test_10_template);
+
+2&: drop text search template test_10_template;
+
+1: commit;
+
+2<:
+
+1: select ts_lexize('public.test_10_dictionary', 'test');
+
+drop text search template test_10_template cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+
+1: begin;
+2: begin;
+2: drop text search template test_10_template;
+1&: create text search dictionary test_10_dictionary(template = test_10_template);
+
+2: commit;
+1<:
+1: end;

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -1,23 +1,6 @@
 -- Test cases when a parallel transaction drops a dependency object
 -- while current transaction is yet not committed.
 
--- start_matchsubs
--- m/cache lookup failed for type \d+/
--- s/cache lookup failed for type \d+/cache lookup failed for type XXXXX/
--- m/cache lookup failed for language \d+/
--- s/cache lookup failed for language \d+/cache lookup failed for language XXXXX/
--- m/cache lookup failed for function \d+/
--- s/cache lookup failed for function \d+/cache lookup failed for function XXXXX/
--- m/format_type.c:\d+/
--- s/format_type.c:\d+/format_type.c:XXX/
--- m/lsyscache.c:\d+/
--- s/lsyscache.c:\d+/lsyscache.c:XXX/
--- m/fmgr.c:\d+/
--- s/fmgr.c:\d+/fmgr.c:XXX/
--- m/ruleutils.c:\d+/
--- s/ruleutils.c:\d+/ruleutils.c:XXX/
--- end_matchsubs
-
 -- Case 1. Function dependency on the schema.
 create schema test_1_schema;
 

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -11,10 +11,11 @@ $$ language sql;
 
 -- Check that we didn't add extra locks. Here we lock only namespace, so the count is 1.
 -- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
-1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object')
-select count(1), gp_segment_id from pg_locks
-where classid in (select classid from cte) and objid in (select objid from cte)
-group by gp_segment_id order by gp_segment_id;
+1:  select count(1), l.gp_segment_id
+from pg_locks l
+join pg_locks r using (locktype, classid, objid)
+where r.pid = pg_backend_pid() and r.locktype = 'object'
+group by 2 order by 2;
 
 2&: drop schema test_1_schema;
 
@@ -49,10 +50,11 @@ $$ language sql;
 
 -- Check that we didn't add extra locks. Here we lock namespace ('public') and type, so the count is 2.
 -- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
-1:  with cte as (select * from pg_locks where pid = pg_backend_pid() and locktype = 'object')
-select count(1), gp_segment_id from pg_locks
-where classid in (select classid from cte) and objid in (select objid from cte)
-group by gp_segment_id order by gp_segment_id;
+1:  select count(1), l.gp_segment_id
+from pg_locks l
+join pg_locks r using (locktype, classid, objid)
+where r.pid = pg_backend_pid() and r.locktype = 'object'
+group by 2 order by 2;
 
 2&: drop type test_2_type;
 


### PR DESCRIPTION
Protect object creation from dropping referenced objects

Problem description:
If an object had been created inside a transaction and it had a dependency on 
some other object (like schema, custom data type, etc), and that referenced 
object had been dropped from another transaction before the first transaction 
had been committed, the new object was broken. 

Ex. steps:
```
Session 1: create type test_type as enum ('one', 'two');
Session 1: begin;
Session 1: create table test_table(a test_type);
Session 2: drop type test_type;
Session 1: commit;
Session 1: select * from test_table;
```
gave result:
```
ERROR:  cache lookup failed for type 16385 (lsyscache.c:2796)
```

The issue reproduced for all dependencies that are registered in 'pg_depend'.

Root cause:
No protection from stealing the objects that are marked as dependencies in
'pg_depend' before the transaction is committed.

Fix:
Lock the referenced object with AccessShareLock when the dependency is created.
Lock is done only for 'normal' dependencies (which means here 'normal
relationship between separately-created objects', when the dependent object may
be dropped without affecting the referenced object, while the referenced object
may only be dropped with CASCADE, in which case the dependent object is dropped
too) and 'auto' (meaning that the dependent object can be dropped separately
from the referenced object, and should be automatically dropped if the
referenced object is dropped).
After the lock is released, do a recheck of the object's presence and error out
if the object was dropped while we waited for the lock.