### PR TITLE
Resolve conflicts in configure, configure.in, fmgr.h and pg_config.h.in

### DIFF
--- a/configure
+++ b/configure
@@ -19086,33 +19086,6 @@ _ACEOF
 
 
 
-<<<<<<< HEAD
-# In GPDB, float4 and float8 are always passed by value. There is
-# GPDB-specific code that assumes that in various places, so it's not
-# configurable.
-float4passbyval=true
-
-$as_echo "#define USE_FLOAT4_BYVAL 1" >>confdefs.h
-
-
-cat >>confdefs.h <<_ACEOF
-#define FLOAT4PASSBYVAL $float4passbyval
-_ACEOF
-
-
-# Note: this setting also controls int8 and related types such as timestamp.
-float8passbyval=true
-
-$as_echo "#define USE_FLOAT8_BYVAL 1" >>confdefs.h
-
-
-cat >>confdefs.h <<_ACEOF
-#define FLOAT8PASSBYVAL $float8passbyval
-_ACEOF
-
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 # Determine memory alignment requirements for the basic C data types.
 
 # The cast to long int works around a bug in the HP C Compiler,

--- a/configure.in
+++ b/configure.in
@@ -2320,21 +2320,6 @@ AC_CHECK_SIZEOF([void *])
 AC_CHECK_SIZEOF([size_t])
 AC_CHECK_SIZEOF([long])
 
-<<<<<<< HEAD
-# In GPDB, float4 and float8 are always passed by value. There is
-# GPDB-specific code that assumes that in various places, so it's not
-# configurable.
-float4passbyval=true
-AC_DEFINE([USE_FLOAT4_BYVAL], 1, [Define to 1 if you want float4 values to be passed by value. (Always defined in GPDB)])
-AC_DEFINE_UNQUOTED([FLOAT4PASSBYVAL], [$float4passbyval], [float4 values are passed by value if 'true', by reference if 'false' (always true in GPDB)])
-
-# Note: this setting also controls int8 and related types such as timestamp.
-float8passbyval=true
-AC_DEFINE([USE_FLOAT8_BYVAL], 1, [Define to 1 if you want float8, int8, etc values to be passed by value. (Always defined in GPDB)])
-AC_DEFINE_UNQUOTED([FLOAT8PASSBYVAL], [$float8passbyval], [float8, int8, and related values are passed by value if 'true', by reference if 'false' (always true in GPDB)])
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 # Determine memory alignment requirements for the basic C data types.
 
 AC_CHECK_ALIGNOF(short)

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -475,18 +475,10 @@ typedef enum {
 	FUNC_MAX_ARGS, \
 	INDEX_MAX_KEYS, \
 	NAMEDATALEN, \
-<<<<<<< HEAD
-	FLOAT4PASSBYVAL, \
 	FLOAT8PASSBYVAL, \
 	PgMagicProductGreenplum \
-=======
-	FLOAT8PASSBYVAL \
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 }
 
-#ifndef FLOAT4PASSBYVAL
-#define FLOAT4PASSBYVAL 1
-#endif
 #ifndef FLOAT8PASSBYVAL
 #define FLOAT8PASSBYVAL 1
 #endif

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -73,7 +73,7 @@
    MSVC and with C++ compilers. */
 #undef FLEXIBLE_ARRAY_MEMBER
 
-/* In GPDB, float8 are always passed by value. There is GPDB-specific code that
+/* In GPDB, float8 is always passed by value. There is GPDB-specific code that
    assumes that in various places, so it's not configurable. */
 
 /* float8, int8, and related values are passed by value if 'true', by

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -73,13 +73,8 @@
    MSVC and with C++ compilers. */
 #undef FLEXIBLE_ARRAY_MEMBER
 
-/* In GPDB, float4 and float8 are always passed by value. There is
-   GPDB-specific code that assumes that in various places, so it's not
-   configurable. */
-
-/* float4 values are passed by value if 'true', by reference if 'false'
-   (always true in GPDB) */
-#define FLOAT4PASSBYVAL true
+/* In GPDB, float8 are always passed by value. There is GPDB-specific code that
+   assumes that in various places, so it's not configurable. */
 
 /* float8, int8, and related values are passed by value if 'true', by
    reference if 'false' (always true in GPDB) */
@@ -977,10 +972,6 @@
 
 /* Define to use /dev/urandom for random number generation */
 #undef USE_DEV_URANDOM
-
-/* Define to 1 if you want float4 values to be passed by value. (Always
-   defined in GPDB) */
-#define USE_FLOAT4_BYVAL 1
 
 /* Define to 1 if you want float8, int8, etc values to be passed by value.
    (Always defined in GPDB) */

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -73,17 +73,18 @@
    MSVC and with C++ compilers. */
 #undef FLEXIBLE_ARRAY_MEMBER
 
-<<<<<<< HEAD
+/* In GPDB, float4 and float8 are always passed by value. There is
+   GPDB-specific code that assumes that in various places, so it's not
+   configurable. */
+
 /* float4 values are passed by value if 'true', by reference if 'false'
    (always true in GPDB) */
-#undef FLOAT4PASSBYVAL
+#define FLOAT4PASSBYVAL true
 
 /* float8, int8, and related values are passed by value if 'true', by
    reference if 'false' (always true in GPDB) */
-#undef FLOAT8PASSBYVAL
+#define FLOAT8PASSBYVAL true
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* Define to 1 if gettimeofday() takes only 1 argument. */
 #undef GETTIMEOFDAY_1ARG
 
@@ -902,14 +903,10 @@
 /* Define to best printf format archetype, usually gnu_printf if available. */
 #undef PG_PRINTF_ATTRIBUTE
 
-<<<<<<< HEAD
-/* Postgres version Greenplum Database is based on */
-=======
 /* Define to 1 to use <stdbool.h> to define type bool. */
 #undef PG_USE_STDBOOL
 
-/* PostgreSQL version as a string */
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+/* Postgres version Greenplum Database is based on */
 #undef PG_VERSION
 
 /* PostgreSQL version as a number */
@@ -981,20 +978,17 @@
 /* Define to use /dev/urandom for random number generation */
 #undef USE_DEV_URANDOM
 
-<<<<<<< HEAD
 /* Define to 1 if you want float4 values to be passed by value. (Always
    defined in GPDB) */
-#undef USE_FLOAT4_BYVAL
+#define USE_FLOAT4_BYVAL 1
 
 /* Define to 1 if you want float8, int8, etc values to be passed by value.
    (Always defined in GPDB) */
-#undef USE_FLOAT8_BYVAL
+#define USE_FLOAT8_BYVAL 1
 
 /* Define to 1 to build with gpcloud (--enable-gpcloud) */
 #undef USE_GPCLOUD
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* Define to build with ICU support. (--with-icu) */
 #undef USE_ICU
 


### PR DESCRIPTION
Resolve conflicts in configure, configure.in, fmgr.h and pg_config.h.in

1) Commits 2e4db24 and 4513d8b removed float4-byval and float8-byval
definitions from the configuration in the pg_config_manual.h include, while an
earlier commit fa287d0 had already hardcoded float4-byval and float8-byval for
GPDB.

2) Commit 7a0574b added the PG_USE_STDBOOL undefine to
src/include/pg_config.h.in, while an earlier commit 6b0e52b had already changed
the comment before the PG_VERSION undefine near that location.

3) Commit 2e4db24 removed the FLOAT4PASSBYVAL define, while earlier commit
19cd1cf already added the PgMagicProductGreenplum value to the enum and its
usage in the PG_MODULE_MAGIC_DATA define in src/include/fmgr.h