### PR TITLE
Resolve conflict in src/backend/optimizer/prep/prepjointree.c

### DIFF
--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -87,13 +87,9 @@ static void pull_up_union_leaf_queries(Node *setOp, PlannerInfo *root,
 									   int parentRTindex, Query *setOpQuery,
 									   int childRToffset);
 static void make_setop_translation_list(Query *query, Index newvarno,
-<<<<<<< HEAD
-										List **translated_vars);
-=======
 										AppendRelInfo *appinfo);
 static bool is_simple_subquery(Query *subquery, RangeTblEntry *rte,
 							   JoinExpr *lowest_outer_join);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 static Node *pull_up_simple_values(PlannerInfo *root, Node *jtnode,
 								   RangeTblEntry *rte);
 static bool is_simple_values(PlannerInfo *root, RangeTblEntry *rte);

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -88,8 +88,6 @@ static void pull_up_union_leaf_queries(Node *setOp, PlannerInfo *root,
 									   int childRToffset);
 static void make_setop_translation_list(Query *query, Index newvarno,
 										AppendRelInfo *appinfo);
-static bool is_simple_subquery(Query *subquery, RangeTblEntry *rte,
-							   JoinExpr *lowest_outer_join);
 static Node *pull_up_simple_values(PlannerInfo *root, Node *jtnode,
 								   RangeTblEntry *rte);
 static bool is_simple_values(PlannerInfo *root, RangeTblEntry *rte);


### PR DESCRIPTION
Commit ce76c0b changed the argument of the make_setop_translation_list()
function. The conflict occured because the 19cd1cf moved declaration of the
is_simple_subquery() function.
