### PR TITLE
Resolve conflicts in src/backend/commands/dbcommands.c

### DIFF
--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -73,7 +73,6 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "catalog/oid_dispatch.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
@@ -83,8 +82,6 @@
 
 #include "utils/pg_rusage.h"
 
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 typedef struct
 {
 	Oid			src_dboid;		/* source (template) DB */
@@ -1559,25 +1556,11 @@ movedb(const char *dbname, const char *tblspcname)
 
 	if (Gp_role == GP_ROLE_EXECUTE)
 	{
-<<<<<<< HEAD
 		/*
 		 * QE needs to release session level locks as can't Prepare Transaction
 		 * with session locks.
 		 */
 		MoveDbSessionLockRelease();
-=======
-		xl_dbase_drop_rec xlrec;
-
-		xlrec.db_id = db_id;
-		xlrec.ntablespaces = 1;
-
-		XLogBeginInsert();
-		XLogRegisterData((char *) &xlrec, sizeof(xl_dbase_drop_rec));
-		XLogRegisterData((char *) &src_tblspcoid, sizeof(Oid));
-
-		(void) XLogInsert(RM_DBASE_ID,
-						  XLOG_DBASE_DROP | XLR_SPECIAL_REL_UPDATE);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 	}
 
 	/*
@@ -1605,9 +1588,7 @@ movedb_failure_callback(int code, Datum arg)
 
 	(void) rmtree(dstpath, true);
 }
-<<<<<<< HEAD
 #endif
-=======
 
 /*
  * Process options and call dropdb function.
@@ -1633,7 +1614,6 @@ DropDatabase(ParseState *pstate, DropdbStmt *stmt)
 
 	dropdb(stmt->dbname, stmt->missing_ok, force);
 }
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /*
  * ALTER DATABASE name ...

--- a/src/include/utils/faultinjector_lists.h
+++ b/src/include/utils/faultinjector_lists.h
@@ -53,7 +53,7 @@ FI_TYPE(FaultInjectorTypeWaitUntilTriggered, "wait_until_triggered")
 #ifdef FI_DDL_STATEMENT
 FI_DDL_STATEMENT(DDLNotSpecified = 0, "")
 FI_DDL_STATEMENT(CreateDatabase, "create_database")
-FI_DDL_STATEMENT(DropDatabase, "drop_database")
+FI_DDL_STATEMENT(Drop_Database, "drop_database")
 FI_DDL_STATEMENT(CreateTable, "create_table")
 FI_DDL_STATEMENT(DropTable, "drop_table")
 FI_DDL_STATEMENT(CreateIndex, "create_index")


### PR DESCRIPTION
Resolve conflicts in src/backend/commands/dbcommands.c

1) Commit 14aec03 sorted the includes in src/backend/commands/dbcommands.c and
removed the empty line after them, while GPDB-specific includes had already
been added to the same place.

2) Commit e6d8069 added a call to XLogRegisterData in the moveb function in
src/backend/commands/dbcommands.c, while earlier commit ee951fd had already
added GPDB-specific logic nearby.

3) Commit 1379fd5 added a new DropDatabase function to
src/backend/commands/dbcommands.c, while an earlier commit 3adad71 added a
disable for movedb_failure_callback above that location.

4) The new DropDatabase function conflicts with a GPDB-specific macro of the
same name in src/include/utils/faultinjector_lists.h, so that macro has been
renamed.