### PR TITLE
Fix gp_svec test

### DIFF
--- a/gpcontrib/gp_sparse_vector/expected/gp_svec.out
+++ b/gpcontrib/gp_sparse_vector/expected/gp_svec.out
@@ -271,7 +271,6 @@ WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_
  routines                          |                        3
  sequences                         |                        3
  sql_features                      |                        3
- sql_packages                      |                        3
  sql_parts                         |                        3
  table_constraints                 |                        3
  table_privileges                  |                        3
@@ -280,7 +279,7 @@ WHERE a.character_maximum_length == b.character_maximum_length ORDER BY a.table_
  usage_privileges                  |                        3
  user_defined_types                |                        3
  views                             |                        3
-(25 rows)
+(24 rows)
 
 DROP EXTENSION gp_sparse_vector;
 RESET search_path;


### PR DESCRIPTION
Commit 2fc2a88e6722df40245d3ae2ec7f8fc1c6bf0596 removed sql_packages table from 
information_schema. But this table appeared in the gp_svec test output, so we need to 
remove it.