### PR TITLE
Resolve conflicts in src/include/replication/walsender_private.h

### DIFF
--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -101,18 +101,16 @@ typedef struct WalSnd
 	 */
 	TimestampTz replyTime;
 
-<<<<<<< HEAD
+	/* Statistics for transactions spilled to disk. */
+	int64		spillTxns;
+	int64		spillCount;
+	int64		spillBytes;
+
 	/*
 	 * Indicates whether the WalSnd represents a connection with a Greenplum
 	 * mirror in streaming mode
 	 */
 	bool 		is_for_gp_walreceiver;
-=======
-	/* Statistics for transactions spilled to disk. */
-	int64		spillTxns;
-	int64		spillCount;
-	int64		spillBytes;
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 } WalSnd;
 
 extern WalSnd *MyWalSnd;


### PR DESCRIPTION
Resolve conflicts in src/include/replication/walsender_private.h

Commit 9290ad1 added new fields spillTxns, spillCount and spillBytes to the
WalSnd structure, while earlier commit e03a755 already added a new
GPDB-specific field is_for_gp_walreceiver to the same place.