### PR TITLE
Resolve conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302506161
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201911241
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#define CATALOG_VERSION_NO	302507011
 
 #endif


### PR DESCRIPTION
Resolve conflicts in src/include/catalog/catversion.h

Commit 8b7ae5a updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.