### PR TITLE
Resolve conflicts caused by sorting of includes

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -51,11 +51,7 @@
 #include "catalog/pg_depend.h"
 #include "catalog/pg_description.h"
 #include "catalog/pg_inherits.h"
-<<<<<<< HEAD
 #include "catalog/pg_namespace.h"
-#include "catalog/pg_operator.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_operator.h"
 #include "catalog/pg_tablespace.h"
@@ -86,12 +82,10 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/pg_rusage.h"
-<<<<<<< HEAD
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
-#include "utils/snapmgr.h"
 
 #include "catalog/oid_dispatch.h"
 #include "cdb/cdbappendonlyam.h"
@@ -99,11 +93,6 @@
 #include "cdb/cdbvars.h"
 #include "cdb/cdboidsync.h"
 #include "utils/faultinjector.h"
-=======
-#include "utils/snapmgr.h"
-#include "utils/syscache.h"
-#include "utils/tuplesort.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_index_pg_class_oid = InvalidOid;

--- a/src/backend/catalog/pg_enum.c
+++ b/src/backend/catalog/pg_enum.c
@@ -22,11 +22,7 @@
 #include "catalog/indexing.h"
 #include "catalog/pg_enum.h"
 #include "catalog/pg_type.h"
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
-#include "storage/lmgr.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "miscadmin.h"
 #include "nodes/value.h"
 #include "storage/lmgr.h"
@@ -37,13 +33,10 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "catalog/oid_dispatch.h"
 
-=======
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_pg_enum_oid = InvalidOid;
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /*
  * Hash table of enum value OIDs created during the current transaction by

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -26,12 +26,9 @@
 #include "access/xlogutils.h"
 #include "catalog/storage.h"
 #include "catalog/storage_xlog.h"
-<<<<<<< HEAD
-#include "common/relpath.h"
 #include "commands/dbcommands.h"
-=======
+#include "common/relpath.h"
 #include "miscadmin.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "storage/freespace.h"
 #include "storage/smgr.h"
 #include "utils/memutils.h"

--- a/src/backend/commands/alter.c
+++ b/src/backend/commands/alter.c
@@ -69,13 +69,9 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdisp_query.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static Oid	AlterObjectNamespace_internal(Relation rel, Oid objid, Oid nspOid);
 
 /*

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -35,15 +35,12 @@
 #include "catalog/index.h"
 #include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
-<<<<<<< HEAD
+#include "catalog/pg_am.h"
 #include "catalog/pg_appendonly.h"
 #include "catalog/pg_attribute_encoding.h"
-#include "catalog/pg_type.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_tablespace.h"
-=======
-#include "catalog/pg_am.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#include "catalog/pg_type.h"
 #include "catalog/toasting.h"
 #include "commands/cluster.h"
 #include "commands/progress.h"
@@ -68,7 +65,6 @@
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
 
-<<<<<<< HEAD
 #include "catalog/aocatalog.h"
 #include "catalog/oid_dispatch.h"
 #include "cdb/cdbvars.h"
@@ -76,8 +72,6 @@
 #include "cdb/cdboidsync.h"
 #include "libpq/pqformat.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*
  * This struct is used to pass around the information on tables to be
  * clustered. We need this so we can make a list of them when invoked without

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -63,7 +63,6 @@
 #include "utils/rls.h"
 #include "utils/snapmgr.h"
 
-<<<<<<< HEAD
 #include "access/external.h"
 #include "access/url.h"
 #include "catalog/catalog.h"
@@ -84,9 +83,6 @@
 #include "utils/resscheduler.h"
 #include "utils/string_utils.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #define ISOCTAL(c) (((c) >= '0') && ((c) <= '7'))
 #define OCTVALUE(c) ((c) - '0')
 

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -52,7 +52,6 @@
 #include "utils/rls.h"
 #include "utils/snapmgr.h"
 
-<<<<<<< HEAD
 #include "catalog/oid_dispatch.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbaocsam.h"
@@ -63,8 +62,6 @@
 #include "cdb/memquota.h"
 #include "utils/metrics_utils.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 typedef struct
 {
 	DestReceiver pub;			/* publicly-known function pointers */

--- a/src/backend/commands/opclasscmds.c
+++ b/src/backend/commands/opclasscmds.c
@@ -51,13 +51,9 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdisp_query.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static void AlterOpFamilyAdd(AlterOpFamilyStmt *stmt,
 							 Oid amoid, Oid opfamilyoid,
 							 int maxOpNumber, int maxProcNumber,

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -24,11 +24,8 @@
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
-<<<<<<< HEAD
 #include "catalog/oid_dispatch.h"
-=======
 #include "catalog/pg_authid.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "catalog/pg_namespace.h"
 #include "commands/dbcommands.h"
 #include "commands/event_trigger.h"
@@ -41,14 +38,10 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbvars.h"
 #include "cdb/cdbsreh.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static void AlterSchemaOwner_internal(HeapTuple tup, Relation rel, Oid newOwnerId);
 
 /*

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -98,7 +98,6 @@
 #include "utils/tarrable.h"
 #include "utils/varlena.h"
 
-<<<<<<< HEAD
 #include "catalog/heap.h"
 #include "catalog/oid_dispatch.h"
 #include "cdb/cdbdisp_query.h"
@@ -106,9 +105,6 @@
 #include "cdb/cdbutil.h"
 #include "miscadmin.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* GUC variables */
 char	   *default_tablespace = NULL;
 char	   *temp_tablespaces = NULL;

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -39,14 +39,10 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbvars.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static void checkViewTupleDesc(TupleDesc newdesc, TupleDesc olddesc);
 
 /*---------------------------------------------------------------------

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -30,10 +30,7 @@
 #include "executor/nodeFunctionscan.h"
 #include "executor/nodeGather.h"
 #include "executor/nodeGatherMerge.h"
-<<<<<<< HEAD
-=======
 #include "executor/nodeGroup.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "executor/nodeHash.h"
 #include "executor/nodeHashjoin.h"
 #include "executor/nodeIndexonlyscan.h"
@@ -76,12 +73,8 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
-
-static bool TargetListSupportsBackwardScan(List *targetlist);
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static bool IndexSupportsBackwardScan(Oid indexid);
+static bool TargetListSupportsBackwardScan(List *targetlist);
 
 
 /*

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -30,7 +30,7 @@
 #include "executor/nodeFunctionscan.h"
 #include "executor/nodeGather.h"
 #include "executor/nodeGatherMerge.h"
-#include "executor/nodeGroup.h"
+// #include "executor/nodeGroup.h" // Group node has been disabled in GPDB
 #include "executor/nodeHash.h"
 #include "executor/nodeHashjoin.h"
 #include "executor/nodeIndexonlyscan.h"

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -77,13 +77,9 @@
 #include "utils/typcache.h"
 #include "utils/xml.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 #include "utils/fmgroids.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*
  * Use computed-goto-based opcode dispatch when computed gotos are available.
  * But use a separate symbol so that it's easy to adjust locally in this file

--- a/src/backend/executor/execGrouping.c
+++ b/src/backend/executor/execGrouping.c
@@ -24,10 +24,6 @@
 #include "common/hashfn.h"
 #include "executor/executor.h"
 #include "miscadmin.h"
-<<<<<<< HEAD
-=======
-#include "utils/hashutils.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -118,7 +118,7 @@
 #include "executor/nodeWindowAgg.h"
 #include "executor/nodeWorktablescan.h"
 #include "miscadmin.h"
-<<<<<<< HEAD
+#include "nodes/nodeFuncs.h"
 
 #include "cdb/cdbvars.h"
 #include "cdb/ml_ipc.h"			/* interconnect context */
@@ -157,9 +157,6 @@ static CdbVisitOpt planstate_walk_kids(PlanState *planstate,
 				 CdbVisitOpt (*walker) (PlanState *planstate, void *context),
 					void *context,
 					int flags);
-=======
-#include "nodes/nodeFuncs.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 static TupleTableSlot *ExecProcNodeFirst(PlanState *node);
 #if 0

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -69,11 +69,8 @@
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static TupleDesc ExecTypeFromTLInternal(List *targetList,
 										bool skipjunk);
 static pg_attribute_always_inline void slot_deform_heap_tuple(TupleTableSlot *slot, HeapTuple tuple, uint32 *offp,

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -270,10 +270,7 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
-<<<<<<< HEAD
 #include "utils/dynahash.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "utils/expandeddatum.h"
 #include "utils/faultinjector.h"
 #include "utils/logtape.h"
@@ -281,8 +278,6 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
-<<<<<<< HEAD
-#include "utils/datum.h"
 
 #include "cdb/cdbexplain.h"
 #include "lib/stringinfo.h"             /* StringInfo */
@@ -381,8 +376,6 @@ typedef struct HashAggBatch
 	int				 input_tapenum;	/* input partition tape */
 	int64			 input_tuples;	/* number of tuples in this batch */
 } HashAggBatch;
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 static void select_current_set(AggState *aggstate, int setno, bool is_hash);
 static void initialize_phase(AggState *aggstate, int newphase);

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -58,12 +58,9 @@
 #include "nodes/tidbitmap.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
-<<<<<<< HEAD
+#include "utils/spccache.h"
 
 #include "cdb/cdbvars.h" /* gp_select_invisible */
-=======
-#include "utils/spccache.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 static TupleTableSlot *BitmapHeapNext(BitmapHeapScanState *node);
 static inline void BitmapDoneInitializingSharedState(ParallelBitmapHeapState *pstate);

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -42,19 +42,14 @@
 #include "port/atomics.h"
 #include "utils/dynahash.h"
 #include "utils/lsyscache.h"
-<<<<<<< HEAD
 #include "utils/faultinjector.h"
+#include "utils/memutils.h"
 #include "utils/syscache.h"
 
 #include "cdb/cdbexplain.h"
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
-=======
-#include "utils/memutils.h"
-#include "utils/syscache.h"
-
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static void ExecHashIncreaseNumBatches(HashJoinTable hashtable);
 static void ExecHashIncreaseNumBuckets(HashJoinTable hashtable);
 static void ExecParallelHashIncreaseNumBatches(HashJoinTable hashtable);

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -49,11 +49,8 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
-<<<<<<< HEAD
-#include "utils/faultinjector.h"
-=======
 #include "utils/expandeddatum.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/regproc.h"

--- a/src/backend/jit/llvm/llvmjit.c
+++ b/src/backend/jit/llvm/llvmjit.c
@@ -34,8 +34,6 @@
 #include <llvm-c/Transforms/Utils.h>
 #endif
 
-<<<<<<< HEAD
-=======
 #include "jit/llvmjit.h"
 #include "jit/llvmjit_emit.h"
 #include "miscadmin.h"
@@ -44,7 +42,6 @@
 #include "utils/memutils.h"
 #include "utils/resowner_private.h"
 
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* Handle of a module emitted via ORC JIT */
 typedef struct LLVMJitHandle
 {

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -39,7 +39,6 @@
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 
-<<<<<<< HEAD
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "catalog/indexing.h"
@@ -63,8 +62,6 @@ extern bool gp_reject_internal_tcp_conn;
 int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
 #endif
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*----------------------------------------------------------------
  * Global authentication functions
  *----------------------------------------------------------------

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -29,12 +29,9 @@
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"
-<<<<<<< HEAD
 #include "statistics/statistics.h"
 
 #include "cdb/cdbvars.h"        /* cdb GUCs */
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /*
  * Data structure for accumulating info about possible range-query

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -36,15 +36,11 @@
 #include "rewrite/rewriteManip.h"
 #include "utils/lsyscache.h"
 
-<<<<<<< HEAD
 #include "access/heapam.h"
 #include "cdb/cdbmutate.h"
 #include "nodes/makefuncs.h"
 #include "parser/parsetree.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* These parameters are set by GUC */
 int			from_collapse_limit;
 int			join_collapse_limit;

--- a/src/backend/optimizer/plan/planagg.c
+++ b/src/backend/optimizer/plan/planagg.c
@@ -49,15 +49,11 @@
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbpath.h"
 #include "cdb/cdbsetop.h"
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static bool find_minmax_aggs_walker(Node *node, List **context);
 static bool build_minmax_path(PlannerInfo *root, MinMaxAggInfo *mminfo,
 							  Oid eqop, Oid sortop, bool nulls_first);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -56,13 +56,9 @@
 #include "optimizer/transform.h"
 #include "optimizer/tlist.h"
 #include "parser/analyze.h"
-<<<<<<< HEAD
 #include "parser/parse_oper.h"
-#include "parser/parse_relation.h"
-#include "parser/parsetree.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "parser/parse_agg.h"
+#include "parser/parse_relation.h"
 #include "parser/parsetree.h"
 #include "partitioning/partdesc.h"
 #include "rewrite/rewriteManip.h"
@@ -72,7 +68,6 @@
 #include "utils/selfuncs.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "catalog/pg_proc.h"
 #include "cdb/cdbhash.h"
 #include "cdb/cdbllize.h"
@@ -90,9 +85,6 @@
 #include "storage/lmgr.h"
 #include "utils/guc.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* GUC parameters */
 double		cursor_tuple_fraction = DEFAULT_CURSOR_TUPLE_FRACTION;
 int			force_parallel_mode = FORCE_PARALLEL_OFF;

--- a/src/backend/optimizer/prep/preptlist.c
+++ b/src/backend/optimizer/prep/preptlist.c
@@ -54,7 +54,6 @@
 #include "rewrite/rewriteHandler.h"
 #include "utils/rel.h"
 
-<<<<<<< HEAD
 #include "catalog/gp_distribution_policy.h"     /* CDB: POLICYTYPE_PARTITIONED */
 #include "catalog/pg_inherits.h"
 #include "optimizer/plancat.h"
@@ -62,9 +61,6 @@
 #include "utils/lsyscache.h"
 
 static List *expand_targetlist(PlannerInfo *root, List *tlist, int command_type,
-=======
-static List *expand_targetlist(List *tlist, int command_type,
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 							   Index result_relation, Relation rel);
 static List *supplement_simply_updatable_targetlist(PlannerInfo *root,
 													List *range_table,

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -38,7 +38,6 @@
 #include "utils/selfuncs.h"
 #include "optimizer/tlist.h"
 
-<<<<<<< HEAD
 #include "catalog/pg_operator.h"
 #include "catalog/pg_proc.h"
 #include "cdb/cdbhash.h"        /* cdb_default_distribution_opfamily_for_type() */
@@ -50,8 +49,6 @@
 #include "executor/nodeHash.h"
 #include "utils/guc.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 typedef enum
 {
 	COSTS_EQUAL,				/* path costs are fuzzily equal */

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -54,7 +54,7 @@
 #include "utils/partcache.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
-<<<<<<< HEAD
+#include "utils/syscache.h"
 
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbrelsize.h"
@@ -62,10 +62,6 @@
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_inherits.h"
 #include "utils/guc.h"
-
-=======
-#include "utils/syscache.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /* GUC parameter */
 int			constraint_exclusion = CONSTRAINT_EXCLUSION_PARTITION;

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -52,15 +52,12 @@
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
-<<<<<<< HEAD
+#include "utils/syscache.h"
 
 #include "catalog/pg_operator.h"
 #include "cdb/cdbvars.h"
 #include "utils/builtins.h"
 #include "utils/regproc.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
-#include "utils/syscache.h"
 
 /* Convenience macro for the most common makeNamespaceItem() case */
 #define makeDefaultNSItem(rte)	makeNamespaceItem(rte, true, true, false, true)

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -40,12 +40,8 @@
 #include "utils/syscache.h"
 #include "utils/varlena.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #define MAX_FUZZY_DISTANCE				3
 
 static RangeTblEntry *scanNameSpaceForRefname(ParseState *pstate,

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -14,11 +14,6 @@
 
 #include <unistd.h>
 
-<<<<<<< HEAD
-#include "cdb/ic_proxy_bgworker.h"
-#include "libpq/pqsignal.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "access/parallel.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
@@ -42,6 +37,7 @@
 #include "utils/ps_status.h"
 #include "utils/timeout.h"
 
+#include "cdb/ic_proxy_bgworker.h"
 #include "postmaster/backoff.h"
 #include "postmaster/fts.h"
 #include "utils/gdd.h"

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -70,7 +70,6 @@
 #include "utils/snapmgr.h"
 #include "utils/timestamp.h"
 
-<<<<<<< HEAD
 #include "libpq-int.h"
 #include "cdb/cdbconn.h"
 #include "cdb/cdbdispatchresult.h"
@@ -81,9 +80,6 @@
 #include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* ----------
  * Timer definitions.
  * ----------

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -42,7 +42,6 @@
 #include "utils/relcache.h"
 #include "utils/timestamp.h"
 
-<<<<<<< HEAD
 #include "access/genam.h"
 #include "access/hash.h"
 #include "access/xact.h"
@@ -60,9 +59,6 @@
 #include "utils/snapmgr.h"
 #include "utils/tarrable.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 typedef struct
 {
 	const char *label;

--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -19,16 +19,11 @@
 #include <unistd.h>
 #include <sys/time.h>
 
-<<<<<<< HEAD
-#include "libpq-fe.h"
-#include "libpq/pqcomm.h"
-#include "pqexpbuffer.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "access/xlog.h"
 #include "catalog/pg_type.h"
 #include "funcapi.h"
 #include "libpq-fe.h"
+#include "libpq/pqcomm.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "pgstat.h"

--- a/src/backend/replication/logical/logicalfuncs.c
+++ b/src/backend/replication/logical/logicalfuncs.c
@@ -17,13 +17,6 @@
 
 #include <unistd.h>
 
-<<<<<<< HEAD
-#include "fmgr.h"
-#include "funcapi.h"
-#include "miscadmin.h"
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogutils.h"

--- a/src/backend/statistics/dependencies.c
+++ b/src/backend/statistics/dependencies.c
@@ -22,12 +22,9 @@
 #include "nodes/nodeFuncs.h"
 #include "nodes/nodes.h"
 #include "nodes/pathnodes.h"
-<<<<<<< HEAD
-#include "parser/parsetree.h"
-=======
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#include "parser/parsetree.h"
 #include "statistics/extended_stats_internal.h"
 #include "statistics/statistics.h"
 #include "utils/bytea.h"

--- a/src/backend/storage/buffer/buf_init.c
+++ b/src/backend/storage/buffer/buf_init.c
@@ -14,7 +14,6 @@
  */
 #include "postgres.h"
 
-<<<<<<< HEAD
 #include <sys/mman.h>
 
 #ifdef MPROTECT_BUFFERS
@@ -22,9 +21,6 @@
 #include "miscadmin.h"
 #endif
 
-#include "storage/bufmgr.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -96,21 +96,10 @@
 #include "utils/workfile_mgr.h"
 #include "utils/faultinjector.h"
 
-<<<<<<< HEAD
 // Provide some indirection here in case we have problems with lseek and
 // 64 bits on some platforms
 #define pg_lseek64(a,b,c) (int64)lseek(a,b,c)
 
-
-/* Define PG_FLUSH_DATA_WORKS if we have an implementation for pg_flush_data */
-#if defined(HAVE_SYNC_FILE_RANGE)
-#define PG_FLUSH_DATA_WORKS 1
-#elif defined(USE_POSIX_FADVISE) && defined(POSIX_FADV_DONTNEED)
-#define PG_FLUSH_DATA_WORKS 1
-#endif
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* Define PG_FLUSH_DATA_WORKS if we have an implementation for pg_flush_data */
 #if defined(HAVE_SYNC_FILE_RANGE)
 #define PG_FLUSH_DATA_WORKS 1

--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -29,11 +29,8 @@
 #include "tcop/tcopprot.h"
 #include "utils/resgroup.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*
  * The SIGUSR1 signal is multiplexed to support signalling multiple event
  * types. The specific reason is communicated via flags in shared memory.

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -58,28 +58,21 @@
 #include "storage/procarray.h"
 #include "storage/procsignal.h"
 #include "storage/spin.h"
-<<<<<<< HEAD
-#include "utils/faultinjector.h"
+#include "storage/standby.h"
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
-
-#include "utils/sharedsnapshot.h"  /*SharedLocalSnapshotSlot*/
 
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbtm.h"
 #include "cdb/cdbvars.h"  /*Gp_is_writer*/
 #include "port/atomics.h"
 #include "postmaster/fts.h"
+#include "utils/faultinjector.h"
 #include "utils/resource_manager.h"
 #include "utils/resscheduler.h"
 #include "utils/session_state.h"
+#include "utils/sharedsnapshot.h"  /*SharedLocalSnapshotSlot*/
 
-=======
-#include "storage/standby.h"
-#include "utils/timeout.h"
-#include "utils/timestamp.h"
-
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* GUC variables */
 int			DeadlockTimeout = 1000;
 int			StatementTimeout = 0;

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -27,14 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-<<<<<<< HEAD
-#include "access/aomd.h"
-#include "access/htup_details.h"
-#include "catalog/catalog.h"
-#include "miscadmin.h"
 #include "access/xlogutils.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "access/xlog.h"
 #include "access/xlogutils.h"
 #include "commands/tablespace.h"
@@ -51,6 +44,9 @@
 #include "utils/hsearch.h"
 #include "utils/memutils.h"
 
+#include "access/aomd.h"
+#include "access/htup_details.h"
+#include "catalog/catalog.h"
 #include "catalog/pg_tablespace.h"
 #include "utils/faultinjector.h"
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -87,8 +87,6 @@
 #include "utils/snapmgr.h"
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
-<<<<<<< HEAD
-#include "mb/pg_wchar.h"
 
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
@@ -104,11 +102,8 @@
 #include "access/twophase.h"
 #include "postmaster/backoff.h"
 #include "utils/resource_manager.h"
-
 #include "utils/session_state.h"
 #include "utils/vmem_tracker.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /* ----------------
  *		global variables

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -20,12 +20,7 @@
 #include "catalog/catalog.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_auth_members.h"
-<<<<<<< HEAD
-#include "catalog/pg_type.h"
-#include "cdb/cdbvars.h"
-=======
 #include "catalog/pg_authid.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "catalog/pg_class.h"
 #include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
@@ -45,6 +40,8 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/varlena.h"
+
+#include "cdb/cdbvars.h"
 
 typedef struct
 {

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -32,7 +32,6 @@
 #include "utils/memutils.h"
 #include "utils/tzparser.h"
 
-<<<<<<< HEAD
 /*
  * We don't support locale-aware month names or day-of-week names, or non-arabic numbers,
  * and we know the only alpha or numeric chars we can handle are in the ASCII7 set.
@@ -46,8 +45,6 @@
 #undef isalnum
 #define isalnum(x) (isalpha(x) || isdigit(x))
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static int	DecodeNumber(int flen, char *field, bool haveTextMonth,
 						 int fmask, int *tmask,
 						 struct pg_tm *tm, fsec_t *fsec, bool *is2digits);

--- a/src/backend/utils/adt/misc.c
+++ b/src/backend/utils/adt/misc.c
@@ -40,16 +40,12 @@
 #include "utils/ruleutils.h"
 #include "utils/timestamp.h"
 
-<<<<<<< HEAD
 #include "catalog/pg_authid.h"
 #include "postmaster/fts.h"
 #include "storage/pmsignal.h"
 #include "storage/procarray.h"
 #include "utils/backend_cancel.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /*
  * Common subroutine for num_nulls() and num_nonnulls().
  * Returns true if successful, false if function should return NULL.

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -77,11 +77,8 @@
 #include "utils/varlena.h"
 #include "utils/xml.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbhash.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* ----------
  * Pretty formatting constants
  * ----------

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -50,11 +50,8 @@
 #include "catalog/pg_amproc.h"
 #include "catalog/pg_attrdef.h"
 #include "catalog/pg_auth_members.h"
-<<<<<<< HEAD
 #include "catalog/pg_auth_time_constraint.h"
-=======
 #include "catalog/pg_authid.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_database.h"
 #include "catalog/pg_namespace.h"
@@ -96,7 +93,6 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "access/transam.h"
 #include "catalog/gp_distribution_policy.h"         /* GpPolicy */
 #include "catalog/heap.h"
@@ -105,11 +101,7 @@
 #include "cdb/cdbvars.h"        /* Gp_role */
 #include "cdb/cdbsreh.h"
 
-
 #define RELCACHE_INIT_FILEMAGIC		0x773266	/* version ID value */
-=======
-#define RELCACHE_INIT_FILEMAGIC		0x573266	/* version ID value */
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /*
  * Default policy for whether to apply RECOVER_RELATION_BUILD_MEMORY:

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -80,13 +80,9 @@
 #include "utils/syscache.h"
 #include "utils/timeout.h"
 
-<<<<<<< HEAD
 #include "utils/resource_manager.h"
 #include "utils/session_state.h"
 
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static HeapTuple GetDatabaseTuple(const char *dbname);
 static HeapTuple GetDatabaseTupleByOid(Oid dboid);
 static void PerformAuthentication(Port *port);

--- a/src/backend/utils/misc/superuser.c
+++ b/src/backend/utils/misc/superuser.c
@@ -25,12 +25,8 @@
 #include "miscadmin.h"
 #include "utils/inval.h"
 #include "utils/syscache.h"
-<<<<<<< HEAD
-#include "storage/proc.h"
-#include "miscadmin.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
+#include "storage/proc.h"
 
 /*
  * In common cases the same roleid (ie, the session or current ID) will

--- a/src/backend/utils/time/combocid.c
+++ b/src/backend/utils/time/combocid.c
@@ -53,14 +53,11 @@
 #include "utils/hsearch.h"
 #include "utils/memutils.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 #include "storage/proc.h"
 #include "storage/dsm.h"
 #include "utils/resowner.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 /* Hash table to lookup combo cids by cmin and cmax */
 static HTAB *comboHash = NULL;
 

--- a/src/pl/plpython/plpy_elog.c
+++ b/src/pl/plpython/plpy_elog.c
@@ -7,13 +7,7 @@
 #include "postgres.h"
 
 #include "lib/stringinfo.h"
-<<<<<<< HEAD
 #include "miscadmin.h"
-
-#include "plpython.h"
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "plpy_elog.h"
 #include "plpy_main.h"
 #include "plpy_procedure.h"

--- a/src/pl/plpython/plpy_plpymodule.c
+++ b/src/pl/plpython/plpy_plpymodule.c
@@ -16,14 +16,9 @@
 #include "plpy_resultobject.h"
 #include "plpy_spi.h"
 #include "plpy_subxactobject.h"
-<<<<<<< HEAD
-#include "plpy_main.h"
-
-=======
 #include "plpython.h"
 #include "utils/builtins.h"
 #include "utils/snapmgr.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 HTAB	   *PLy_spi_exceptions = NULL;
 

--- a/src/pl/plpython/plpy_spi.c
+++ b/src/pl/plpython/plpy_spi.c
@@ -13,18 +13,6 @@
 #include "catalog/pg_type.h"
 #include "executor/spi.h"
 #include "mb/pg_wchar.h"
-#include "parser/parse_type.h"
-<<<<<<< HEAD
-#include "utils/memutils.h"
-#include "utils/syscache.h"
-#include "utils/faultinjector.h"
-
-#include "plpython.h"
-
-#include "plpy_spi.h"
-
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "plpy_elog.h"
 #include "plpy_main.h"
 #include "plpy_planobject.h"
@@ -35,6 +23,9 @@
 #include "plpython.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
+
+#include "parser/parse_type.h"
+#include "utils/faultinjector.h"
 
 static PyObject *PLy_spi_execute_query(char *query, long limit);
 static PyObject *PLy_spi_execute_fetch_result(SPITupleTable *tuptable,

--- a/src/pl/plpython/plpy_subxactobject.c
+++ b/src/pl/plpython/plpy_subxactobject.c
@@ -8,13 +8,10 @@
 
 #include "access/xact.h"
 #include "plpy_elog.h"
-<<<<<<< HEAD
 #include "plpy_main.h"
-=======
 #include "plpy_subxactobject.h"
 #include "plpython.h"
 #include "utils/memutils.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 List	   *explicit_subtransactions = NIL;
 


### PR DESCRIPTION
Resolve conflicts caused by sorting of includes

1) Commit 14aec03 sorted the includes in src/backend/catalog/index.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same location.

2) Commit 14aec03 sorted the includes in src/backend/catalog/pg_enum.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same location.

3) Commit 14aec03 sorted the includes in src/backend/catalog/storage.c, while
GPDB-specific includes had already been added to the same location.

4) Commit 14aec03 sorted the includes in src/backend/commands/alter.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

5) Commit 14aec03 sorted the includes in src/backend/commands/cluster.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

6) Commit 14aec03 sorted the includes in src/backend/commands/copy.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

7) Commit 14aec03 sorted the includes in src/backend/commands/createas.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

8) Commit 14aec03 sorted the includes in src/backend/commands/opclasscmds.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

9) Commit 14aec03 sorted the includes in src/backend/commands/schemacmds.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

10) Commit 14aec03 sorted the includes in src/backend/executor/execExprInterp.c
and removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

11) Commit 14aec03 sorted the includes in src/backend/executor/execGrouping.c,
while GPDB-specific includes had already been added to the same location.

12) Commit 14aec03 sorted the includes in src/backend/commands/tablespace.c and
removed the empty line after them, while earlier GPDB-specific includes had
already been added to that same place.

13) Commit 14aec03 sorted the includes in src/backend/commands/view.c and
removed the empty line after them, while earlier GPDB-specific includes had
already been added to that place.

14) Commit 14aec03 sorted the includes in src/backend/executor/execAmi.c and
removed the empty line after them, while earlier GPDB-specific includes and
functions had already been added to that place.

15) Commit 14aec03 sorted the includes in src/backend/executor/execProcnode.c
and removed the empty line after them, while earlier GPDB-specific includes and
functions had already been added to that place.

16) Commit 14aec03 sorted the includes in src/backend/executor/execTuples.c and
removed the empty line after them, while earlier GPDB-specific includes had
already been added to that place.

17) Commit 14aec03 sorted the includes in src/backend/executor/nodeAgg.c and
removed the empty line after them, while earlier GPDB-specific includes,
defines, and structures had already been added to that place.

18) Commit 14aec03 sorted the includes in
src/backend/executor/nodeBitmapHeapscan.c and removed the empty line after
them, while earlier GPDB-specific includes had already been added to that
place.

19) Commit 14aec03 sorted the includes in src/backend/executor/nodeHash.c and
removed the empty line after them, while earlier GPDB-specific includes had
already been added to that place.

20) Commit 14aec03 sorted the includes in the
src/backend/executor/nodeWindowAgg.c file, while GPDB-specific includes had
already been added to the same place.

21) Commit 14aec03 sorted the includes in src/backend/jit/llvm/llvmjit.c, while
GPDB-specific includes had already been added to the same location.

22) Commit 14aec03 sorted the includes in
src/backend/optimizer/path/clausesel.c and removed the empty line after them,
while earlier GPDB-specific includes had already been added to that place.

23) Commit 14aec03 sorted the includes in
src/backend/optimizer/plan/initsplan.c and removed the empty line after them,
while earlier GPDB-specific includes had already been added to that place.

24) Commit 14aec03 sorted the includes in src/backend/optimizer/plan/planagg.c
and removed the empty line after them, while earlier GPDB-specific includes had
already been added to that place.

25) Commit 14aec03 sorted the includes in src/backend/optimizer/plan/planner.c
and removed the empty line after them, while earlier GPDB-specific includes had
already been added to that place.

26) Commit 14aec03 sorted the includes in
src/backend/optimizer/prep/preptlist.c and removed the empty line after them,
while earlier GPDB-specific includes had already been added to that place.

27) Commit e048722 removed the empty line after the includes in
src/backend/libpq/auth.c, while GPDB-specific includes, variables and functions
were already added to the same place.

28) Commit 14aec03 sorted the includes in src/backend/optimizer/util/pathnode.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same place.

29) Commit 14aec03 sorted the includes in src/backend/optimizer/util/plancat.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same place.

30) Commit 14aec03 sorted the includes in src/backend/parser/parse_clause.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same place.

31) Commit 14aec03 sorted the includes in src/backend/parser/parse_relation.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same place.

32) Commit 14aec03 sorted the includes in src/backend/postmaster/bgworker.c,
while previously GPDB-specific includes were already added to the same
location.

33) Commit 14aec03 sorted the includes in src/backend/postmaster/pgstat.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

34) Commit 14aec03 sorted the includes in src/backend/replication/basebackup.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same location.

35) Commit 14aec03 sorted the includes in
src/backend/replication/libpqwalreceiver/libpqwalreceiver.c, while previously
GPDB-specific includes were already added to the same location.

36) Commit 14aec03 sorted the includes in
src/backend/replication/logical/logicalfuncs.c, while previously GPDB-specific
includes were already added to the same location.

37) Commit 14aec03 sorted the includes in
src/backend/statistics/dependencies.c, while previously GPDB-specific includes
were already added to the same location.

38) Commit 14aec03 sorted the includes in
src/backend/storage/buffer/buf_init.c, while previously GPDB-specific includes
were already added to the same location.

39) Commit 14aec03 sorted the includes in src/backend/storage/file/fd.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

40) Commit 14aec03 sorted the includes in src/backend/storage/ipc/procsignal.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same location.

41) Commit 14aec03 sorted the includes in src/backend/storage/lmgr/proc.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

42) Commit 14aec03 sorted the includes in src/backend/storage/smgr/md.c, while
previously GPDB-specific includes were already added to the same location.

43) Commit 14aec03 sorted the includes in src/backend/tcop/postgres.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

44) Commit 14aec03 sorted the includes in src/backend/utils/adt/acl.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

45) Commit 14aec03 removed the empty line after the includes in
src/backend/utils/adt/datetime.c, although GPDB-specific defines had already
been added to the same location.

46) Commit 14aec03 sorted the includes in src/backend/utils/adt/misc.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

47) Commit 14aec03 sorted the includes in src/backend/utils/adt/ruleutils.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

48) Commit 14aec03 sorted the includes in src/backend/utils/cache/relcache.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same location.

49) Commit 14aec03 sorted the includes in src/backend/utils/init/postinit.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

50) Commit 14aec03 sorted the includes in src/backend/utils/misc/superuser.c
and removed the empty line after them, while previously GPDB-specific includes
were already added to the same location.

51) Commit 14aec03 sorted the includes in src/backend/utils/time/combocid.c and
removed the empty line after them, while previously GPDB-specific includes were
already added to the same location.

52) Commit e048722 sorted the includes in src/pl/plpython/plpy_elog.c, while
previously GPDB-specific includes were already added to the same place.

53) Commit e048722 sorted the includes in src/pl/plpython/plpy_plpymodule.c,
while previously GPDB-specific includes were already added to the same place.

54) Commit e048722 sorted the includes in src/pl/plpython/plpy_spi.c, while
previously GPDB-specific includes were already added to the same place.

55) Commit e048722 sorted the includes in src/pl/plpython/plpy_subxactobject.c,
while previously GPDB-specific includes were already added to the same place.