### PR TITLE
Fix sequence test

### DIFF
--- a/src/test/regress/expected/sequence.out
+++ b/src/test/regress/expected/sequence.out
@@ -574,13 +574,7 @@ SELECT nextval('seq2');
 --SELECT lastval();
 DROP SEQUENCE seq2;
 -- should fail
-<<<<<<< HEAD
 --SELECT lastval();
-CREATE USER regress_seq_user;
-=======
-SELECT lastval();
-ERROR:  lastval is not yet defined in this session
->>>>>>> BISECT_HEAD
 -- Test sequences in read-only transactions
 CREATE TEMPORARY SEQUENCE sequence_test_temp1;
 START TRANSACTION READ ONLY;


### PR DESCRIPTION
Commit ad4b7aeb84434c958e2df76fa69b68493a889e4a moved a create role while
earlier commit 6b0e52beadd678c5050af9c978c26d171ba86ae0 commented out line
nearby.