### PR TITLE
ADBDEV-7691, ADBDEV-7690: Track PQresult allocations in server side, Gracefully handle OOM when cancelling a query

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -685,6 +685,8 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 			handlePollSuccess(pParms, fds);
 	}
 
+	SIMPLE_FAULT_INJECTOR("check_dispatch_result_end");
+
 	pfree(fds);
 }
 

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -823,6 +823,60 @@ handlePollError(CdbDispatchCmdAsync *pParms)
 }
 
 /*
+ * Try to completely discard results from a dispatchResult's connection without
+ * extra memory allocations by abusing libpq state-machine hacks.
+ */
+static void
+tryToWipeResults(CdbDispatchResult *dispatchResult)
+{
+	PGresult   *res;
+	PGnotify   *notify;
+	PGconn	   *conn = dispatchResult->segdbDesc->conn;
+
+	/* Free some memory and replace current result with a fatal error dummy. */
+	pqSaveErrorResult(conn);
+
+	/* Make sure PQgetResult() calls are not blocking. */
+	PQconsumeInput(conn);
+
+	/*
+	 * Discard anything that is unread. Since our result contains a fatal
+	 * error, we'll just consume the entire message without actually parsing
+	 * it.
+	 */
+	while (!PQisBusy(conn) && (res = PQgetResult(conn)) != NULL)
+	{
+		switch (PQresultStatus(res))
+		{
+			case PGRES_COPY_IN:
+			case PGRES_COPY_OUT:
+			case PGRES_COPY_BOTH:
+				PQendcopy(conn);
+				/* fallthrough */
+			default:
+				PQclear(res);
+		}
+
+		pqSaveErrorResult(conn);
+	}
+
+	/* Free notices. */
+	while ((notify = PQnotifies(conn)) != NULL)
+		PQfreemem(notify);
+
+	/* The result is not needed anymore. */
+	pqClearAsyncResult(conn);
+
+	if (PQisBusy(conn) && PQstatus(conn) != CONNECTION_BAD)
+	{
+		/* Some work is still remaining until we can die. */
+		return;
+	}
+
+	dispatchResult->stillRunning = false;
+}
+
+/*
  * Receive and process results from QEs.
  */
 static void
@@ -867,6 +921,24 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 
 		ELOG_DISPATCHER_DEBUG("PQsocket says there are results from %d of %d (%s)",
 							  i + 1, pParms->dispatchCount, segdbDesc->whoami);
+
+
+		/*
+		 * Was dispatchCancel() the callee? We don't need to read the results then.
+		 */
+		if (pParms->waitMode == DISPATCH_WAIT_CANCEL)
+		{
+			/*
+			 * If we're cancelling the transaction due to an OOM, there
+			 * might not be enough memory to discard the result properly.
+			 * Let's get the big guns out.
+			 */
+			tryToWipeResults(dispatchResult);
+
+			forwardQENotices();
+
+			continue;
+		}
 
 		/*
 		 * Receive and process results from this QE.

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -109,13 +109,31 @@ int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
  * than looking into errcodes.h since it reflects historical behavior
  * rather than that of the current code.
  */
+#ifdef ERRCODE_APPNAME_UNKNOWN
+#undef ERRCODE_APPNAME_UNKNOWN
+#endif
+
 #define ERRCODE_APPNAME_UNKNOWN "42704"
 
 /* This is part of the protocol so just define it */
+#ifdef ERRCODE_INVALID_PASSWORD
+#undef ERRCODE_INVALID_PASSWORD
+#endif
+
 #define ERRCODE_INVALID_PASSWORD "28P01"
+
 /* This too */
+#ifdef ERRCODE_CANNOT_CONNECT_NOW
+#undef ERRCODE_CANNOT_CONNECT_NOW
+#endif
+
 #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
+
 /* And this GPDB-specific one, too */
+#ifdef ERRCODE_MIRROR_READY
+#undef ERRCODE_MIRROR_READY
+#endif
+
 #define ERRCODE_MIRROR_READY "57M02"
 
 /*

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -151,7 +151,7 @@ PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status)
 {
 	PGresult   *result;
 
-	result = (PGresult *) malloc(sizeof(PGresult));
+	result = (PGresult *) pqPalloc(sizeof(PGresult));
 	if (!result)
 		return NULL;
 
@@ -407,7 +407,7 @@ dupEvents(PGEvent *events, int count)
 	if (!events || count <= 0)
 		return NULL;
 
-	newEvents = (PGEvent *) malloc(count * sizeof(PGEvent));
+	newEvents = (PGEvent *) pqPalloc(count * sizeof(PGEvent));
 	if (!newEvents)
 		return NULL;
 
@@ -417,12 +417,12 @@ dupEvents(PGEvent *events, int count)
 		newEvents[i].passThrough = events[i].passThrough;
 		newEvents[i].data = NULL;
 		newEvents[i].resultInitialized = FALSE;
-		newEvents[i].name = strdup(events[i].name);
+		newEvents[i].name = pqPstrdup(events[i].name);
 		if (!newEvents[i].name)
 		{
 			while (--i >= 0)
-				free(newEvents[i].name);
-			free(newEvents);
+				pqPfree(newEvents[i].name);
+			pqPfree(newEvents);
 			return NULL;
 		}
 	}
@@ -585,7 +585,7 @@ pqResultAlloc(PGresult *res, size_t nBytes, bool isBinary)
 	 */
 	if (nBytes >= PGRESULT_SEP_ALLOC_THRESHOLD)
 	{
-		block = (PGresult_data *) malloc(nBytes + PGRESULT_BLOCK_OVERHEAD);
+		block = (PGresult_data *) pqPalloc(nBytes + PGRESULT_BLOCK_OVERHEAD);
 		if (!block)
 			return NULL;
 		space = block->space + PGRESULT_BLOCK_OVERHEAD;
@@ -609,7 +609,7 @@ pqResultAlloc(PGresult *res, size_t nBytes, bool isBinary)
 	}
 
 	/* Otherwise, start a new block. */
-	block = (PGresult_data *) malloc(PGRESULT_DATA_BLOCKSIZE);
+	block = (PGresult_data *) pqPalloc(PGRESULT_DATA_BLOCKSIZE);
 	if (!block)
 		return NULL;
 	block->next = res->curBlock;
@@ -709,18 +709,18 @@ PQclear(PGresult *res)
 	}
 
 	if (res->events)
-		free(res->events);
+		pqPfree(res->events);
 
 	/* Free all the subsidiary blocks */
 	while ((block = res->curBlock) != NULL)
 	{
 		res->curBlock = block->next;
-		free(block);
+		pqPfree(block);
 	}
 
 	/* Free the top-level tuple pointer array */
 	if (res->tuples)
-		free(res->tuples);
+		pqPfree(res->tuples);
 
 	/* zero out the pointer fields to catch programming errors */
 	res->attDescs = NULL;
@@ -732,20 +732,20 @@ PQclear(PGresult *res)
 	/* res->curBlock was zeroed out earlier */
 
 	if (res->extras)
-		free(res->extras);
+		pqPfree(res->extras);
 	res->extraslen = 0;
 	res->extras = NULL;
 
 	if (res->aotupcounts)
-		free(res->aotupcounts);
+		pqPfree(res->aotupcounts);
 	res->naotupcounts = 0;
 
 	if (res->waitGxids)
-		free(res->waitGxids);
+		pqPfree(res->waitGxids);
 	res->waitGxids = NULL;
 	res->nWaits = 0;
 	/* Free the PGresult structure itself */
-	free(res);
+	pqPfree(res);
 }
 
 /*
@@ -951,10 +951,10 @@ pqAddTuple(PGresult *res, PGresAttValue *tup, const char **errmsgp)
 
 		if (res->tuples == NULL)
 			newTuples = (PGresAttValue **)
-				malloc(newSize * sizeof(PGresAttValue *));
+				pqPalloc(newSize * sizeof(PGresAttValue *));
 		else
 			newTuples = (PGresAttValue **)
-				realloc(res->tuples, newSize * sizeof(PGresAttValue *));
+				pqRepalloc(res->tuples, newSize * sizeof(PGresAttValue *));
 		if (!newTuples)
 			return FALSE;		/* malloc or realloc failed */
 		res->tupArrSize = newSize;

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -267,7 +267,7 @@ pqParseInput3(PGconn *conn)
 
 					/* now just loop through */
 					conn->result->aotupcounts =
-						malloc(sizeof(PQaoRelTupCount) * conn->result->naotupcounts);
+						pqPalloc(sizeof(PQaoRelTupCount) * conn->result->naotupcounts);
 					ao = conn->result->aotupcounts;
 					for (i = 0; i < conn->result->naotupcounts; i++)
 					{
@@ -529,7 +529,7 @@ pqParseInput3(PGconn *conn)
 
 					if (pqGetInt(&conn->result->extraslen, 4, conn))
 						return;
-					conn->result->extras = malloc(conn->result->extraslen);
+					conn->result->extras = pqPalloc(conn->result->extraslen);
 					if (pqGetnchar((char *)conn->result->extras, conn->result->extraslen, conn))
 						return;
 					conn->asyncStatus = PGASYNC_READY;
@@ -555,7 +555,7 @@ pqParseInput3(PGconn *conn)
 					{
 						if (conn->result->waitGxids == NULL)
 							conn->result->waitGxids =
-								malloc(sizeof(int) * conn->result->nWaits);
+								pqPalloc(sizeof(int) * conn->result->nWaits);
 						for (i = 0; i < conn->result->nWaits; i++)
 						{
 							int gxid;

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -84,6 +84,34 @@ typedef struct
 #endif   /* USE_SSL */
 
 /*
+ * Definitions meant to lessen the malloc() usage for CDB routines in
+ * server-sided code for struct PGresult allocations.
+ */
+#ifndef FRONTEND
+#include "postgres.h"
+#include "utils/memutils.h"
+
+/*
+ * CurTransactionContext's lifetime lasts until the end of the current query,
+ * which does the job well for backends. Auxiliary processes do not set
+ * transaction contexts, so we have to use TopMemoryContext to achieve a
+ * lifetime equivalent to malloc().
+ */
+#define PQ_PALLOC_CONTEXT \
+	((CurTransactionContext != NULL) ? CurTransactionContext : TopMemoryContext)
+
+#define pqPalloc(sz) MemoryContextAlloc(PQ_PALLOC_CONTEXT, sz)
+#define pqPstrdup(x) MemoryContextStrdup(PQ_PALLOC_CONTEXT, x)
+#define pqRepalloc(x, sz) repalloc(x, sz)
+#define pqPfree(x) pfree(x)
+#else
+#define pqPalloc(sz) malloc(sz)
+#define pqPstrdup(x) strdup(x)
+#define pqRepalloc(x, sz) realloc(x, sz)
+#define pqPfree(x) free(x)
+#endif
+
+/*
  * POSTGRES backend dependent Constants.
  */
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/fault_inject.source
@@ -249,3 +249,28 @@ SELECT gp_inject_fault('fetch_tuples_from_endpoint', 'resume', dbid)
     WHERE content=2 AND role='p';
 
 DROP TABLE t2;
+
+SELECT gp_inject_fault('alloc_endpoint_slot_full', 'reset', 2);
+SELECT gp_inject_fault('alloc_endpoint_slot_full_reset', 'reset', 2);
+
+-- Test 8: QD shouldn't hang waiting.
+
+-- start_ignore
+DROP TABLE t3;
+-- end_ignore
+
+CREATE TABLE t3 AS SELECT generate_series(1, 10) AS a DISTRIBUTED by (a);
+
+SELECT gp_inject_fault('alloc_endpoint_slot_full', 'error', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+BEGIN;
+-- QE encounters error and destroys the endpoint immediately. QD successfully
+-- resets the query, sends ACKs, and discards transaction.
+DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t3;
+ROLLBACK;
+
+SELECT gp_inject_fault('alloc_endpoint_slot_full', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+DROP TABLE t3;

--- a/src/test/isolation2/input/resgroup/resgroup_oom.source
+++ b/src/test/isolation2/input/resgroup/resgroup_oom.source
@@ -44,6 +44,10 @@ gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 1<:
 
+-- And finally, make sure we don't enter error recursion on fail.
+ALTER RESOURCE GROUP rg_oom_test SET memory_shared_quota 0;
+1: SELECT count(*) FROM gp_mock_cdbdispatchcommand(10000000);
+
 DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
 DROP ROLE role_oom_test;
 DROP RESOURCE GROUP rg_oom_test;

--- a/src/test/isolation2/input/resgroup/resgroup_oom.source
+++ b/src/test/isolation2/input/resgroup/resgroup_oom.source
@@ -1,0 +1,49 @@
+-- start_matchsubs
+-- m/ERROR:  Out of memory.*/
+-- s/ERROR:  Out of memory.*/ERROR:  Out of memory/
+-- m/ERROR:  Canceling query because of high VMEM usage.*/
+-- s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Out of memory/
+-- end_matchsubs
+
+-- start_ignore
+CREATE EXTENSION gp_inject_fault;
+DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
+DROP ROLE role_oom_test;
+DROP RESOURCE GROUP rg_oom_test;
+-- end_ignore
+CREATE RESOURCE GROUP rg_oom_test
+WITH (cpu_rate_limit=20, memory_limit=20, memory_shared_quota=100);
+CREATE ROLE role_oom_test RESOURCE GROUP rg_oom_test;
+CREATE FUNCTION gp_mock_cdbdispatchcommand(amount int)
+RETURNS SETOF text AS '@abs_srcdir@/../regress/regress.so',
+'gp_mock_cdbdispatchcommand' LANGUAGE C;
+
+1: SET ROLE TO role_oom_test;
+
+-- Freeze coordinator's session after it reads results from segments.
+SELECT gp_inject_fault('check_dispatch_result_end', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Send the heavy query.
+1&: SELECT count(*) FROM gp_mock_cdbdispatchcommand(1000000);
+
+-- Wait until we receive everything.
+SELECT gp_wait_until_triggered_fault('check_dispatch_result_end', 1, dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- The query should've used ~135 MB of memory. Allow 15 MB error.
+WITH r AS (
+  SELECT (memory_usage->'-1'->'used')::text::int AS mb
+  FROM gp_toolkit.gp_resgroup_status WHERE rsgname = 'rg_oom_test'
+)
+SELECT r.mb < 150 AS "under 150 MB", r.mb > 120 AS "above 120 MB"
+FROM r;
+
+SELECT gp_inject_fault('check_dispatch_result_end', 'reset', dbid) FROM
+gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+1<:
+
+DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
+DROP ROLE role_oom_test;
+DROP RESOURCE GROUP rg_oom_test;

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -61,4 +61,6 @@ test: resgroup/resgroup_large_group_id
 
 test: resgroup/resgroup_startup_memory
 
+test: resgroup/resgroup_oom
+
 test: resgroup/disable_resgroup

--- a/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/fault_inject.source
@@ -770,3 +770,47 @@ ROLLBACK
 
 DROP TABLE t2;
 DROP
+
+SELECT gp_inject_fault('alloc_endpoint_slot_full', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('alloc_endpoint_slot_full_reset', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Test 8: QD shouldn't hang waiting.
+
+-- start_ignore
+DROP TABLE t3;
+-- end_ignore
+
+CREATE TABLE t3 AS SELECT generate_series(1, 10) AS a DISTRIBUTED by (a);
+CREATE 10
+
+SELECT gp_inject_fault('alloc_endpoint_slot_full', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+BEGIN;
+BEGIN
+-- QE encounters error and destroys the endpoint immediately. QD successfully
+-- resets the query, sends ACKs, and discards transaction.
+DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t3;
+ERROR:  fault triggered, fault name:'alloc_endpoint_slot_full' fault type:'error'  (seg0 127.0.0.1:6002 pid=8916)
+ROLLBACK;
+ROLLBACK
+
+SELECT gp_inject_fault('alloc_endpoint_slot_full', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+DROP TABLE t3;
+DROP

--- a/src/test/isolation2/output/resgroup/resgroup_oom.source
+++ b/src/test/isolation2/output/resgroup/resgroup_oom.source
@@ -1,0 +1,59 @@
+-- start_matchsubs
+-- m/ERROR:  Out of memory.*/
+-- s/ERROR:  Out of memory.*/ERROR:  Out of memory/
+-- m/ERROR:  Canceling query because of high VMEM usage.*/
+-- s/ERROR:  Canceling query because of high VMEM usage.*/ERROR:  Out of memory/
+-- end_matchsubs
+
+CREATE RESOURCE GROUP rg_oom_test WITH (cpu_rate_limit=20, memory_limit=20, memory_shared_quota=100);
+CREATE
+CREATE ROLE role_oom_test RESOURCE GROUP rg_oom_test;
+CREATE
+CREATE FUNCTION gp_mock_cdbdispatchcommand(amount int) RETURNS SETOF text AS '@abs_srcdir@/../regress/regress.so', 'gp_mock_cdbdispatchcommand' LANGUAGE C;
+CREATE
+
+1: SET ROLE TO role_oom_test;
+SET
+
+-- Freeze coordinator's session after it reads results from segments.
+SELECT gp_inject_fault('check_dispatch_result_end', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Send the heavy query.
+1&: SELECT count(*) FROM gp_mock_cdbdispatchcommand(1000000);  <waiting ...>
+
+-- Wait until we receive everything.
+SELECT gp_wait_until_triggered_fault('check_dispatch_result_end', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- The query should've used ~135 MB of memory. Allow 15 MB error.
+WITH r AS ( SELECT (memory_usage->'-1'->'used')::text::int AS mb FROM gp_toolkit.gp_resgroup_status WHERE rsgname = 'rg_oom_test' ) SELECT r.mb < 150 AS "under 150 MB", r.mb > 120 AS "above 120 MB" FROM r;
+ under 150 MB | above 120 MB 
+--------------+--------------
+ t            | t            
+(1 row)
+
+SELECT gp_inject_fault('check_dispatch_result_end', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ count   
+---------
+ 4000000 
+(1 row)
+
+DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
+DROP
+DROP ROLE role_oom_test;
+DROP
+DROP RESOURCE GROUP rg_oom_test;
+DROP

--- a/src/test/isolation2/output/resgroup/resgroup_oom_1.source
+++ b/src/test/isolation2/output/resgroup/resgroup_oom_1.source
@@ -56,7 +56,6 @@ ALTER RESOURCE GROUP rg_oom_test SET memory_shared_quota 0;
 ALTER
 1: SELECT count(*) FROM gp_mock_cdbdispatchcommand(10000000);
 ERROR:  Out of memory
-DETAIL:  Resource group memory limit reached
 
 DROP FUNCTION gp_mock_cdbdispatchcommand(amount int);
 DROP

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -2446,3 +2446,116 @@ srf_done:
 
 	SRF_RETURN_DONE(fctx);
 }
+
+typedef struct
+{
+	int cur_tuple_idx;
+	int cur_segment_idx;
+	int cur_segment_tuple_idx;
+
+	int n_segments;
+	int n_tuples;
+
+	Datum some_text;
+	struct pg_result **pg_results;
+} gp_mock_cdbdispatchcommand_status;
+
+/*
+ * This test function mocks CdbDispatchCommand() with a customizable amount of
+ * tuples.
+ */
+PG_FUNCTION_INFO_V1(gp_mock_cdbdispatchcommand);
+Datum
+gp_mock_cdbdispatchcommand(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *func_ctx;
+	gp_mock_cdbdispatchcommand_status *my_status;
+
+	int arg_tuple_amount = PG_GETARG_INT32(0);
+
+	if (arg_tuple_amount <= 0)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("gp_mock_cdbdispatchcommand() should only be "
+							   "called with it's parameter greater than 0")));
+	}
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		func_ctx = SRF_FIRSTCALL_INIT();
+
+		MemoryContext oldcontext =
+			MemoryContextSwitchTo(func_ctx->multi_call_memory_ctx);
+
+		my_status = palloc0(sizeof(gp_mock_cdbdispatchcommand_status));
+
+		/* Cache the return result. */
+		my_status->some_text = CStringGetTextDatum("sometext");
+
+		/* Send the command to segments from QD. */
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			char *query =
+				psprintf("SELECT * FROM gp_mock_cdbdispatchcommand(%d)",
+						 arg_tuple_amount);
+
+			CdbPgResults cdb_pgresults = {0};
+			CdbDispatchCommand(query, DF_WITH_SNAPSHOT, &cdb_pgresults);
+
+			pfree(query);
+
+			Assert(cdb_pgresults.numResults > 0);
+
+			for (int i = 0; i < cdb_pgresults.numResults; i++)
+			{
+				Assert(PQresultStatus(cdb_pgresults.pg_results[i]) ==
+					   PGRES_TUPLES_OK);
+				my_status->n_tuples += PQntuples(cdb_pgresults.pg_results[i]);
+			}
+
+			my_status->n_segments = cdb_pgresults.numResults;
+			my_status->pg_results = cdb_pgresults.pg_results;
+		}
+
+		func_ctx->user_fctx = my_status;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	func_ctx = SRF_PERCALL_SETUP();
+	my_status = func_ctx->user_fctx;
+
+	/* Generate fake tuples from every segment. */
+	if (my_status->cur_tuple_idx < arg_tuple_amount)
+	{
+		my_status->cur_tuple_idx++;
+		SRF_RETURN_NEXT(func_ctx, my_status->some_text);
+	}
+
+	/* Receive tuples from the loop above on master. */
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		while (my_status->cur_segment_idx < my_status->n_segments)
+		{
+			PGresult *res = my_status->pg_results[my_status->cur_segment_idx];
+
+			if (my_status->cur_segment_tuple_idx < PQntuples(res))
+			{
+				Datum ret = CStringGetTextDatum(
+					PQgetvalue(res, my_status->cur_segment_tuple_idx, 0));
+
+				my_status->cur_segment_tuple_idx++;
+				SRF_RETURN_NEXT(func_ctx, ret);
+			}
+
+			PQclear(res);
+
+			my_status->cur_segment_idx++;
+			my_status->cur_segment_tuple_idx = 0;
+		}
+
+		pfree(my_status->pg_results);
+	}
+
+	SRF_RETURN_DONE(func_ctx);
+}


### PR DESCRIPTION
When querying `pg_locks` (or using `pg_lock_status()`), approximately 75% of backend memory allocations for resulting tuples weren't registered with Vmtracker or Resource Group Control. This memory would also leak if the query was cancelled or failed.

This happened because `CdbDispatchCommand()`, which is used by `pg_locks`, internally uses libpq to obtain the results, which were allocated as `PQresult` structures with bare `malloc()`, even on the server side.

Another issue is that if a query fails under resource group manager due to a lack of memory, the query is cancelled due to an error. The coordinator would still try to receive tuples from segments upon cancellation. Retrieving tuples requires more memory allocations, which may cause the same OOM error again. The query will get cancelled due to an error, entering into a recursion and leading to an eventual crash.

The first commit fixes both the memory leak and untracked memory issues by enforcing Vmtracker routines for `PGresult` allocations on the server-side. The original code is unchanged from #1231, besides addressing errcode-related macro redefinition warnings by un-defining them first.

The second commit prevents error recursion, upon query cancellation. It implements proper query cancellation by explicitly ignoring any libpq data from segments without extra memory allocations. The said issue cannot be reproduced without first commit. The original code was updated since #1231, based on #1668.

The PR contains several patches as separate, atomic commits, and therefore should be rebased. ADCC extension tests should pass before merging the PR.

---

When approved the PR will be moved to [Greengage](https://github.com/GreengageDB/greengage) repo for merge. ABI tests for `adb-6.x-dev` are broken.