### PR TITLE
Resolve conflicts in reloptions.c and tablecmds.c

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1160,7 +1160,7 @@ extractRelOptions(HeapTuple tuple, TupleDesc tupdesc,
  * returned array.  Values of type string are allocated separately and must
  * be freed by the caller.
  */
-static relopt_value *
+relopt_value *
 parseRelOptions(Datum options, bool validate, relopt_kind kind,
 				int *numrelopts)
 {

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1608,12 +1608,10 @@ bytea *
 partitioned_table_reloptions(Datum reloptions, bool validate)
 {
 	/*
-	 * There are no options for partitioned tables yet, but this is able to do
-	 * some validation.
+	 * GPDB: we maintain reloptions for partition roots to support reloption
+	 * inheritance and hierarchy wide ALTER TABLE SET().
 	 */
-	return (bytea *) build_reloptions(reloptions, validate,
-									  RELOPT_KIND_PARTITIONED,
-									  0, NULL, 0);
+	return default_reloptions(reloptions, validate, RELOPT_KIND_HEAP);
 }
 
 /*
@@ -1658,19 +1656,7 @@ heap_reloptions(char relkind, Datum reloptions, bool validate)
 			return (bytea *) rdopts;
 		case RELKIND_RELATION:
 		case RELKIND_MATVIEW:
-<<<<<<< HEAD
-				return default_reloptions(reloptions, validate,
-										  RELOPT_KIND_HEAP);
-		case RELKIND_PARTITIONED_TABLE:
-			/*
-			 * GPDB: we maintain reloptions for partition roots to support reloption
-			 * inheritance and hierarchy wide ALTER TABLE SET().
-			 */
-			return default_reloptions(reloptions, validate,
-									  RELOPT_KIND_HEAP);
-=======
 			return default_reloptions(reloptions, validate, RELOPT_KIND_HEAP);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 		default:
 			/* other relkinds are not supported */
 			return NULL;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -119,7 +119,6 @@
 #include "utils/timestamp.h"
 #include "utils/typcache.h"
 
-<<<<<<< HEAD
 #include "access/appendonly_compaction.h"
 #include "access/bitmap_private.h"
 #include "access/external.h"
@@ -135,8 +134,6 @@
 
 const char *synthetic_sql = "(internally generated SQL command)";
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*
  * ON COMMIT action list
  */
@@ -828,7 +825,6 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	reloptions = transformRelOptions((Datum) oldoptions, stmt->options, NULL, validnsps,
 									 true, false);
 
-<<<<<<< HEAD
 	/*
 	 * Greenplum: special case checks for reloptions that correspond to
 	 * appendonly relations. This check can not be performed earlier because it
@@ -857,12 +853,8 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 									 (accessMethodId == AO_COLUMN_TABLE_AM_OID));
 
 		reloptions = transformAOStdRdOptions(stdRdOptions, reloptions);
-	} else if (relkind == RELKIND_VIEW)
-		(void) view_reloptions(reloptions, true);
-	else
-		(void) heap_reloptions(relkind, reloptions, true);
-=======
-	switch (relkind)
+	}
+	else switch (relkind)
 	{
 		case RELKIND_VIEW:
 			(void) view_reloptions(reloptions, true);
@@ -873,7 +865,6 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		default:
 			(void) heap_reloptions(relkind, reloptions, true);
 	}
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 	if (stmt->ofTypename)
 	{
@@ -14420,7 +14411,6 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 		case RELKIND_RELATION:
 		case RELKIND_TOASTVALUE:
 		case RELKIND_MATVIEW:
-<<<<<<< HEAD
 		case RELKIND_PARTITIONED_TABLE:
 		case RELKIND_AOSEGMENTS:
 		case RELKIND_AOBLOCKDIR:
@@ -14441,14 +14431,10 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 					*aoopt_changed = !relOptionsEquals(datum, newOptions);
 
 			}
+			else if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+				(void) partitioned_table_reloptions(newOptions, true);
 			else
 				(void) heap_reloptions(rel->rd_rel->relkind, newOptions, true);
-=======
-			(void) heap_reloptions(rel->rd_rel->relkind, newOptions, true);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
-			break;
-		case RELKIND_PARTITIONED_TABLE:
-			(void) partitioned_table_reloptions(newOptions, true);
 			break;
 		case RELKIND_VIEW:
 			(void) view_reloptions(newOptions, true);

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -204,6 +204,8 @@ extern Datum transformRelOptions(Datum oldOptions, List *defList,
 extern List *untransformRelOptions(Datum options);
 extern bytea *extractRelOptions(HeapTuple tuple, TupleDesc tupdesc,
 								amoptions_function amoptions);
+extern relopt_value *parseRelOptions(Datum options, bool validate,
+									 relopt_kind kind, int *numrelopts);
 extern void *build_reloptions(Datum reloptions, bool validate,
 							  relopt_kind kind,
 							  Size relopt_struct_size,


### PR DESCRIPTION
Resolve conflicts in reloptions.c and tablecmds.c

1) Commit 1bbd608 removed the default_reloptions call from the heap_reloptions
function in src/backend/access/common/reloptions.c for the
RELKIND_PARTITIONED_TABLE case, while earlier commit 2cb8a3d changed the type
of this call from RELOPT_KIND_PARTITIONED to RELOPT_KIND_HEAP.

2) Commit 14aec03 removed the empty line before the OnCommitItem structure
definition in src/backend/commands/tablecmds.c, while earlier commit 19cd1cf
had already added a new global variable synthetic_sql in the same place.

3) Commit 1bbd608 changed the relkind condition to a switch case in
src/backend/commands/tablecmds.c in the DefineRelation function, while the
earlier commit 19cd1cf had already added GPDB-specific logic before this place.

4) Commit 1bbd608 split the case for RELKIND_PARTITIONED_TABLE in
src/backend/commands/tablecmds.c in the ATExecSetRelOptions function, while the
earlier commit 6b0e52b had already added GPDB-specific cases to the same place.

5) Commit 50d22de made the public function parseRelOptions private, but it is
already used in GPDB-specific code in src/backend/access/common/reloptions_gp.c
and src/backend/commands/cluster.c.