### PR TITLE
Resolve conflicts in src/include/executor/tuptable.h

### DIFF
--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -15,11 +15,8 @@
 #define TUPTABLE_H
 
 #include "access/htup.h"
-<<<<<<< HEAD
-#include "access/memtup.h"
-=======
 #include "access/htup_details.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#include "access/memtup.h"
 #include "access/sysattr.h"
 #include "access/tupdesc.h"
 #include "storage/buf.h"


### PR DESCRIPTION
Resolve conflicts in src/include/executor/tuptable.h

Commit e048722 moved the include access/htup_details.h up (alphabetically) in
src/include/executor/tuptable.h, while earlier commit 6b0e52b had already added
a new include access/memtup.h in the same place.