### PR TITLE
Resolve conflicts in src/include/access/xlogutils.h

### DIFF
--- a/src/include/access/xlogutils.h
+++ b/src/include/access/xlogutils.h
@@ -54,13 +54,8 @@ extern int	read_local_xlog_page(XLogReaderState *state,
 extern void XLogReadDetermineTimeline(XLogReaderState *state,
 									  XLogRecPtr wantPage, uint32 wantLength);
 
-<<<<<<< HEAD
-extern void XLogAOSegmentFile(RelFileNode rnode, uint32 segmentFileNum);
-
-extern void XLogReadDetermineTimeline(XLogReaderState *state,
-					XLogRecPtr wantPage, uint32 wantLength);
-=======
 extern void WALReadRaiseError(WALReadError *errinfo);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+
+extern void XLogAOSegmentFile(RelFileNode rnode, uint32 segmentFileNum);
 
 #endif


### PR DESCRIPTION
Resolve conflicts in src/include/access/xlogutils.h

Commit 0dc8ead added a new function WALReadRaiseError, while earlier commit
b659d04 already added a new function XLogAOSegmentFile in the same place.