### PR TITLE
Resolve conflicts in src/include/access/xact.h

### DIFF
--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -254,13 +254,8 @@ typedef struct xl_xact_subxacts
 
 typedef struct xl_xact_relfilenodes
 {
-<<<<<<< HEAD
-	int			nrels;			/* number of subtransaction XIDs */
-	RelFileNodePendingDelete xnodes[FLEXIBLE_ARRAY_MEMBER];
-=======
 	int			nrels;			/* number of relations */
-	RelFileNode xnodes[FLEXIBLE_ARRAY_MEMBER];
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+	RelFileNodePendingDelete xnodes[FLEXIBLE_ARRAY_MEMBER];
 } xl_xact_relfilenodes;
 #define MinSizeOfXactRelfilenodes offsetof(xl_xact_relfilenodes, xnodes)
 


### PR DESCRIPTION
Resolve conflicts in src/include/access/xact.h

Commit f9cb8bd changed the comment of the nrels field in the
xl_xact_relfilenodes structure, while the earlier commit 8ae22d1 had already
changed the type of the next xnodes field from RelFileNode to
RelFileNodePendingDelete.