### PR TITLE
Fix gp_dump_query_oids test

### DIFF
--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -1829,7 +1829,7 @@ ApplyRetrieveRule(Query *parsetree,
 
 	rte->rtekind = RTE_SUBQUERY;
 	rte->subquery = rule_action;
-	rte->security_barrier = RelationIsSecurityView(relation);
+	rte->security_barrier = RelationIsSecurityView(relation, parsetree);
 	/* Clear fields that should not be set in a subquery RTE */
 	rte->relid = InvalidOid;
 	rte->relkind = 0;
@@ -3423,7 +3423,7 @@ rewriteTargetView(Query *parsetree, Relation view)
 
 		ChangeVarNodes(viewqual, base_rt_index, new_rt_index, 0);
 
-		if (RelationIsSecurityView(view))
+		if (RelationIsSecurityView(view, parsetree))
 		{
 			/*
 			 * The view's quals go in front of existing barrier quals: those

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -363,9 +363,12 @@ typedef struct ViewOptions
  * RelationIsSecurityView
  *		Returns whether the relation is security view, or not.  Note multiple
  *		eval of argument!
+ *	GPDB
+ *		In GPDB, we also use this macro for materialized views.
  */
-#define RelationIsSecurityView(relation)									\
-	(AssertMacro(relation->rd_rel->relkind == RELKIND_VIEW),				\
+#define RelationIsSecurityView(relation, parseTree)							 \
+	(AssertMacro(relation->rd_rel->relkind == RELKIND_VIEW ||				 \
+(relation->rd_rel->relkind == RELKIND_MATVIEW && parsetree->expandMatViews)),\
 	 (relation)->rd_options ?												\
 	  ((ViewOptions *) (relation)->rd_options)->security_barrier : false)
 


### PR DESCRIPTION
Commit 396773762425126a85243fc85a267d401496beb8 added some assertions to the 
RelationIsSecurityView macro. But in the gpdb since commit 
eedd5ff94edc137abe75ebe16b094bd977345435 this macro is also used with matview.
This caused the gp_dump_query_oids test to fail. Because it uses the
gp_dump_query_oids function, which rewrites the materialized view.
