### PR TITLE
Resolve conflicts in src/include/access/hash.h

### DIFF
--- a/src/include/access/hash.h
+++ b/src/include/access/hash.h
@@ -20,11 +20,8 @@
 #include "access/amapi.h"
 #include "access/itup.h"
 #include "access/sdir.h"
-<<<<<<< HEAD
-#include "common/hashfn.h"
-=======
 #include "catalog/pg_am_d.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#include "common/hashfn.h"
 #include "lib/stringinfo.h"
 #include "storage/bufmgr.h"
 #include "storage/lockdefs.h"


### PR DESCRIPTION
Resolve conflicts in src/include/access/hash.h

Commit 4cb658a added include catalog/pg_am_d.h to src/include/access/hash.h,
while earlier commit 5d3dc2e had already added include common/hashfn.h to the
same location.