### PR TITLE
ADBDEV-7466 Port GROUP BY patches to 6X

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="41793672096">
+    <dxl:Plan Id="0" SpaceSize="1817826704">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250698.553420" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,7 +425,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1817826704">
+    <dxl:Plan Id="0" SpaceSize="1521614688">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356250698.553420" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CountAny.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CountAny.mdp
@@ -731,48 +731,87 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1293.131215" Rows="10.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="19" Alias="?column?">
+        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="1293.130856" Rows="10.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="19" Alias="?column?">
+          <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+          </dxl:OpExpr>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.131215" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.130816" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="19" Alias="?column?">
-            <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+          <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+            <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.130856" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.130736" Rows="20.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="19" Alias="?column?">
-              <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                <dxl:Coalesce TypeMdid="0.20.1.0">
-                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                </dxl:Coalesce>
-              </dxl:OpExpr>
+            <dxl:ProjElem ColId="18" Alias="count">
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.130816" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.130168" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ProjElem ColId="18" Alias="count">
                 <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.130736" Rows="20.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.130160" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
@@ -780,59 +819,46 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.129741" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.130168" Rows="2.000000" Width="8"/>
-                </dxl:Properties>
+                <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
-                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.130160" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.129740" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="count">
-                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.129741" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.129704" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -841,67 +867,38 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.129740" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="9" Alias="i">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.129704" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                              <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="9" Alias="i">
-                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Aggregate>
-                    </dxl:GatherMotion>
+                      <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
                   </dxl:Aggregate>
-                </dxl:BroadcastMotion>
-              </dxl:Materialize>
-            </dxl:NestedLoopJoin>
-          </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+                </dxl:GatherMotion>
+              </dxl:Aggregate>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:Result>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CountStar.mdp
@@ -719,45 +719,84 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1293.104056" Rows="10.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="19" Alias="?column?">
+        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="1293.103696" Rows="10.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="19" Alias="?column?">
+          <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.104056" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="19" Alias="?column?">
-            <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+          <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+            <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.103696" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="19" Alias="?column?">
-              <dxl:Coalesce TypeMdid="0.20.1.0">
-                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Coalesce>
+            <dxl:ProjElem ColId="18" Alias="count">
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ProjElem ColId="18" Alias="count">
                 <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
@@ -765,60 +804,45 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
-                </dxl:Properties>
+                <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
-                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="count">
-                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                          <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                          </dxl:ValuesList>
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
                           <dxl:ValuesList ParamType="aggdistinct"/>
@@ -826,61 +850,34 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
+                      <dxl:ProjList/>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Aggregate>
-                    </dxl:GatherMotion>
+                      <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
                   </dxl:Aggregate>
-                </dxl:BroadcastMotion>
-              </dxl:Materialize>
-            </dxl:NestedLoopJoin>
-          </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+                </dxl:GatherMotion>
+              </dxl:Aggregate>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:Result>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DqaSubqueryMax.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaSubqueryMax.mdp
@@ -643,7 +643,7 @@
     <dxl:Plan Id="0" SpaceSize="24">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="903842.531783" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="903842.622639" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="12" Alias="?column?">
@@ -654,100 +654,90 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="903842.531779" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="903842.622635" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="11" ColName="max" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2000000"/>
+            </dxl:Comparison>
           </dxl:JoinFilter>
-          <dxl:Result>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="451.658715" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
             </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="11" ColName="max" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2000000"/>
-              </dxl:Comparison>
-            </dxl:Filter>
-            <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="11" Alias="max">
+                <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
               </dxl:Properties>
-              <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="11" Alias="max">
-                  <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                <dxl:ProjElem ColId="13" Alias="ColRef_0013">
+                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="451.658682" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="451.658667" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
+                <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="13" Alias="ColRef_0013">
-                    <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="451.658667" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="446.400000" Rows="2000000.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="13" Alias="ColRef_0013">
-                      <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                        <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="2" Alias="b">
+                      <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="446.400000" Rows="2000000.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="2" Alias="b">
-                        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="tsk">
-                      <dxl:Columns>
-                        <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Aggregate>
-              </dxl:GatherMotion>
-            </dxl:Aggregate>
-          </dxl:Result>
+                  <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="tsk">
+                    <dxl:Columns>
+                      <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Aggregate>
+            </dxl:GatherMotion>
+          </dxl:Aggregate>
           <dxl:Result>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-PartAO-SemiJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-PartAO-SemiJoin.mdp
@@ -1229,18 +1229,45 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1435">
+    <dxl:Plan Id="0" SpaceSize="481">
+  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="831.364792" Rows="1.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:GroupingColumns/>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="17" Alias="count">
+        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+          <dxl:ValuesList ParamType="aggargs">
+            <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+          </dxl:ValuesList>
+          <dxl:ValuesList ParamType="aggdirectargs"/>
+          <dxl:ValuesList ParamType="aggorder"/>
+          <dxl:ValuesList ParamType="aggdistinct"/>
+        </dxl:AggFunc>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="831.364791" Rows="1.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+          <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:SortingColumnList/>
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="831.364792" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="831.364761" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="17" Alias="count">
-            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
-              <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
-              </dxl:ValuesList>
+          <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+              <dxl:ValuesList ParamType="aggargs"/>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
               <dxl:ValuesList ParamType="aggdistinct"/>
@@ -1248,45 +1275,42 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="831.364791" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="831.364761" Rows="200.000000" Width="1"/>
           </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-              <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
+          <dxl:ProjList/>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="831.364761" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.025857" Rows="600.000000" Width="4"/>
             </dxl:Properties>
-            <dxl:GroupingColumns/>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs"/>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
+              <dxl:ProjElem ColId="6" Alias="a">
+                <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
+            <dxl:SortingColumnList/>
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="831.364761" Rows="200.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.011537" Rows="200.000000" Width="4"/>
               </dxl:Properties>
-              <dxl:ProjList/>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="6"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="6" Alias="a">
+                  <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.025857" Rows="600.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.003357" Rows="200.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="6" Alias="a">
@@ -1295,38 +1319,39 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.011537" Rows="200.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.002523" Rows="200.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="6"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="6" Alias="a">
                       <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.003357" Rows="200.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.002523" Rows="200.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="16" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="6" Alias="a">
                         <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr Opfamily="0.1977.1.0">
-                        <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Result>
+                    <dxl:OneTimeFilter/>
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.002523" Rows="200.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001760" Rows="200.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="6" Alias="a">
@@ -1334,127 +1359,102 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.002523" Rows="200.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="16" Alias="?column?">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="6" Alias="a">
-                            <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.001760" Rows="200.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="6" Alias="a">
-                              <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.24708.1.0" TableName="batch">
-                            <dxl:Columns>
-                              <dxl:Column ColId="6" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="7" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="7"/>
-                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Result>
-                    </dxl:Result>
-                  </dxl:RedistributeMotion>
-                </dxl:Aggregate>
-              </dxl:BroadcastMotion>
-              <dxl:Sequence>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="400.333301" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:TableDescriptor Mdid="6.24708.1.0" TableName="batch">
+                        <dxl:Columns>
+                          <dxl:Column ColId="6" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="7" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="7"/>
+                          <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Result>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
+            </dxl:Aggregate>
+          </dxl:BroadcastMotion>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="400.333301" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="6.24673.1.0" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:Not>
+                  <dxl:IsNull>
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:PartitionSelector RelationMdid="6.24673.1.0" PartitionLevels="1" ScanId="1">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:PartEqFilters>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PartEqFilters>
-                  <dxl:PartFilters>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PartFilters>
-                  <dxl:ResidualFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:ResidualFilter>
-                  <dxl:PropagationExpression>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:PropagationExpression>
-                  <dxl:PrintableFilter>
-                    <dxl:Not>
-                      <dxl:IsNull>
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:IsNull>
-                    </dxl:Not>
-                  </dxl:PrintableFilter>
-                </dxl:PartitionSelector>
-                <dxl:DynamicBitmapTableScan PartIndexId="1">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="400.333301" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:RecheckCond>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:RecheckCond>
-                  <dxl:BitmapIndexProbe>
-                    <dxl:IndexCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:IndexCondList>
-                    <dxl:IndexDescriptor Mdid="0.24718.1.0" IndexName="test_partitioned_1_prt_p_neg_a_idx"/>
-                  </dxl:BitmapIndexProbe>
-                  <dxl:TableDescriptor Mdid="6.24673.1.0" TableName="test_partitioned">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="7"/>
-                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="4" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:DynamicBitmapTableScan>
-              </dxl:Sequence>
-              <dxl:NLJIndexParamList>
-                <dxl:NLJIndexParam ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:NLJIndexParamList>
-            </dxl:NestedLoopJoin>
-          </dxl:Aggregate>
-        </dxl:GatherMotion>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicBitmapTableScan PartIndexId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="400.333301" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:RecheckCond>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:RecheckCond>
+              <dxl:BitmapIndexProbe>
+                <dxl:IndexCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:IndexCondList>
+                <dxl:IndexDescriptor Mdid="0.24718.1.0" IndexName="test_partitioned_1_prt_p_neg_a_idx"/>
+              </dxl:BitmapIndexProbe>
+              <dxl:TableDescriptor Mdid="6.24673.1.0" TableName="test_partitioned">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="7"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicBitmapTableScan>
+          </dxl:Sequence>
+          <dxl:NLJIndexParamList>
+            <dxl:NLJIndexParam ColId="6" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:NLJIndexParamList>
+        </dxl:NestedLoopJoin>
       </dxl:Aggregate>
-    </dxl:Plan>
+    </dxl:GatherMotion>
+  </dxl:Aggregate>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1298,7 +1298,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6945516">
+    <dxl:Plan Id="0" SpaceSize="456186">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1357145192.514491" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6379,7 +6379,7 @@ ORDER BY s_name;
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1863552">
+    <dxl:Plan Id="0" SpaceSize="1360704">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="24583535.993774" Rows="49.989277" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesFromExistsSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesFromExistsSubquery.mdp
@@ -6,16 +6,17 @@
     create table r (r1 int, r2 int) distributed by (r2);
     create table s (s1 int, s2 int) distributed by (s2);
     explain select * from r where r2 > 8 and exists (select 1 from s where r2=s2 and r1=s1 and s1>99);
-                                      QUERY PLAN
-    ------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-       ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=8)
-             Hash Cond: ((r.r2 = s.s2) AND (r.r1 = s.s1))
-             ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=8)
-                   Filter: ((r1 > 99) AND (r2 > 8))
-             ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                   ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=8)
-                         Filter: ((s1 > 99) AND (s2 > 8))
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: ((r.r2 = s.s2) AND (r.r1 = s.s1))
+         ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=8)
+               Filter: ((r1 > 99) AND (r2 > 8))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=8)
+                           Filter: ((s1 > 99) AND (s2 > 8))
     		]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
@@ -349,7 +350,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="192">
+    <dxl:Plan Id="0" SpaceSize="112">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000984" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesFromMultiSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesFromMultiSubquery.mdp
@@ -10,29 +10,33 @@
     and r2 in (select s2 from s where r4=s4 and s4 > 10 and s4 < 100)
     and exists (select 1 from s where r5=s5 and r3=s3 and s3=20)
     and not exists(select 1 from s where r5=s5 and r2=s2 and s2=18);
-                                                      QUERY PLAN
-    ---------------------------------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=20)
-       ->  Hash Semi Join  (cost=0.00..1724.00 rows=1 width=20)
-             Hash Cond: ((r.r5 = s_2.s5) AND (r.r3 = s_2.s3))
-             ->  Hash Anti Join  (cost=0.00..1293.00 rows=1 width=20)
-                   Hash Cond: ((r.r5 = s_1.s5) AND (r.r2 = s_1.s2))
-                   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=20)
-                         Hash Cond: ((r.r4 = s.s4) AND (r.r2 = s.s2))
-                         ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=20)
-                               Filter: ((r3 = 20) AND (r4 > 10) AND (r4 < 100) AND (r1 > 0))
-                         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                     ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=8)
-                                           Filter: ((s4 > 10) AND (s4 < 100))
-                   ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                               ->  Seq Scan on s s_1  (cost=0.00..431.00 rows=1 width=8)
-                                     Filter: (s2 = 18)
-             ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                         ->  Seq Scan on s s_2  (cost=0.00..431.00 rows=1 width=8)
-                               Filter: (s3 = 20)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1724.00 rows=1 width=20)
+   ->  Hash Semi Join  (cost=0.00..1724.00 rows=1 width=20)
+         Hash Cond: ((r.r4 = s_2.s4) AND (r.r2 = s_2.s2))
+         ->  Hash Semi Join  (cost=0.00..1293.00 rows=1 width=20)
+               Hash Cond: ((r.r5 = s_1.s5) AND (r.r3 = s_1.s3))
+               ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=20)
+                     Hash Cond: ((r.r5 = s.s5) AND (r.r2 = s.s2))
+                     ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=20)
+                           Filter: ((r3 = 20) AND (r4 > 10) AND (r4 < 100) AND (r1 > 0))
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=8)
+                                                   Filter: (s2 = 18)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Seq Scan on s s_1  (cost=0.00..431.00 rows=1 width=8)
+                                             Filter: (s3 = 20)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on s s_2  (cost=0.00..431.00 rows=1 width=8)
+                           Filter: ((s4 > 10) AND (s4 < 100))
             ]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
@@ -515,10 +519,66 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="156422908">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="79157552">
+  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1724.002298" Rows="1.000000" Width="20"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="0" Alias="r1">
+        <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="1" Alias="r2">
+        <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="2" Alias="r3">
+        <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="3" Alias="r4">
+        <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="4" Alias="r5">
+        <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:HashJoin JoinType="In">
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="1724.002223" Rows="1.000000" Width="20"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="0" Alias="r1">
+          <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="1" Alias="r2">
+          <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="2" Alias="r3">
+          <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="3" Alias="r4">
+          <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="4" Alias="r5">
+          <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:JoinFilter/>
+      <dxl:HashCondList>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="13" ColName="s2" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:HashCondList>
+      <dxl:HashJoin JoinType="In">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.002298" Rows="1.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001530" Rows="1.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="r1">
@@ -538,10 +598,20 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:HashJoin JoinType="In">
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="28" ColName="s5" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:HashJoin JoinType="LeftAntiSemiJoin">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.002223" Rows="1.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000834" Rows="1.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="r1">
@@ -565,16 +635,16 @@
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
               <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="28" ColName="s5" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="41" ColName="s5" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
-              <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.001528" Rows="1.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="r1">
@@ -593,167 +663,60 @@
                 <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="41" ColName="s5" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:HashJoin JoinType="In">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000832" Rows="1.000000" Width="20"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="r1">
-                  <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="r2">
-                  <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="r3">
+            <dxl:Filter>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="3" Alias="r4">
-                  <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="4" Alias="r5">
-                  <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="20"/>
                 </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="13" ColName="s2" TypeMdid="0.23.1.0"/>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                  <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
                 </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000000" Width="20"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="r1">
-                    <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="r2">
-                    <dxl:Ident ColId="1" ColName="r2" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="r3">
-                    <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="r4">
-                    <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="4" Alias="r5">
-                    <dxl:Ident ColId="4" ColName="r5" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:And>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="2" ColName="r3" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="20"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                      <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                      <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
-                    </dxl:Comparison>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                      <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                    </dxl:Comparison>
-                  </dxl:And>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r" LockMode="1">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="r1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="r2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="r3" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="3" Attno="4" ColName="r4" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="4" Attno="5" ColName="r5" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000168" Rows="3.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="13" Alias="s2">
-                    <dxl:Ident ColId="13" ColName="s2" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="15" Alias="s4">
-                    <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="13" Alias="s2">
-                      <dxl:Ident ColId="13" ColName="s2" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="15" Alias="s4">
-                      <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                        <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                        <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
-                      </dxl:Comparison>
-                    </dxl:And>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="s" LockMode="1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="12" Attno="1" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="13" Attno="2" ColName="s2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="15" Attno="4" ColName="s4" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
-            </dxl:HashJoin>
-            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                  <dxl:Ident ColId="3" ColName="r4" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                  <dxl:Ident ColId="0" ColName="r1" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="6.16421.1.0" TableName="r">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="r1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="r2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="3" ColName="r3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="4" ColName="r4" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="5" ColName="r5" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="38" Alias="s2">
+                <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="41" Alias="s5">
+                <dxl:Ident ColId="41" ColName="s5" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="38" Alias="s2">
@@ -764,12 +727,15 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
+              <dxl:OneTimeFilter/>
               <dxl:Result>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="49" Alias="?column?">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="38" Alias="s2">
                     <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
@@ -779,14 +745,11 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
-                <dxl:Result>
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="49" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="38" Alias="s2">
                       <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
@@ -794,48 +757,48 @@
                       <dxl:Ident ColId="41" ColName="s5" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="38" Alias="s2">
-                        <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="s5">
-                        <dxl:Ident ColId="41" ColName="s5" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="18"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="s" LockMode="1">
-                      <dxl:Columns>
-                        <dxl:Column ColId="37" Attno="1" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="38" Attno="2" ColName="s2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="41" Attno="5" ColName="s5" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="42" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="43" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="44" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="45" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="46" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="47" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="48" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Result>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="38" ColName="s2" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="18"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="s">
+                    <dxl:Columns>
+                      <dxl:Column ColId="37" Attno="1" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="38" Attno="2" ColName="s2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="41" Attno="5" ColName="s5" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="42" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="43" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="44" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="45" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="46" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="47" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="48" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
               </dxl:Result>
-            </dxl:BroadcastMotion>
-          </dxl:HashJoin>
-          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            </dxl:Result>
+          </dxl:BroadcastMotion>
+        </dxl:HashJoin>
+        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="26" Alias="s3">
+              <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="28" Alias="s5">
+              <dxl:Ident ColId="28" ColName="s5" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000171" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="26" Alias="s3">
@@ -846,12 +809,15 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
+            <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="36" Alias="?column?">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="26" Alias="s3">
                   <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
@@ -861,14 +827,11 @@
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:Result>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="36" Alias="?column?">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="26" Alias="s3">
                     <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
@@ -876,46 +839,87 @@
                     <dxl:Ident ColId="28" ColName="s5" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="26" Alias="s3">
-                      <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="s5">
-                      <dxl:Ident ColId="28" ColName="s5" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="20"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="s" LockMode="1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="24" Attno="1" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="26" Attno="3" ColName="s3" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="28" Attno="5" ColName="s5" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="30" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="31" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="32" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="33" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="34" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="35" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="26" ColName="s3" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="20"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="s">
+                  <dxl:Columns>
+                    <dxl:Column ColId="24" Attno="1" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="26" Attno="3" ColName="s3" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="28" Attno="5" ColName="s5" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="30" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="31" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="32" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="33" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="34" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="35" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
             </dxl:Result>
-          </dxl:BroadcastMotion>
-        </dxl:HashJoin>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+          </dxl:Result>
+        </dxl:BroadcastMotion>
+      </dxl:HashJoin>
+      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000168" Rows="3.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="13" Alias="s2">
+            <dxl:Ident ColId="13" ColName="s2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="15" Alias="s4">
+            <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="13" Alias="s2">
+              <dxl:Ident ColId="13" ColName="s2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="15" Alias="s4">
+              <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:And>
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                <dxl:Ident ColId="15" ColName="s4" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
+              </dxl:Comparison>
+            </dxl:And>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.16424.1.0" TableName="s">
+            <dxl:Columns>
+              <dxl:Column ColId="12" Attno="1" ColName="s1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="2" ColName="s2" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="4" ColName="s4" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:BroadcastMotion>
+    </dxl:HashJoin>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesIntFromExistsSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesIntFromExistsSubquery.mdp
@@ -7,17 +7,19 @@
     create table r(r1 int, r2 int, r3 text, r4 varchar(20), r5 char(10));
     create table s(s1 int, s2 int, s3 text, s4 varchar(20), s5 char(10));
     explain select * from r where exists (select 1 from s where r2=s2 and s2=9);
-                                                QUERY PLAN
-    ---------------------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=46)
-       ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=46)
-             Hash Cond: (r.r2 = s.s2)
-             ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=46)
-                   Filter: (r2 = 9)
-             ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                         ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=4)
-                               Filter: (s2 = 9)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=46)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=46)
+         Hash Cond: (r.r2 = s.s2)
+         ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=46)
+               Filter: (r2 = 9)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: (s2 = 9)
     		]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
@@ -406,7 +408,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="792">
+    <dxl:Plan Id="0" SpaceSize="472">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000637" Rows="1.000000" Width="46"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesJoinSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesJoinSubquery.mdp
@@ -10,28 +10,30 @@
     explain select * from r join s on r2 = s2 and r3=s3 where
         exists (select 1 from foo where r2=b and r3=c and b > 10)
         and r4 in (1,2,3,4,5);
-                                                     QUERY PLAN
-    -------------------------------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=40)
-       ->  Hash Semi Join  (cost=0.00..1293.00 rows=1 width=40)
-             Hash Cond: ((r.r2 = foo.b) AND (r.r3 = foo.c))
-             ->  Hash Join  (cost=0.00..862.00 rows=1 width=40)
-                   Hash Cond: ((r.r2 = s.s2) AND (r.r3 = s.s3))
-                   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=20)
-                         Hash Key: r.r2
-                         ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=20)
-                               Filter: ((r2 > 10) AND (r4 = ANY ('{1,2,3,4,5}'::integer[])))
-                   ->  Hash  (cost=431.00..431.00 rows=1 width=20)
-                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=20)
-                               Hash Key: s.s2
-                               ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=20)
-                                     Filter: (s2 > 10)
-             ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                         Hash Key: foo.b
-                         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-                               Filter: (b > 10)
-    		]]>
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1293.00 rows=1 width=40)
+   ->  Hash Semi Join  (cost=0.00..1293.00 rows=1 width=40)
+         Hash Cond: ((r.r2 = foo.b) AND (r.r3 = foo.c))
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=40)
+               Hash Cond: ((r.r2 = s.s2) AND (r.r3 = s.s3))
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=20)
+                     Hash Key: r.r2
+                     ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=20)
+                           Filter: ((r2 > 10) AND (r4 = ANY ('{1,2,3,4,5}'::integer[])))
+               ->  Hash  (cost=431.00..431.00 rows=1 width=20)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=20)
+                           Hash Key: s.s2
+                           ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=20)
+                                 Filter: (s2 > 10)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     Hash Key: foo.b
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                                       Filter: (b > 10)
+    ]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
@@ -481,7 +483,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="118488">
+    <dxl:Plan Id="0" SpaceSize="72616">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001941" Rows="1.000000" Width="40"/>

--- a/src/backend/gporca/data/dxl/minidump/InferPredicatesMultiColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InferPredicatesMultiColumns.mdp
@@ -8,17 +8,19 @@
     create table s(s1 int, s2 int, s3 int, s4 int, s5 int);
     explain select * from r where r1 > 0 and exists (
         select 1 from s where r5=s5 and r3=s3 and s3=20 and r4=s4 and s4 between 10 and 100);
-                                                 QUERY PLAN
-    ----------------------------------------------------------------------------------------------------
-     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=20)
-       ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=20)
-             Hash Cond: ((r.r5 = s.s5) AND (r.r3 = s.s3) AND (r.r4 = s.s4))
-             ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=20)
-                   Filter: ((r3 = 20) AND (r4 >= 10) AND (r4 <= 100) AND (r1 > 0))
-             ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                         ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=12)
-                               Filter: ((s3 = 20) AND (s4 >= 10) AND (s4 <= 100))
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=20)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=20)
+         Hash Cond: ((r.r5 = s.s5) AND (r.r3 = s.s3) AND (r.r4 = s.s4))
+         ->  Seq Scan on r  (cost=0.00..431.00 rows=1 width=20)
+               Filter: ((r3 = 20) AND (r4 >= 10) AND (r4 <= 100) AND (r1 > 0))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Seq Scan on s  (cost=0.00..431.00 rows=1 width=12)
+                                       Filter: ((s3 = 20) AND (s4 >= 10) AND (s4 <= 100))
     		]]>
     </dxl:Comment>
   <dxl:Thread Id="0">
@@ -421,7 +423,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3363">
+    <dxl:Plan Id="0" SpaceSize="1539">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001244" Rows="1.000000" Width="20"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJNullRejectingZeroPlacePredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJNullRejectingZeroPlacePredicates.mdp
@@ -23,8 +23,8 @@
           ->  Nested Loop Left Join
                 Join Filter: true
                 ->  Result
-                ->  Aggregate
-                      ->  Materialize
+                ->  Materialize
+                    ->  Aggregate
                             ->  Gather Motion 3:1  (slice1; segments: 3)
                                   ->  Hash Join
                                         Hash Cond: (join_null_rej1.i = join_null_rej2.i)
@@ -415,161 +415,158 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="180">
-      <dxl:Result>
+  <dxl:Result>
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1324032.591012" Rows="1.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="19" Alias="cnt">
+        <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:OneTimeFilter/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="1324032.591004" Rows="2.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+          <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.591012" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.590988" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="19" Alias="cnt">
-            <dxl:Coalesce TypeMdid="0.20.1.0">
-              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-            </dxl:Coalesce>
+          <dxl:ProjElem ColId="18" Alias="cnt">
+            <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
+        <dxl:JoinFilter>
+          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+        </dxl:JoinFilter>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.591004" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-              <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="0" Alias="">
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        </dxl:Result>
+        <dxl:Materialize Eager="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000485" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="18" Alias="cnt">
+              <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.590988" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.000000" Width="8"/>
             </dxl:Properties>
+            <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="18" Alias="cnt">
-                <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
+                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs"/>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:JoinFilter>
-            <dxl:Result>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.200000" Width="1"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
+              <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-            </dxl:Result>
-            <dxl:Materialize Eager="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000485" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="18" Alias="cnt">
-                  <dxl:Ident ColId="18" ColName="cnt" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:SortingColumnList/>
+              <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000473" Rows="1.200000" Width="1"/>
                 </dxl:Properties>
-                <dxl:GroupingColumns/>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="18" Alias="cnt">
-                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                      <dxl:ValuesList ParamType="aggargs"/>
-                      <dxl:ValuesList ParamType="aggdirectargs"/>
-                      <dxl:ValuesList ParamType="aggorder"/>
-                      <dxl:ValuesList ParamType="aggdistinct"/>
-                    </dxl:AggFunc>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
+                <dxl:ProjList/>
                 <dxl:Filter/>
-                <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="862.000477" Rows="1.200000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
-                  <dxl:ProjList/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="i">
+                      <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashJoin JoinType="Inner">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000473" Rows="1.200000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="i">
-                          <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.72818.1.0" TableName="join_null_rej1">
-                        <dxl:Columns>
-                          <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.200000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="9" Alias="i">
-                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2535.1.0">
-                          <dxl:Ident ColId="10" ColName="t" TypeMdid="0.1114.1.0"/>
-                          <dxl:FuncExpr FuncId="0.1299.1.0" FuncRetSet="false" TypeMdid="0.1184.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:TableDescriptor Mdid="6.72821.1.0" TableName="join_null_rej2">
-                        <dxl:Columns>
-                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="10" Attno="2" ColName="t" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:HashJoin>
-                </dxl:GatherMotion>
-              </dxl:Aggregate>
-            </dxl:Materialize>
-          </dxl:NestedLoopJoin>
-        </dxl:Result>
-      </dxl:Result>
-    </dxl:Plan>
+                  <dxl:TableDescriptor Mdid="6.72818.1.0" TableName="join_null_rej1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.200000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2535.1.0">
+                      <dxl:Ident ColId="10" ColName="t" TypeMdid="0.1114.1.0"/>
+                      <dxl:FuncExpr FuncId="0.1299.1.0" FuncRetSet="false" TypeMdid="0.1184.1.0" FuncVariadic="false"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="6.72821.1.0" TableName="join_null_rej2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="t" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:HashJoin>
+            </dxl:GatherMotion>
+          </dxl:Aggregate>
+        </dxl:Materialize>
+      </dxl:NestedLoopJoin>
+    </dxl:Result>
+  </dxl:Result>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -588,7 +588,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="13648900">
+    <dxl:Plan Id="0" SpaceSize="11680900">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.003419" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/NotExists-SuperflousOuterRefWithGbAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NotExists-SuperflousOuterRefWithGbAgg.mdp
@@ -374,7 +374,7 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="32">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.001220" Rows="2.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/NullIf-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NullIf-With-Subquery.mdp
@@ -427,150 +427,65 @@ FROM x
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="55">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.004152" Rows="10.000000" Width="8"/>
-        </dxl:Properties>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="19" Alias="nullif">
-            <dxl:Ident ColId="19" ColName="nullif" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="20" Alias="?column?">
-            <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.003793" Rows="10.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="19" Alias="nullif">
-              <dxl:NullIf OperatorMdid="0.15.1.0" TypeMdid="0.23.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Coalesce TypeMdid="0.20.1.0">
-                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                </dxl:Coalesce>
-              </dxl:NullIf>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="?column?">
-              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:OpExpr>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.003753" Rows="10.000000" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="0" Alias="i">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="j">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Left">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.003673" Rows="10.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="i">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="count">
-                  <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
+    <dxl:Plan Id="0" SpaceSize="11">
+  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="5172.213816" Rows="1000.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="19" Alias="nullif">
+        <dxl:Ident ColId="19" ColName="nullif" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="20" Alias="?column?">
+        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="5172.177896" Rows="1000.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="19" Alias="nullif">
+          <dxl:NullIf OperatorMdid="0.15.1.0" TypeMdid="0.23.1.0">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+              <dxl:TestExpr/>
+              <dxl:ParamList>
+                <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ParamList>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.007809" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="i">
-                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="j">
-                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.32779.1.1" TableName="x">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000459" Rows="10.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="9"/>
-                </dxl:GroupingColumns>
+                <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
-                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                       <dxl:ValuesList ParamType="aggargs"/>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
                       <dxl:ValuesList ParamType="aggdistinct"/>
                     </dxl:AggFunc>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="i">
-                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000405" Rows="10.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.007809" Rows="2.000000" Width="1"/>
                   </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="9" Alias="i">
+                  <dxl:ProjList/>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList>
-                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  </dxl:SortingColumnList>
-                  <dxl:LimitCount/>
-                  <dxl:LimitOffset/>
-                  <dxl:TableScan>
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001229" Rows="20.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="i">
@@ -578,25 +493,85 @@ FROM x
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.32802.1.1" TableName="y">
-                      <dxl:Columns>
-                        <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:Sort>
+                    <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001189" Rows="20.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="i">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="i">
+                            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="6.32802.1.1" TableName="y">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
               </dxl:Aggregate>
-            </dxl:HashJoin>
-          </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+            </dxl:SubPlan>
+          </dxl:NullIf>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="20" Alias="?column?">
+          <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:OpExpr>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:TableScan>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="5172.173896" Rows="1000.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="j">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:TableDescriptor Mdid="6.32779.1.1" TableName="x">
+          <dxl:Columns>
+            <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:TableScan>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -533,7 +533,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="731">
+    <dxl:Plan Id="0" SpaceSize="333">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022556" Rows="99.900000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQExists.mdp
@@ -309,7 +309,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="57">
+    <dxl:Plan Id="0" SpaceSize="35">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000680" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SQNotExists.mdp
@@ -303,7 +303,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="33">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000680" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/ProjectCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectCountStar.mdp
@@ -739,59 +739,98 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="24">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1293.104136" Rows="10.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="20" Alias="?column?">
+        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="1293.103776" Rows="10.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="20" Alias="?column?">
+          <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.104136" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.103736" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="20" Alias="?column?">
-            <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.20.1.0"/>
+          <dxl:ProjElem ColId="19" Alias="?column?">
+            <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+            </dxl:OpExpr>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
+        <dxl:OneTimeFilter/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.103776" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="20" Alias="?column?">
-              <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Result>
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.103736" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="19" Alias="?column?">
-                <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  <dxl:Coalesce TypeMdid="0.20.1.0">
-                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                  </dxl:Coalesce>
-                </dxl:OpExpr>
+              <dxl:ProjElem ColId="18" Alias="count">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:Materialize Eager="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                <dxl:ProjElem ColId="18" Alias="count">
                   <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
@@ -799,60 +838,45 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:TableScan>
+                <dxl:SortingColumnList/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:Materialize Eager="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
-                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="count">
-                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                        <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                            <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
-                            </dxl:ValuesList>
+                        <dxl:ProjElem ColId="22" Alias="ColRef_0022">
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                            <dxl:ValuesList ParamType="aggargs"/>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>
                             <dxl:ValuesList ParamType="aggdistinct"/>
@@ -860,62 +884,35 @@ SELECT (SELECT 1 + count(*) FROM x) FROM y;
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                      <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
                         </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                            <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
+                        <dxl:ProjList/>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns/>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                                <dxl:ValuesList ParamType="aggargs"/>
-                                <dxl:ValuesList ParamType="aggdirectargs"/>
-                                <dxl:ValuesList ParamType="aggorder"/>
-                                <dxl:ValuesList ParamType="aggdistinct"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
-                              <dxl:Columns>
-                                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:Aggregate>
-                      </dxl:GatherMotion>
+                        <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
                     </dxl:Aggregate>
-                  </dxl:BroadcastMotion>
-                </dxl:Materialize>
-              </dxl:NestedLoopJoin>
-            </dxl:Result>
-          </dxl:Result>
+                  </dxl:GatherMotion>
+                </dxl:Aggregate>
+              </dxl:BroadcastMotion>
+            </dxl:Materialize>
+          </dxl:NestedLoopJoin>
         </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+      </dxl:Result>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ProjectOutsideCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ProjectOutsideCountStar.mdp
@@ -729,48 +729,87 @@
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1293.104056" Rows="10.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="19" Alias="?column?">
+        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="1293.103696" Rows="10.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="19" Alias="?column?">
+          <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+          </dxl:OpExpr>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.104056" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="19" Alias="?column?">
-            <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+          <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+            <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:OneTimeFilter/>
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.103696" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="19" Alias="?column?">
-              <dxl:OpExpr OperatorName="+" OperatorMdid="0.692.1.0" OperatorType="0.20.1.0">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                <dxl:Coalesce TypeMdid="0.20.1.0">
-                  <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                </dxl:Coalesce>
-              </dxl:OpExpr>
+            <dxl:ProjElem ColId="18" Alias="count">
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.103656" Rows="20.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ProjElem ColId="18" Alias="count">
                 <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.103576" Rows="20.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
@@ -778,60 +817,45 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:TableScan>
+              <dxl:SortingColumnList/>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="10.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.3373378.1.1" TableName="y">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.103009" Rows="2.000000" Width="8"/>
-                </dxl:Properties>
+                <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
-                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.103001" Rows="2.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="count">
-                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                      <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.102582" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="18" Alias="count">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                          <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                          </dxl:ValuesList>
+                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
                           <dxl:ValuesList ParamType="aggdistinct"/>
@@ -839,61 +863,34 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.102581" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
+                      <dxl:ProjList/>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.102545" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.094165" Rows="9011.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Aggregate>
-                    </dxl:GatherMotion>
+                      <dxl:TableDescriptor Mdid="6.3373352.1.1" TableName="x">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
                   </dxl:Aggregate>
-                </dxl:BroadcastMotion>
-              </dxl:Materialize>
-            </dxl:NestedLoopJoin>
-          </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+                </dxl:GatherMotion>
+              </dxl:Aggregate>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:Result>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp
@@ -306,122 +306,60 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
       </dxl:LogicalGet>
     </dxl:LogicalProject>
   </dxl:Query>
-  <dxl:Plan Id="0" SpaceSize="20">
-    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+  <dxl:Plan Id="0" SpaceSize="7">
+  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="5172.058598" Rows="1.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="19" Alias="?column?">
+        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
       <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="862.000673" Rows="1.000000" Width="8"/>
+        <dxl:Cost StartupCost="0" TotalCost="5172.058568" Rows="1.000000" Width="8"/>
       </dxl:Properties>
       <dxl:ProjList>
         <dxl:ProjElem ColId="19" Alias="?column?">
-          <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
-        </dxl:ProjElem>
-      </dxl:ProjList>
-      <dxl:Filter/>
-      <dxl:SortingColumnList/>
-      <dxl:Result>
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000643" Rows="1.000000" Width="8"/>
-        </dxl:Properties>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="19" Alias="?column?">
-            <dxl:Coalesce TypeMdid="0.20.1.0">
-              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
-              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-            </dxl:Coalesce>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:OneTimeFilter/>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="2.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:HashJoin JoinType="Left">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000635" Rows="2.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="18" Alias="count">
-                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
+          <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+            <dxl:TestExpr/>
+            <dxl:ParamList>
+              <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ParamList>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="8"/>
               </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16396.1.1" TableName="foo">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="9"/>
-              </dxl:GroupingColumns>
+              <dxl:GroupingColumns/>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs"/>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
                     <dxl:ValuesList ParamType="aggdistinct"/>
                   </dxl:AggFunc>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="c">
-                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="1"/>
                 </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="c">
+                <dxl:ProjList/>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:TableScan>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
+                <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000247" Rows="3.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="c">
@@ -429,24 +367,73 @@ EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Sort>
+                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000243" Rows="3.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="c">
+                        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="c">
+                          <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:BroadcastMotion>
+                </dxl:Materialize>
+              </dxl:Result>
             </dxl:Aggregate>
-          </dxl:HashJoin>
-        </dxl:Result>
-      </dxl:Result>
-    </dxl:GatherMotion>
-  </dxl:Plan>
+          </dxl:SubPlan>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:TableScan>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="5172.058566" Rows="1000.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:TableDescriptor Mdid="6.16396.1.1" TableName="foo">
+          <dxl:Columns>
+            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:TableScan>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -399,46 +399,32 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="464">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.000816" Rows="1.000000" Width="8"/>
-        </dxl:Properties>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="29" Alias="?column?">
-            <dxl:Ident ColId="29" ColName="?column?" TypeMdid="0.20.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.000786" Rows="1.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="29" Alias="?column?">
-              <dxl:Coalesce TypeMdid="0.20.1.0">
-                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Coalesce>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.000784" Rows="2.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Left">
+    <dxl:Plan Id="0" SpaceSize="88">
+  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="30170.080479" Rows="1.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="29" Alias="?column?">
+        <dxl:Ident ColId="29" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="30170.080449" Rows="1.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="29" Alias="?column?">
+          <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+            <dxl:TestExpr/>
+            <dxl:ParamList>
+              <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ParamList>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.000778" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="5172.001761" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="28" Alias="count">
@@ -446,76 +432,40 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="8"/>
                 </dxl:Properties>
+                <dxl:GroupingColumns/>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.16396.1.1" TableName="foo">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000183" Rows="1.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="e">
-                    <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="28" Alias="count">
-                    <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
+                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs"/>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="1"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="19"/>
-                  </dxl:GroupingColumns>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="28" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
-                        <dxl:ValuesList ParamType="aggargs"/>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="19" Alias="e">
+                  <dxl:ProjList/>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000247" Rows="3.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="19" Alias="e">
@@ -523,14 +473,9 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:TableScan>
+                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000243" Rows="3.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="19" Alias="e">
@@ -538,77 +483,105 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.16450.1.1" TableName="jazz">
-                        <dxl:Columns>
-                          <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:Sort>
-                </dxl:Aggregate>
-                <dxl:Materialize Eager="false">
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="e">
+                            <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="6.16450.1.1" TableName="jazz">
+                          <dxl:Columns>
+                            <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
+              </dxl:Aggregate>
+              <dxl:Materialize Eager="true">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>
-                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                  <dxl:SortingColumnList/>
+                  <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:Limit>
+                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:Result>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
-                          <dxl:ProjList/>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="9"/>
+                          </dxl:GroupingColumns>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="18" Alias="count">
+                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                                <dxl:ValuesList ParamType="aggargs"/>
+                                <dxl:ValuesList ParamType="aggdirectargs"/>
+                                <dxl:ValuesList ParamType="aggorder"/>
+                                <dxl:ValuesList ParamType="aggdistinct"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="9" Alias="c">
+                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                          <dxl:Sort SortDiscardDuplicates="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
                             </dxl:Properties>
-                            <dxl:GroupingColumns>
-                              <dxl:GroupingColumn ColId="9"/>
-                            </dxl:GroupingColumns>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="18" Alias="count">
-                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
-                                  <dxl:ValuesList ParamType="aggargs"/>
-                                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                                  <dxl:ValuesList ParamType="aggorder"/>
-                                  <dxl:ValuesList ParamType="aggdistinct"/>
-                                </dxl:AggFunc>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="9" Alias="c">
                                 <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:TableScan>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="9" Alias="c">
@@ -616,52 +589,63 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList>
-                                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              </dxl:SortingColumnList>
-                              <dxl:LimitCount/>
-                              <dxl:LimitOffset/>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="9" Alias="c">
-                                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Sort>
-                          </dxl:Aggregate>
-                        </dxl:Result>
-                      </dxl:GatherMotion>
-                      <dxl:LimitCount>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                      </dxl:LimitCount>
-                      <dxl:LimitOffset>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                      </dxl:LimitOffset>
-                    </dxl:Limit>
-                  </dxl:BroadcastMotion>
-                </dxl:Materialize>
-              </dxl:NestedLoopJoin>
-            </dxl:HashJoin>
-          </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+                              <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Sort>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:GatherMotion>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:SubPlan>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:TableScan>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="30170.080446" Rows="1000.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:TableDescriptor Mdid="6.16396.1.1" TableName="foo">
+          <dxl:Columns>
+            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:TableScan>
+    </dxl:Result>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SelectHavingCount.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectHavingCount.mdp
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  create table t (i int) distributed by (i);
+  explain select count(*) from t group by () having count(*) > 2;
+                                            QUERY PLAN                                        
+  ------------------------------------------------------------------------------------------
+   Result  (cost=0.00..431.00 rows=1 width=8)
+     Filter: ((count()) > 2)
+     ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                 ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=1)
+   Optimizer: GPORCA
+  (6 rows)
+
+  Objective: HAVING clause should not be pushed through the aggregate, and so 
+    this should return no rows if count(*) is less than 2.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103045,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.419.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.477.1.0"/>
+        <dxl:Commutator Mdid="0.37.1.0"/>
+        <dxl:InverseOp Mdid="0.420.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.110550.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.110550.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.110550.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+          <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:Comparison>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns/>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="count">
+              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs"/>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="count">
+              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs"/>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.110550.1.0" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000043" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="8" Alias="count">
+            <dxl:Ident ColId="8" ColName="count" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.419.1.0">
+            <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+          </dxl:Comparison>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns/>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="8" Alias="count">
+              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs"/>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="count">
+              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs"/>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.110550.1.0" TableName="t">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:Aggregate>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SelectHavingCountIsNull.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectHavingCountIsNull.mdp
@@ -1,0 +1,498 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  create table foo (a int, b int);
+  create table bar (c int, d int);
+  insert into foo values (1, 1);
+  explain select (select count(*) from bar where c = a having count(*) is null) from foo;
+                                                        QUERY PLAN                                                       
+  -----------------------------------------------------------------------------------------------------------------------
+  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324047.03 rows=1 width=8)
+    ->  Seq Scan on foo  (cost=0.00..1324047.03 rows=334 width=8)
+          SubPlan 1
+            ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                  Filter: ((count()) IS NULL)
+                  ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                        ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                              Filter: (bar.c = foo.a)
+                              ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                          ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+  Optimizer: GPORCA
+  (12 rows)
+
+  Objective: HAVING clause should be handled correctly even when it itself contains count(*).
+    Specifically, this should return NULL, not 0.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103045,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.110529.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.110553.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.110553.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.110553.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.110529.1.0" Name="foo" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.110529.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="23" ColName="count" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="23" Alias="count">
+            <dxl:ScalarSubquery ColId="21">
+              <dxl:LogicalSelect>
+                <dxl:IsNull>
+                  <dxl:Ident ColId="22" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:IsNull>
+                <dxl:LogicalGroupBy>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="21" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs"/>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="22" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs"/>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:LogicalSelect>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="6.110553.1.0" TableName="bar">
+                        <dxl:Columns>
+                          <dxl:Column ColId="12" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="13" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                  </dxl:LogicalSelect>
+                </dxl:LogicalGroupBy>
+              </dxl:LogicalSelect>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.110529.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324047.031072" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="22" Alias="count">
+            <dxl:Ident ColId="22" ColName="count" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324047.031042" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="22" Alias="count">
+              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000346" Rows="3.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="20" Alias="count">
+                      <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:IsNull>
+                      <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:IsNull>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000247" Rows="3.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="c">
+                            <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000243" Rows="3.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="11" Alias="c">
+                              <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="11" Alias="c">
+                                <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.110553.1.0" TableName="bar">
+                              <dxl:Columns>
+                                <dxl:Column ColId="11" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324047.031039" Rows="1000.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.110529.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SelectHavingFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectHavingFalse.mdp
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  create table t (i int) distributed by (i);
+  explain select count(*) from t group by () having false;
+                      QUERY PLAN                
+  ------------------------------------------
+    Result  (cost=0.00..0.00 rows=0 width=8)
+      One-Time Filter: false
+    Optimizer: GPORCA
+  (3 rows)
+
+  Objective: HAVING clause should not be pushed through
+      the aggregate, and so this should return no rows.
+  ]]>
+  </dxl:Comment>
+<dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103045,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="6.110550.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+        <dxl:LogicalGroupBy>
+          <dxl:GroupingColumns/>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="count">
+              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                <dxl:ValuesList ParamType="aggargs"/>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.110550.1.0" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalGroupBy>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="0">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="8" Alias="count">
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter>
+          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+        </dxl:OneTimeFilter>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SelectHavingSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectHavingSubquery.mdp
@@ -1,0 +1,415 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  create table t (i int) distributed by (i);
+  explain select v.c, (select count(*) from (select * from t) x having v.c)
+    from (values (false),(true)) v(c) order by v.c;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..882688.47 rows=4 width=9)
+   ->  Sort  (cost=0.00..882688.47 rows=4 width=9)
+         Sort Key: "Values".column1
+         ->  Nested Loop Left Join  (cost=0.00..882688.47 rows=4 width=9)
+               Join Filter: "Values".column1
+               ->  Values Scan on "Values"  (cost=0.00..0.00 rows=2 width=1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: GPORCA
+(11 rows)
+
+  Objective: HAVING clause should not be pushed through
+      the aggregate, and so this should return NULL for v.c = false
+      and count(*) for v.c = true.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103045,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.58.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.56.1.0"/>
+        <dxl:Commutator Mdid="0.59.1.0"/>
+        <dxl:InverseOp Mdid="0.1695.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.7017.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.110566.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.110566.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.110566.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.16.1.0"/>
+        <dxl:Ident ColId="12" ColName="count" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="1" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="12" Alias="count">
+              <dxl:ScalarSubquery ColId="11">
+                <dxl:LogicalSelect>
+                  <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.16.1.0"/>
+                  <dxl:LogicalGroupBy>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="6.110566.1.0" TableName="t">
+                        <dxl:Columns>
+                          <dxl:Column ColId="3" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                  </dxl:LogicalGroupBy>
+                </dxl:LogicalSelect>
+              </dxl:ScalarSubquery>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="column1" TypeMdid="0.16.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="false"/>
+            </dxl:ConstTuple>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:LogicalProject>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="54">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="882688.467117" Rows="2.000000" Width="9"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="c">
+            <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.16.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="count">
+            <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="882688.467099" Rows="4.000000" Width="9"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+              <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="0" Alias="column1">
+              <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.16.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="882688.467063" Rows="4.000000" Width="9"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="column1">
+                <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.16.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="count">
+                <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="882688.466655" Rows="4.000000" Width="9"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="column1">
+                  <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.16.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="count">
+                  <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.16.1.0"/>
+              </dxl:JoinFilter>
+              <dxl:Values>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="2.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="column1">
+                    <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.16.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:ValuesList>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ValuesList>
+              </dxl:Values>
+              <dxl:Materialize Eager="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="count">
+                    <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs"/>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.110566.1.0" TableName="t">
+                        <dxl:Columns>
+                          <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                </dxl:Aggregate>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Sort>
+        </dxl:Result>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp
@@ -298,7 +298,7 @@ explain select * from x where x.i in (select x.y from y);
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.088746" Rows="500.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.095234" Rows="500.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -309,116 +309,87 @@ explain select * from x where x.i in (select x.y from y);
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ExistsSubPlan">
             <dxl:TestExpr/>
             <dxl:ParamList/>
-            <dxl:Result>
+            <dxl:Limit>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.011458" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.017946" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="22" Alias="ColRef_0022">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="9" Alias="i">
+                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
+              <dxl:Materialize Eager="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.011458" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.017938" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                    <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
+                  <dxl:ProjElem ColId="9" Alias="i">
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                    <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:Filter/>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.011425" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.017930" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                        <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="9" Alias="i">
+                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Materialize Eager="true">
+                  <dxl:SortingColumnList/>
+                  <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.011424" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.017894" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      <dxl:ProjElem ColId="9" Alias="i">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.011416" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                          <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                        <dxl:ProjElem ColId="9" Alias="i">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.011380" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.40972.1.1" TableName="y">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Aggregate>
-                    </dxl:GatherMotion>
-                  </dxl:Materialize>
-                </dxl:Aggregate>
-              </dxl:Result>
-            </dxl:Result>
+                      <dxl:TableDescriptor Mdid="6.40972.1.1" TableName="y">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:GatherMotion>
+              </dxl:Materialize>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,7 +456,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22142">
+    <dxl:Plan Id="0" SpaceSize="12906">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2462,7 +2462,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1154">
+    <dxl:Plan Id="0" SpaceSize="950">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryNoPullUpTableValueFunction.mdp
@@ -145,140 +145,137 @@ SELECT 0 IS DISTINCT FROM (SELECT COUNT(*) FROM (SELECT UNNEST(ARRAY[1,2,3,4])) 
       </dxl:LogicalProject>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:Result>
+  <dxl:Result>
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="431.000220" Rows="1.000000" Width="1"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="4" Alias="?column?">
+        <dxl:IsDistinctFrom OperatorMdid="0.15.1.0">
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
+        </dxl:IsDistinctFrom>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:OneTimeFilter/>
+    <dxl:Result>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="431.000219" Rows="2.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="5" Alias="ColRef_0005">
+          <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:OneTimeFilter/>
+      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000220" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000203" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="4" Alias="?column?">
-            <dxl:IsDistinctFrom OperatorMdid="0.15.1.0">
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-              <dxl:Coalesce TypeMdid="0.20.1.0">
-                <dxl:Ident ColId="5" ColName="ColRef_0005" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Coalesce>
-            </dxl:IsDistinctFrom>
+          <dxl:ProjElem ColId="3" Alias="count">
+            <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:OneTimeFilter/>
+        <dxl:JoinFilter>
+          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+        </dxl:JoinFilter>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000219" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="5" Alias="ColRef_0005">
-              <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="0" Alias="">
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        </dxl:Result>
+        <dxl:Materialize Eager="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000111" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="3" Alias="count">
+              <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000203" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000103" Rows="1.000000" Width="8"/>
             </dxl:Properties>
+            <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="3" Alias="count">
-                <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
+                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs">
+                    <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.20.1.0"/>
+                  </dxl:ValuesList>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:JoinFilter>
-            <dxl:Result>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="8"/>
               </dxl:Properties>
+              <dxl:GroupingColumns/>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs"/>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-            </dxl:Result>
-            <dxl:Materialize Eager="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000111" Rows="1.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="3" Alias="count">
-                  <dxl:Ident ColId="3" ColName="count" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000103" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
-                <dxl:GroupingColumns/>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="3" Alias="count">
-                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
-                      <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.20.1.0"/>
-                      </dxl:ValuesList>
-                      <dxl:ValuesList ParamType="aggdirectargs"/>
-                      <dxl:ValuesList ParamType="aggorder"/>
-                      <dxl:ValuesList ParamType="aggdistinct"/>
-                    </dxl:AggFunc>
+                  <dxl:ProjElem ColId="2" Alias="unnest">
+                    <dxl:FuncExpr FuncId="0.3240.1.0" FuncRetSet="true" TypeMdid="0.23.1.0" FuncVariadic="false">
+                      <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
+                      </dxl:Array>
+                    </dxl:FuncExpr>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:OneTimeFilter/>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns/>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="6" Alias="ColRef_0006">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
-                        <dxl:ValuesList ParamType="aggargs"/>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="1" Alias="">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000102" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="2" Alias="unnest">
-                        <dxl:FuncExpr FuncId="0.3240.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
-                          <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                          </dxl:Array>
-                        </dxl:FuncExpr>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                  </dxl:Result>
-                </dxl:Aggregate>
-              </dxl:Aggregate>
-            </dxl:Materialize>
-          </dxl:NestedLoopJoin>
-        </dxl:Result>
-      </dxl:Result>
-    </dxl:Plan>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
+              </dxl:Result>
+            </dxl:Aggregate>
+          </dxl:Aggregate>
+        </dxl:Materialize>
+      </dxl:NestedLoopJoin>
+    </dxl:Result>
+  </dxl:Result>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
@@ -286,442 +286,430 @@ SELECT generate_series((
         </dxl:OpExpr>
       </dxl:LogicalTVF>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="342">
-      <dxl:TableValuedFunction FuncId="0.1068.1.0" Name="generate_series" TypeMdid="0.20.1.0">
+<dxl:Plan Id="0" SpaceSize="342">
+  <dxl:TableValuedFunction FuncId="0.1068.1.0" Name="generate_series" TypeMdid="0.20.1.0">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="0" Alias="generate_series">
+        <dxl:Ident ColId="0" ColName="generate_series" TypeMdid="0.20.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+      <dxl:TestExpr/>
+      <dxl:ParamList/>
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="generate_series">
-            <dxl:Ident ColId="0" ColName="generate_series" TypeMdid="0.20.1.0"/>
+          <dxl:ProjElem ColId="51" Alias="ColRef_0024">
+            <dxl:Ident ColId="51" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-          <dxl:TestExpr/>
-          <dxl:ParamList/>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="51" Alias="ColRef_0024">
+              <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="52" Alias="ColRef_0025">
+              <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
+                <dxl:Ident ColId="77" ColName="ColRef_0077" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:OpExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="51" Alias="ColRef_0024">
-                <dxl:Ident ColId="51" ColName="ColRef_0024" TypeMdid="0.20.1.0"/>
+              <dxl:ProjElem ColId="76" Alias="ColRef_0076">
+                <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="77" Alias="ColRef_0077">
+                <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:Result>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="51" Alias="ColRef_0024">
-                  <dxl:Coalesce TypeMdid="0.20.1.0">
-                    <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                  </dxl:Coalesce>
+                <dxl:ProjElem ColId="64" Alias="count">
+                  <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="ColRef_0025">
-                  <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
-                    <dxl:Coalesce TypeMdid="0.20.1.0">
-                      <dxl:Ident ColId="77" ColName="ColRef_0077" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:Coalesce>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:OpExpr>
+                <dxl:ProjElem ColId="75" Alias="count">
+                  <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="76" Alias="ColRef_0076">
+                  <dxl:ProjElem ColId="64" Alias="count">
                     <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="77" Alias="ColRef_0077">
-                    <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="53" Alias="ColRef_0023">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="count">
                       <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="75" Alias="count">
-                      <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="count">
-                        <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
-                    <dxl:Result>
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="53" Alias="ColRef_0023">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
+                      <dxl:ProjList/>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                    <dxl:Materialize Eager="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="64" Alias="count">
-                          <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="64" Alias="count">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
-                              <dxl:Columns>
-                                <dxl:Column ColId="54" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="55" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="56" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:GatherMotion>
-                      </dxl:Aggregate>
-                    </dxl:Materialize>
-                  </dxl:NestedLoopJoin>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="75" Alias="count">
-                        <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="75" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="66" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="67" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:GatherMotion>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
-            </dxl:Result>
-          </dxl:Result>
-        </dxl:SubPlan>
-        <dxl:ConstValue TypeMdid="0.20.1.0" Value="16"/>
-        <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
-          <dxl:TestExpr/>
-          <dxl:ParamList/>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="52" Alias="ColRef_0025">
-                <dxl:Ident ColId="52" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="51" Alias="ColRef_0024">
-                  <dxl:Coalesce TypeMdid="0.20.1.0">
-                    <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                  </dxl:Coalesce>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="ColRef_0025">
-                  <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
-                    <dxl:Coalesce TypeMdid="0.20.1.0">
-                      <dxl:Ident ColId="77" ColName="ColRef_0077" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:Coalesce>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:OpExpr>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
+                        <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
+                          <dxl:Columns>
+                            <dxl:Column ColId="54" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="55" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="56" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:Materialize>
+              </dxl:NestedLoopJoin>
+              <dxl:Materialize Eager="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="76" Alias="ColRef_0076">
-                    <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="77" Alias="ColRef_0077">
+                  <dxl:ProjElem ColId="75" Alias="count">
                     <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="75" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs"/>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
+                        <dxl:Columns>
+                          <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="66" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="67" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                </dxl:Aggregate>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
+        </dxl:Result>
+      </dxl:Result>
+    </dxl:SubPlan>
+    <dxl:ConstValue TypeMdid="0.20.1.0" Value="16"/>
+    <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+      <dxl:TestExpr/>
+      <dxl:ParamList/>
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="52" Alias="ColRef_0025">
+            <dxl:Ident ColId="52" ColName="ColRef_0025" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="51" Alias="ColRef_0024">
+              <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="52" Alias="ColRef_0025">
+              <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
+                <dxl:Ident ColId="77" ColName="ColRef_0077" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:OpExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="76" Alias="ColRef_0076">
+                <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="77" Alias="ColRef_0077">
+                <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="64" Alias="count">
+                  <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="75" Alias="count">
+                  <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="64" Alias="count">
+                    <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="53" Alias="ColRef_0023">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="64" Alias="count">
                       <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="75" Alias="count">
-                      <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns/>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="64" Alias="count">
-                        <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                          <dxl:ValuesList ParamType="aggargs"/>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
-                    <dxl:Result>
+                    <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="53" Alias="ColRef_0023">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
+                      <dxl:ProjList/>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                    <dxl:Materialize Eager="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="64" Alias="count">
-                          <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="64" Alias="count">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
-                              <dxl:Columns>
-                                <dxl:Column ColId="54" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="55" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="56" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:GatherMotion>
-                      </dxl:Aggregate>
-                    </dxl:Materialize>
-                  </dxl:NestedLoopJoin>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="75" Alias="count">
-                        <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="75" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="66" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="67" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:GatherMotion>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
-            </dxl:Result>
+                        <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
+                          <dxl:Columns>
+                            <dxl:Column ColId="54" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="55" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="56" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:GatherMotion>
+                  </dxl:Aggregate>
+                </dxl:Materialize>
+              </dxl:NestedLoopJoin>
+              <dxl:Materialize Eager="true">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="75" Alias="count">
+                    <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="75" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs"/>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
+                        <dxl:Columns>
+                          <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="66" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="67" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                </dxl:Aggregate>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
           </dxl:Result>
-        </dxl:SubPlan>
-      </dxl:TableValuedFunction>
-    </dxl:Plan>
+        </dxl:Result>
+      </dxl:Result>
+    </dxl:SubPlan>
+  </dxl:TableValuedFunction>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1282,471 +1282,253 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="51358">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+    <dxl:Plan Id="0" SpaceSize="654">
+  <dxl:Result>
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="1845587.736006" Rows="199.680000" Width="148"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="26" Alias="oid">
+        <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="0" Alias="amname">
+        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="41" Alias="oid">
+        <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="34" Alias="opcname">
+        <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="49" Alias="amopsubtype">
+        <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter>
+      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.1863.1.0">
+        <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+        <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+          <dxl:TestExpr/>
+          <dxl:ParamList>
+            <dxl:Param ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+            <dxl:Param ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+          </dxl:ParamList>
+          <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="495.870396" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="72" Alias="count">
+                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                  <dxl:ValuesList ParamType="aggargs"/>
+                  <dxl:ValuesList ParamType="aggdirectargs"/>
+                  <dxl:ValuesList ParamType="aggorder"/>
+                  <dxl:ValuesList ParamType="aggdistinct"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="495.870396" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                    <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                    <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                    <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="6.2602.1.1" TableName="pg_amop">
+                <dxl:Columns>
+                  <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:Aggregate>
+        </dxl:SubPlan>
+      </dxl:Comparison>
+    </dxl:Filter>
+    <dxl:OneTimeFilter/>
+    <dxl:HashJoin JoinType="Inner">
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="874.854217" Rows="702.000000" Width="150"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="0" Alias="amname">
+          <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="1" Alias="amstrategies">
+          <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="26" Alias="oid">
+          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="34" Alias="opcname">
+          <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="41" Alias="oid">
+          <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="49" Alias="amopsubtype">
+          <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:JoinFilter/>
+      <dxl:HashCondList>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+          <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+          <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+        </dxl:Comparison>
+      </dxl:HashCondList>
+      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1306.824501" Rows="199.680000" Width="148"/>
+          <dxl:Cost StartupCost="0" TotalCost="443.223121" Rows="141.000000" Width="146"/>
         </dxl:Properties>
         <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="amname">
+            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="amstrategies">
+            <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+          </dxl:ProjElem>
           <dxl:ProjElem ColId="26" Alias="oid">
             <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="0" Alias="amname">
-            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+          <dxl:ProjElem ColId="34" Alias="opcname">
+            <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="41" Alias="oid">
             <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="34" Alias="opcname">
-            <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:JoinFilter>
+          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+        </dxl:JoinFilter>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000891" Rows="2.000000" Width="74"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="amname">
+              <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="amstrategies">
+              <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="26" Alias="oid">
+              <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:And>
+              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
+                <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2lzdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
+                <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
+                <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+              </dxl:Comparison>
+            </dxl:And>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.2601.1.1" TableName="pg_am">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="amname" TypeMdid="0.19.1.0"/>
+              <dxl:Column ColId="1" Attno="2" ColName="amstrategies" TypeMdid="0.21.1.0"/>
+              <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="26" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+        <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="12.131206" Rows="70.500000" Width="72"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="34" Alias="opcname">
+              <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="41" Alias="oid">
+              <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+              <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
+              <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:IndexDescriptor Mdid="0.2686.1.0" IndexName="pg_opclass_am_name_nsp_index"/>
+          <dxl:TableDescriptor Mdid="6.2616.1.1" TableName="pg_opclass">
+            <dxl:Columns>
+              <dxl:Column ColId="33" Attno="1" ColName="opcamid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="34" Attno="2" ColName="opcname" TypeMdid="0.19.1.0"/>
+              <dxl:Column ColId="40" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="41" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexScan>
+      </dxl:NestedLoopJoin>
+      <dxl:TableScan>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="48" Alias="amopclaid">
+            <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="49" Alias="amopsubtype">
             <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:Result>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1306.714368" Rows="199.680000" Width="148"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="26" Alias="oid">
-              <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="0" Alias="amname">
-              <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="41" Alias="oid">
-              <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="34" Alias="opcname">
-              <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="49" Alias="amopsubtype">
-              <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter>
-            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.1863.1.0">
-              <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-              <dxl:Coalesce TypeMdid="0.20.1.0">
-                <dxl:Ident ColId="73" ColName="ColRef_0073" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Coalesce>
-            </dxl:Comparison>
-          </dxl:Filter>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1306.698971" Rows="702.000000" Width="150"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="73" Alias="ColRef_0073">
-                <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="0" Alias="amname">
-                <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="amstrategies">
-                <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="26" Alias="oid">
-                <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="34" Alias="opcname">
-                <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="41" Alias="oid">
-                <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Left">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1306.663871" Rows="702.000000" Width="158"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="amname">
-                  <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="amstrategies">
-                  <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="26" Alias="oid">
-                  <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="34" Alias="opcname">
-                  <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="41" Alias="oid">
-                  <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                  <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="72" Alias="count">
-                  <dxl:Ident ColId="72" ColName="count" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                  <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="875.127646" Rows="702.000000" Width="150"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="amname">
-                    <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="amstrategies">
-                    <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="oid">
-                    <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="34" Alias="opcname">
-                    <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="oid">
-                    <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                    <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:HashExpr>
-                  <dxl:HashExpr>
-                    <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:HashJoin JoinType="Inner">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="874.854217" Rows="702.000000" Width="150"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="amname">
-                      <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="amstrategies">
-                      <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="oid">
-                      <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="34" Alias="opcname">
-                      <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="oid">
-                      <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                      <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter/>
-                  <dxl:HashCondList>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                      <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:HashCondList>
-                  <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="443.223121" Rows="141.000000" Width="146"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="amname">
-                        <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="amstrategies">
-                        <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="26" Alias="oid">
-                        <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="34" Alias="opcname">
-                        <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="oid">
-                        <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000891" Rows="2.000000" Width="74"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="amname">
-                          <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="amstrategies">
-                          <dxl:Ident ColId="1" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="26" Alias="oid">
-                          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
-                            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2lzdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.643.1.0">
-                            <dxl:Ident ColId="0" ColName="amname" TypeMdid="0.19.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="Z2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                          </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:Filter>
-                      <dxl:TableDescriptor Mdid="6.2601.1.1" TableName="pg_am">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="amname" TypeMdid="0.19.1.0"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="amstrategies" TypeMdid="0.21.1.0"/>
-                          <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="26" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                    <dxl:IndexScan IndexScanDirection="Forward">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="12.131206" Rows="70.500000" Width="72"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="34" Alias="opcname">
-                          <dxl:Ident ColId="34" ColName="opcname" TypeMdid="0.19.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="oid">
-                          <dxl:Ident ColId="41" ColName="oid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:IndexCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                          <dxl:Ident ColId="33" ColName="opcamid" TypeMdid="0.26.1.0"/>
-                          <dxl:Ident ColId="26" ColName="oid" TypeMdid="0.26.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IndexCondList>
-                      <dxl:IndexDescriptor Mdid="0.2686.1.0" IndexName="pg_opclass_am_name_nsp_index"/>
-                      <dxl:TableDescriptor Mdid="6.2616.1.1" TableName="pg_opclass">
-                        <dxl:Columns>
-                          <dxl:Column ColId="33" Attno="1" ColName="opcamid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="34" Attno="2" ColName="opcname" TypeMdid="0.19.1.0"/>
-                          <dxl:Column ColId="40" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="41" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="42" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="43" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="44" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="45" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:IndexScan>
-                  </dxl:NestedLoopJoin>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="48" Alias="amopclaid">
-                        <dxl:Ident ColId="48" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="49" Alias="amopsubtype">
-                        <dxl:Ident ColId="49" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.2602.1.1" TableName="pg_amop">
-                      <dxl:Columns>
-                        <dxl:Column ColId="48" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="49" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:HashJoin>
-              </dxl:RedistributeMotion>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.172320" Rows="702.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="60"/>
-                  <dxl:GroupingColumn ColId="61"/>
-                </dxl:GroupingColumns>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="72" Alias="count">
-                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
-                      <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
-                      </dxl:ValuesList>
-                      <dxl:ValuesList ParamType="aggdirectargs"/>
-                      <dxl:ValuesList ParamType="aggorder"/>
-                      <dxl:ValuesList ParamType="aggdistinct"/>
-                    </dxl:AggFunc>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="60" Alias="amopclaid">
-                    <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="61" Alias="amopsubtype">
-                    <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.113221" Rows="702.000000" Width="16"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="60" Alias="amopclaid">
-                      <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="61" Alias="amopsubtype">
-                      <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="74" Alias="ColRef_0074">
-                      <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="60" Alias="amopclaid">
-                        <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="61" Alias="amopsubtype">
-                        <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="74" Alias="ColRef_0074">
-                        <dxl:Ident ColId="74" ColName="ColRef_0074" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.101502" Rows="702.000000" Width="16"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="60"/>
-                        <dxl:GroupingColumn ColId="61"/>
-                      </dxl:GroupingColumns>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="74" Alias="ColRef_0074">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="60" Alias="amopclaid">
-                          <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="61" Alias="amopsubtype">
-                          <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.042403" Rows="702.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="60" Alias="amopclaid">
-                            <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="61" Alias="amopsubtype">
-                            <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.017375" Rows="702.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="60" Alias="amopclaid">
-                              <dxl:Ident ColId="60" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="61" Alias="amopsubtype">
-                              <dxl:Ident ColId="61" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.2602.1.1" TableName="pg_amop">
-                            <dxl:Columns>
-                              <dxl:Column ColId="60" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="61" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="65" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="66" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="67" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="68" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="69" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="70" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="71" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RandomMotion>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Aggregate>
-            </dxl:HashJoin>
-          </dxl:Result>
-        </dxl:Result>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+        <dxl:TableDescriptor Mdid="6.2602.1.1" TableName="pg_amop">
+          <dxl:Columns>
+            <dxl:Column ColId="48" Attno="1" ColName="amopclaid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="49" Attno="2" ColName="amopsubtype" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="54" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="55" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="56" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="57" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:TableScan>
+    </dxl:HashJoin>
+  </dxl:Result>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/src/operators/CNormalizer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CNormalizer.cpp
@@ -17,6 +17,7 @@
 #include "gpopt/base/CUtils.h"
 #include "gpopt/operators/CLogical.h"
 #include "gpopt/operators/CLogicalConstTableGet.h"
+#include "gpopt/operators/CLogicalGbAgg.h"
 #include "gpopt/operators/CLogicalInnerJoin.h"
 #include "gpopt/operators/CLogicalLeftOuterCorrelatedApply.h"
 #include "gpopt/operators/CLogicalLeftOuterJoin.h"
@@ -145,14 +146,26 @@ CNormalizer::FPushable(CExpression *pexprLogical, CExpression *pexprPred)
 	GPOS_ASSERT(NULL != pexprLogical);
 	GPOS_ASSERT(NULL != pexprPred);
 
-	// do not push through volatile functions below an aggregate
-	// volatile functions can potentially give different results when they
-	// are called so we don't want aggregate to use volatile function result
-	// while it processes each row
-	if (COperator::EopLogicalGbAgg == pexprLogical->Pop()->Eopid() &&
-		(CPredicateUtils::FContainsVolatileFunction(pexprPred)))
+	if (COperator::EopLogicalGbAgg == pexprLogical->Pop()->Eopid())
 	{
-		return false;
+		// do not push through volatile functions below an aggregate
+		// volatile functions can potentially give different results when they
+		// are called so we don't want aggregate to use volatile function result
+		// while it processes each row
+		if (CPredicateUtils::FContainsVolatileFunction(pexprPred))
+		{
+			return false;
+		}
+
+		// we also do not push through aggregate when it has no grouping columns
+		// because HAVING clause should not produce any rows when the predicate
+		// if false but aggregates produce a single row even on empty tables.
+		// Because of this we have to keep the HAVING clause above the aggregate.
+		CLogicalGbAgg *pop = CLogicalGbAgg::PopConvert(pexprLogical->Pop());
+		if (0 == pop->Pdrgpcr()->Size())
+		{
+			return false;
+		}
 	}
 
 

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -752,8 +752,7 @@ CSubqueryHandler::FCreateOuterApplyForScalarSubquery(
 	*ppexprNewOuter = pexprPrj;
 
 	BOOL fGeneratedByQuantified = popSubquery->FGeneratedByQuantified();
-	if (fGeneratedByQuantified ||
-		(fHasCountAggMatchingColumn && 0 == pgbAgg->Pdrgpcr()->Size()))
+	if (fGeneratedByQuantified)
 	{
 		CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 		const IMDTypeInt8 *pmdtypeint8 = md_accessor->PtMDType<IMDTypeInt8>();
@@ -764,27 +763,17 @@ CSubqueryHandler::FCreateOuterApplyForScalarSubquery(
 						CUtils::PexprScalarIdent(mp, pcrComputed),
 						CUtils::PexprScalarConstInt8(mp, 0 /*val*/));
 
-		if (fGeneratedByQuantified)
-		{
-			// we produce Null if count(*) value is -1,
-			// this case can only occur when transforming quantified subquery to
-			// count(*) subquery using CXformSimplifySubquery
-			pmdidInt8->AddRef();
-			*ppexprResidualScalar = GPOS_NEW(mp) CExpression(
-				mp, GPOS_NEW(mp) CScalarIf(mp, pmdidInt8),
-				CUtils::PexprScalarEqCmp(
-					mp, pcrComputed,
-					CUtils::PexprScalarConstInt8(mp, -1 /*value*/)),
-				CUtils::PexprScalarConstInt8(mp, 0 /*value*/, true /*is_null*/),
-				pexprCoalesce);
-		}
-		else
-		{
-			// count(*) value can either be NULL (if produced by a lower outer join), or some value >= 0,
-			// we return coalesce(count(*), 0) in this case
-
-			*ppexprResidualScalar = pexprCoalesce;
-		}
+		// we produce Null if count(*) value is -1,
+		// this case can only occur when transforming quantified subquery to
+		// count(*) subquery using CXformSimplifySubquery
+		pmdidInt8->AddRef();
+		*ppexprResidualScalar = GPOS_NEW(mp) CExpression(
+			mp, GPOS_NEW(mp) CScalarIf(mp, pmdidInt8),
+			CUtils::PexprScalarEqCmp(
+				mp, pcrComputed,
+				CUtils::PexprScalarConstInt8(mp, -1 /*value*/)),
+			CUtils::PexprScalarConstInt8(mp, 0 /*value*/, true /*is_null*/),
+			pexprCoalesce);
 
 		return fSuccess;
 	}

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CAggTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CAggTest.cpp
@@ -99,6 +99,10 @@ const CHAR *rgszAggFileNames[] = {
 	"../data/dxl/minidump/NestedProjectCountStarWithOuterRefs.mdp",
 	"../data/dxl/minidump/AggregateWithSkew.mdp",
 	"../data/dxl/minidump/OrderedAggUsingGroupColumnInDirectArg.mdp",
+	"../data/dxl/minidump/SelectHavingFalse.mdp",
+	"../data/dxl/minidump/SelectHavingCount.mdp",
+	"../data/dxl/minidump/SelectHavingSubquery.mdp",
+	"../data/dxl/minidump/SelectHavingCountIsNull.mdp",
 };
 
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5556,35 +5556,40 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NIL != targetList)
 	{
 		queryNew->targetList = (List *) flatten_join_alias_vars(root, (Node *) targetList);
-		pfree(targetList);
+		if (targetList != queryNew->targetList)
+			list_free(targetList);
 	}
 
 	List * returningList = queryNew->returningList;
 	if (NIL != returningList)
 	{
 		queryNew->returningList = (List *) flatten_join_alias_vars(root, (Node *) returningList);
-		pfree(returningList);
+		if (returningList != queryNew->returningList)
+			list_free(returningList);
 	}
 
 	Node *havingQual = queryNew->havingQual;
 	if (NULL != havingQual)
 	{
 		queryNew->havingQual = flatten_join_alias_vars(root, havingQual);
-		pfree(havingQual);
+		if (havingQual != queryNew->havingQual)
+			pfree(havingQual);
 	}
 
 	List *scatterClause = queryNew->scatterClause;
 	if (NIL != scatterClause)
 	{
 		queryNew->scatterClause = (List *) flatten_join_alias_vars(root, (Node *) scatterClause);
-		pfree(scatterClause);
+		if (scatterClause != queryNew->scatterClause)
+			list_free(scatterClause);
 	}
 
 	Node *limitOffset = queryNew->limitOffset;
 	if (NULL != limitOffset)
 	{
 		queryNew->limitOffset = flatten_join_alias_vars(root, limitOffset);
-		pfree(limitOffset);
+		if (limitOffset != queryNew->limitOffset)
+			pfree(limitOffset);
 	}
 
 	List *windowClause = queryNew->windowClause;
@@ -5611,7 +5616,8 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NULL != limitCount)
 	{
 		queryNew->limitCount = flatten_join_alias_vars(root, limitCount);
-		pfree(limitCount);
+		if (limitCount != queryNew->limitCount)
+			pfree(limitCount);
 	}
 
     return queryNew;

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -1390,23 +1390,21 @@ where i < (select count(*) from smallt where smallt.i = smallt2.i) order by 1,2,
 
 explain select smallt2.* from smallt2
 where i < (select count(*) from smallt where smallt.i = smallt2.i);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=50 width=15)
-   ->  Result  (cost=0.00..862.01 rows=17 width=15)
-         Filter: smallt2.i < COALESCE((count()), 0::bigint)
-         ->  Result  (cost=0.00..862.01 rows=17 width=24)
-               ->  Hash Left Join  (cost=0.00..862.01 rows=17 width=23)
-                     Hash Cond: smallt2.i = smallt.i
-                     ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=15)
-                     ->  Hash  (cost=431.01..431.01 rows=4 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
-                                 Group Key: smallt.i
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
-                                       Sort Key: smallt.i
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
-(14 rows)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324412.64 rows=50 width=15)
+   ->  Result  (cost=0.00..1324412.64 rows=17 width=15)
+         Filter: (smallt2.i < (SubPlan 1))
+         ->  Seq Scan on smallt2  (cost=0.00..1324412.62 rows=334 width=24)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.34 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.34 rows=10 width=1)
+                       Filter: (smallt.i = smallt2.i)
+                       ->  Materialize  (cost=0.00..431.01 rows=100 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
+                                   ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 -- Sort in MergeJoin
 -- start_ignore
@@ -1620,23 +1618,23 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
 (200 rows)
 
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=200 width=15) (actual time=1.423..1.484 rows=100 loops=2)
-   ->  Hash Join  (cost=0.00..862.01 rows=67 width=15) (actual time=0.289..1.208 rows=50 loops=2)
-         Hash Cond: smallt.i = smallt_1.i
-         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 1 of 524288 buckets.
- 
-         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.002..0.007 rows=5 loops=2)
-               Filter: i < 2
-         ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.049..0.049 rows=5 loops=2)
-               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=7 width=4) (actual time=0.037..0.044 rows=5 loops=2)
-                     Filter: i < 2
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).  Work_mem: 1K bytes max.
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=200 width=15) (actual time=1.180..1.194 rows=200 loops=1)
+   ->  Hash Join  (cost=0.00..862.01 rows=67 width=15) (actual time=0.263..0.914 rows=200 loops=1)
+         Hash Cond: (smallt.i = smallt_1.i)
+         Extra Text: (seg1)   Hash chain length 10.0 avg, 10 max, using 2 of 524288 buckets.
+         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.001..0.004 rows=20 loops=1)
+               Filter: (i < 2)
+         ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.013..0.013 rows=20 loops=1)
+               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=7 width=4) (actual time=0.005..0.007 rows=20 loops=1)
+                     Filter: (i < 2)
+ Planning time: 8.321 ms
+   (slice0)    Executor memory: 87K bytes.
+   (slice1)    Executor memory: 4172K bytes avg x 3 workers, 4172K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 3.631 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.562 ms
 (15 rows)
 
 select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -724,3 +724,31 @@ select sum(distinct a), sum(distinct b), c from agg_a group by c;
 
 reset optimizer;
 reset gp_enable_mdqa_shared_scan;
+-- Check for COUNT bug
+create table count_bug_empty (a int, b int);
+create table count_bug_one (a int, b int);
+insert into count_bug_one values (0, 0);
+-- Should return zeros
+select * from count_bug_one
+where count_bug_one.a in (
+  select count(*) from count_bug_empty
+  where count_bug_one.b = count_bug_empty.b
+);
+ a | b 
+---+---
+ 0 | 0
+(1 row)
+
+-- Should be empty
+select * from count_bug_one
+where count_bug_one.a in (
+  select count(*) from count_bug_empty
+  where count_bug_one.b = count_bug_empty.b
+  group by (count_bug_empty.a)
+);
+ a | b 
+---+---
+(0 rows)
+
+drop table count_bug_empty;
+drop table count_bug_one;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -2481,49 +2481,34 @@ where not exists (
               ) a1 on t3.c2 = a1.c1
   where t1.c1 = t2.c2
 );
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice7; segments: 3)
-   ->  Result
-         Filter: (COALESCE((count((count()))), '0'::bigint) = '0'::bigint)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Hash Anti Join
+   Hash Cond: (tt4x.c1 = tt4x_1.c2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on tt4x
+   ->  Hash
          ->  Result
                ->  Hash Left Join
-                     Hash Cond: (tt4x.c1 = tt4x_1.c2)
-                     ->  Seq Scan on tt4x
+                     Hash Cond: (tt4x_2.c2 = tt4x_4.c1)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)
+                           ->  Hash Left Join
+                                 Hash Cond: (tt4x_1.c3 = tt4x_2.c1)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: tt4x_1.c3
+                                       ->  Seq Scan on tt4x tt4x_1
+                                 ->  Hash
+                                       ->  Seq Scan on tt4x tt4x_2
                      ->  Hash
-                           ->  Result
-                                 ->  GroupAggregate
-                                       Group Key: tt4x_1.c2
-                                       ->  Sort
-                                             Sort Key: tt4x_1.c2
-                                             ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                                   Hash Key: tt4x_1.c2
-                                                   ->  Result
-                                                         ->  GroupAggregate
-                                                               Group Key: tt4x_1.c2
-                                                               ->  Sort
-                                                                     Sort Key: tt4x_1.c2
-                                                                     ->  Redistribute Motion 1:3  (slice5)
-                                                                           ->  Hash Left Join
-                                                                                 Hash Cond: (tt4x_2.c2 = tt4x_4.c1)
-                                                                                 ->  Gather Motion 3:1  (slice2; segments: 3)
-                                                                                       ->  Hash Left Join
-                                                                                             Hash Cond: (tt4x_1.c3 = tt4x_2.c1)
-                                                                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                                                                   Hash Key: tt4x_1.c3
-                                                                                                   ->  Seq Scan on tt4x tt4x_1
-                                                                                             ->  Hash
-                                                                                                   ->  Seq Scan on tt4x tt4x_2
-                                                                                 ->  Hash
-                                                                                       ->  Hash Left Join
-                                                                                             Hash Cond: (tt4x_3.c2 = tt4x_4.c1)
-                                                                                             ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                                                                   ->  Seq Scan on tt4x tt4x_3
-                                                                                             ->  Hash
-                                                                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                         ->  Seq Scan on tt4x tt4x_4
+                           ->  Hash Left Join
+                                 Hash Cond: (tt4x_3.c2 = tt4x_4.c1)
+                                 ->  Gather Motion 3:1  (slice4; segments: 3)
+                                       ->  Seq Scan on tt4x tt4x_3
+                                 ->  Hash
+                                       ->  Gather Motion 3:1  (slice5; segments: 3)
+                                             ->  Seq Scan on tt4x tt4x_4
  Optimizer: Pivotal Optimizer (GPORCA)
-(40 rows)
+(25 rows)
 
 --
 -- regression test for problems of the sort depicted in bug #3494

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3558,7 +3558,7 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Delete
-   Output: "outer".ColRef_0025, test.ctid, test.tableoid
+   Output: "outer".ColRef_0023, test.ctid, test.tableoid
    ->  Result
          Output: test.ctid, test.tableoid, test.gp_segment_id, 0
          ->  Hash Anti Join

--- a/src/test/regress/expected/select_having_optimizer.out
+++ b/src/test/regress/expected/select_having_optimizer.out
@@ -153,20 +153,22 @@ select a,count(*) from gstest2 group by rollup(a) having a is distinct from 1 or
 explain (costs off)
 select v.c, (select count(*) from gstest2 group by () having v.c)
   from (values (false),(true)) v(c) order by v.c;
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Sort
-   Sort Key: "*VALUES*".column1
-   ->  Values Scan on "*VALUES*"
-         SubPlan 1  (slice0)
-           ->  Aggregate
-                 Filter: "*VALUES*".column1
-                 ->  Result
-                       ->  Materialize
-                             ->  Gather Motion 3:1  (slice1; segments: 3)
-                                   ->  Seq Scan on gstest2
- Optimizer: Postgres query optimizer
-(11 rows)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Result
+   ->  Result
+         ->  Sort
+               Sort Key: "Values".column1
+               ->  Nested Loop Left Join
+                     Join Filter: "Values".column1
+                     ->  Values Scan on "Values"
+                     ->  Materialize
+                           ->  Aggregate
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                                       ->  Aggregate
+                                             ->  Seq Scan on gstest2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select v.c, (select count(*) from gstest2 group by () having v.c)
   from (values (false),(true)) v(c) order by v.c;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -639,96 +639,84 @@ insert into csq_pullup values ('def',3, 1, 'abc');
 -- text, text
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: 1 = COALESCE((count()), 0::bigint)
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: csq_pullup.t = csq_pullup_1.t
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                 Group Key: csq_pullup_1.t
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: csq_pullup_1.t
-                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(14 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.t = csq_pullup_1.t)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
   t  | n | i |  v  
 -----+---+---+-----
+ abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
  def | 3 | 1 | abc
- abc | 1 | 2 | xyz
 (3 rows)
 
 --
 -- text, varchar
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: (1 = COALESCE((count()), 0::bigint))
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                 Group Key: csq_pullup_1.v
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: csq_pullup_1.v
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             Hash Key: csq_pullup_1.v
-                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(16 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.t = (csq_pullup_1.v)::text)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
 -----+---+---+-----
- xyz | 2 | 3 | def
  def | 3 | 1 | abc
  abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
 (3 rows)
 
 --
 -- numeric, numeric
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=17)
-   Filter: (1 = COALESCE((count()), 0::bigint))
-   ->  Result  (cost=0.00..862.00 rows=1 width=36)
-         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-               Hash Cond: (csq_pullup.n = csq_pullup_1.n)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=13)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=13)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                       Group Key: csq_pullup_1.n
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                             Sort Key: csq_pullup_1.n
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
-                                                   Hash Key: csq_pullup_1.n
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(18 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.n = csq_pullup_1.n)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
 -----+---+---+-----
+ abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
  def | 3 | 1 | abc
- abc | 1 | 2 | xyz
 (3 rows)
 
 --
@@ -739,24 +727,24 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: 1 = ((SubPlan 1))
+         Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1  (slice2; segments: 3)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.n + 1::numeric)
+                       Filter: ((csq_pullup.n + '1'::numeric) = (csq_pullup_1.n + '1'::numeric))
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
   t  | n | i |  v  
 -----+---+---+-----
+ def | 3 | 1 | abc
  abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
- def | 3 | 1 | abc
 (3 rows)
 
 --
@@ -767,16 +755,16 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: 1 = ((SubPlan 1))
+         Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1  (slice2; segments: 3)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.i + 1)::numeric
+                       Filter: ((csq_pullup.n + '1'::numeric) = ((csq_pullup_1.i + 1))::numeric)
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
@@ -798,7 +786,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
          Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
-         SubPlan 1
+         SubPlan 1  (slice2; segments: 3)
            ->  Limit  (cost=0.00..431.00 rows=1 width=8)
                  ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                        ->  Result  (cost=0.00..431.00 rows=1 width=1)
@@ -806,63 +794,61 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                              ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                          ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t LIMIT 1);
   t  | n | i |  v  
 -----+---+---+-----
- xyz | 2 | 3 | def
  def | 3 | 1 | abc
  abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
 (3 rows)
 
 -- subquery contains a HAVING clause
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: (1 = COALESCE((count()), '0'::bigint))
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: (csq_pullup.t = csq_pullup_1.t)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                 Filter: ((count()) < 10)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
-                                       Group Key: csq_pullup_1.t
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: csq_pullup_1.t
-                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(16 rows)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..6465.25 rows=1 width=17)
+   ->  Result  (cost=0.00..6465.25 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..6465.24 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                 Filter: ((count()) < 10)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             Filter: (csq_pullup.t = csq_pullup_1.t)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
   t  | n | i |  v  
 -----+---+---+-----
- xyz | 2 | 3 | def
  def | 3 | 1 | abc
  abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
 (3 rows)
 
 -- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
          Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
-         SubPlan 1
+         SubPlan 1  (slice2; segments: 3)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
                        Filter: ((csq_pullup.n + csq_pullup_1.n) = (csq_pullup_1.i)::numeric)
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
-                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=9)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
@@ -1251,30 +1237,28 @@ explain select row_number() over (order by seq asc) as id, foo.cnt
 from
 (select seq, (select count(*) from t1_mpp_24563 t1 where t1.id = t2.id) cnt from
 	t2_mpp_24563 t2 where value = 7) foo;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=16)
-   ->  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..5172.08 rows=1 width=16)
+   ->  WindowAgg  (cost=0.00..5172.08 rows=1 width=16)
          Order By: t2_mpp_24563.seq
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.08 rows=1 width=12)
                Merge Key: t2_mpp_24563.seq
-               ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                     ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                           ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=12)
-                                       Sort Key: t2_mpp_24563.seq
-                                       ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=12)
-                                             Hash Cond: (t2_mpp_24563.id = t1_mpp_24563.id)
-                                             ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
-                                                   Filter: (value = 7)
-                                             ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                                         Group Key: t1_mpp_24563.id
-                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                               Sort Key: t1_mpp_24563.id
-                                                               ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
+               ->  Result  (cost=0.00..5172.08 rows=1 width=12)
+                     ->  Result  (cost=0.00..5172.08 rows=1 width=12)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: t2_mpp_24563.seq
+                                 ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
+                                       Filter: (value = 7)
+                           SubPlan 1  (slice2; segments: 3)
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                         Filter: (t1_mpp_24563.id = t2_mpp_24563.id)
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                     ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(19 rows)
 
 drop table t1_mpp_24563;
 drop table t2_mpp_24563;
@@ -1304,33 +1288,27 @@ CASE
 	ELSE 'Q2'::text END  AS  cc,  1 AS nn
 FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- WindowAgg  (cost=0.00..862.00 rows=1 width=16)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
-         ->  Result  (cost=0.00..862.00 rows=1 width=12)
-               ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
-                           Hash Cond: ((t_mpp_20470.col_name)::text = (t_mpp_20470_1.col_name)::text)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                 Hash Key: t_mpp_20470.col_name
-                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                             Partitions selected: 2 (out of 2)
-                                       ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                       Group Key: t_mpp_20470_1.col_name
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                             Sort Key: t_mpp_20470_1.col_name
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                                                   Hash Key: t_mpp_20470_1.col_name
-                                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-                                                         ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                               Partitions selected: 2 (out of 2)
-                                                         ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..5172.14 rows=334 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.14 rows=1000 width=12)
+         ->  Result  (cost=0.00..5172.10 rows=334 width=12)
+               ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected: 2 (out of 2)
+                     ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                             Filter: ((t_mpp_20470_1.col_name)::text = (t_mpp_20470.col_name)::text)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=12)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                         ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                               ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                     Partitions selected: 2 (out of 2)
+                                               ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(18 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1842,17 +1820,17 @@ EXPLAIN select count(distinct ss.ten) from
 EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..865.44 rows=1 width=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.44 rows=1 width=1)
-         ->  Limit  (cost=0.00..865.44 rows=1 width=1)
-               ->  Result  (cost=0.00..865.44 rows=3334 width=1)
-                     ->  Result  (cost=0.00..865.44 rows=3334 width=8)
-                           ->  Hash Left Join  (cost=0.00..865.41 rows=3334 width=8)
+ Limit  (cost=0.00..866.24 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..866.24 rows=1 width=1)
+         ->  Limit  (cost=0.00..866.24 rows=1 width=1)
+               ->  Result  (cost=0.00..866.24 rows=3334 width=1)
+                     ->  HashAggregate  (cost=0.00..866.24 rows=3334 width=1)
+                           Group Key: tenk2.unique1, tenk2.ctid, tenk2.gp_segment_id, "outer".ColRef_0048
+                           ->  Hash Left Join  (cost=0.00..864.63 rows=3334 width=15)
                                  Hash Cond: (tenk2.unique1 = tenk1.unique1)
-                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=4)
-                                 ->  Hash  (cost=431.96..431.96 rows=3334 width=12)
-                                       ->  HashAggregate  (cost=0.00..431.96 rows=3334 width=12)
-                                             Group Key: tenk1.unique1
+                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=14)
+                                 ->  Hash  (cost=431.55..431.55 rows=3334 width=5)
+                                       ->  Result  (cost=0.00..431.55 rows=3334 width=5)
                                              ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -261,3 +261,26 @@ select sum(distinct a), sum(distinct b), c from agg_a group by c;
 
 reset optimizer;
 reset gp_enable_mdqa_shared_scan;
+
+-- Check for COUNT bug
+create table count_bug_empty (a int, b int);
+create table count_bug_one (a int, b int);
+insert into count_bug_one values (0, 0);
+
+-- Should return zeros
+select * from count_bug_one
+where count_bug_one.a in (
+  select count(*) from count_bug_empty
+  where count_bug_one.b = count_bug_empty.b
+);
+
+-- Should be empty
+select * from count_bug_one
+where count_bug_one.a in (
+  select count(*) from count_bug_empty
+  where count_bug_one.b = count_bug_empty.b
+  group by (count_bug_empty.a)
+);
+
+drop table count_bug_empty;
+drop table count_bug_one;


### PR DESCRIPTION
This patch backports ports three related commits from GPDB 7 to GPDB 6. Although they are technically separate problems, they depend on each other and so they have to be merged in this specific order.

---

Disable decorrelation for count() with no grouping columns

In SQL standard, GROUP BY clause can represent two distinct operations: normal
GROUP BY with grouping columns, and scalar GROUP BY without grouping columns.
Their main difference is that the scalar GROUP BY always outputs exactly one
row, even when input relation is empty. This especially matters for COUNT(*)
and COUNT(attr) aggregates since in empty input their output is 0, not NULL.

During subquery decorrelation in ORCA, when pulling predicates through GpAgg,
new grouping columns are added to it. This is fine for normal GROUP BYs, but
for scalar GROUP BY (the case when there were no grouping columns originally),
it changes behavior on empty input relations, which produces invalid output.
This seems to be a well-known bug in existing database literature, known as
the "COUNT bug".

This behavior was noticed previously in ORCA, and a "COALESCE fix" was added,
converting NULLs back to 0. However, this fix was added in a previous
transformation (CSubqueryHandler), so it was unnecessary in some cases, and
also didn't cover all of them. Fixing this properly will require a partial
rewrite of CDecorrelator to use better decorrelation algorithms that don't
miss these edge cases.

As a temporary solution, this patch disables decorrelation for GpAgg with no
grouping columns, if COUNT(*) or COUNT(attr) is present, as well as the
COALESCE fix. This unfortunately results in less optimal plans in some cases,
but distinguishing correct decorrelation from incorrect ones is complicated
and requires big rewrites.

Tests affected by this:
1. Search space size is reduced in 12 minidump tests, plans themselves weren't
affected.
2. Unnecessary COALESCE is removed from 7 minidump tests.
3. Swap joins in InferPredicatesFromMultiSubquery.mdp, without affecting
performance.
4. Fix ScalarCorrelatedSubqueryCountStar.mdp and
ScalarSubqueryCountStarInJoin.mdp, since previously they were fixing incorrect
behavior.
5. Change NullIf-With-Subquery.mdp and UnnestSQJoins.mdp to correlated
versions (COALESCE fix worked for them before, so they were correct).
6. Change plans of several regression tests in subselect_gp.sql,
subselect_gp_indexes.sql and eagerfree.sql, replacing them with correlated
plans. Unfortunately, they were the ones where decorrelation was safe even
without COALESCE fix, but there is no easy way to determine that with current
architecture (COALESCE fix was applied to them previously regardless).

Changes from original commit:
1. There is no HAWQ-TPCH-Stat-Derivation.mdp in GPDB 6, changes are not needed.
2. Some ORCA plans (in .mdp and partition_pruning.out) have ColRef id
   changed due to patch influences at attributes sets produced by
   aggregators.
3. Fix join_optimizer.out, new plan is closer to what Postgres produces.
4. Small changes to other test outputs for GPDB 6.

(cherry picked from commit 2ef1914b4df1418befff7443ea5c2b22be74a726)

---

Fix HAVING pushdown in ORCA

According to SQL spec, when HAVING predicate is false, the group should not be
in the output. Specifically, in case of GROUP BY (), output should have no
rows if HAVING predicate is false. However, previously in ORCA the behavior
was different: for example `select count(*) from t group by () having false;`
produced one row containing 0, which is incorrect.

This happened because during expression normalization the HAVING clause
(represented by LogicalSelect above LogicalGbAgg) was pushed through the
aggregation, and so filtering was performed before aggregation, resulting in
an empty group with count(*) of 0. This is valid when there are grouping
columns present, but for GROUP BY () it is not. This patch disables predicate
pushdown in case of no grouping columns.

Other than adding four new ORCA unit tests, this patch also affects several
existing ones:
1. SubqueryInsideScalarIf and CTEWithMergedGroup.mdp: number of plan
alternatives is reduced, since alternatives involving the pushed down
predicate are now forbidden.
2. DqaSubqueryMax: Filtering inside a Join was replaced with JoinFilter, which
shouldn't affect anything.
3. SemiJoin2Select-EnforceSubplan: After commit
652a76f4151f09279d87ea41dab5eae3a503eae2 the plan was changed to something
else without fixing the comment. After this patch, the plan is now back to the
original, matching the comment.

Changes from original commit:
1. Minidumps adjustments to GPDB 6.

(cherry picked from commit fbb8370464df9c97a694ea1edd24bd221b57c03a)

---

Prevent use after free in flatten_join_alias_var_optimizer function

This patch prevents several use after free bugs present in
flatten_join_alias_var_optimizer. Specifically, the function uses
flatten_join_alias_vars function multiple times, and assumes that the
original node can be freed immediately after. This is not always the case
since under some circumstances flatten_join_alias_vars does not modify its
input and simply passes it through without copying. This patch adds conditions
to check if the original node can safely be freed, preventing use after free.

This prevents ORCA falling back to Postgres planner in some cases, in
particular a query with HAVING previously tested in
orca_groupingsets_fallbacks. After this patch we can remove it since it no
longer falls back to Postgres.

Changes from original commit:
GPDB 6 does not contain orca_groupingsets_fallbacks.sql test.

Co-authored-by: Georgy Shelkovy <g.shelkovy@arenadata.io>
(cherry picked from commit 1e001f6053635fba4002e5c0398f1cb47b9dbbc6)

---

Note: Do not squash this