### PR TITLE
Resolve conflicts in src/backend/catalog/aclchk.c

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -82,7 +82,6 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbvars.h"
 
@@ -92,8 +91,6 @@
  */
 bool		revoked_something = false;
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*
  * Internal format used by ALTER DEFAULT PRIVILEGES.
  */


### PR DESCRIPTION
Resolve conflicts in src/backend/catalog/aclchk.c

Commit 14aec03 removed an empty line before the comment to the
revoked_something global variable in src/backend/catalog/aclchk.c, while
earlier GPDB-specific includes had been added to the same place.