### PR TITLE
Resolve conflicts in src/backend/tcop/utility.c

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -41,11 +41,7 @@
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
 #include "commands/extension.h"
-<<<<<<< HEAD
 #include "commands/extprotocolcmds.h"
-#include "commands/matview.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "commands/lockcmds.h"
 #include "commands/matview.h"
 #include "commands/policy.h"
@@ -78,16 +74,13 @@
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
-<<<<<<< HEAD
+#include "utils/syscache.h"
 
 #include "access/table.h"
 #include "catalog/oid_dispatch.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbendpoint.h"
 #include "cdb/cdbvars.h"
-=======
-#include "utils/syscache.h"
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
@@ -675,10 +668,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			break;
 
 		case T_DropdbStmt:
-<<<<<<< HEAD
 			{
-				DropdbStmt *stmt = (DropdbStmt *) parsetree;
-
 				/* no event triggers for global objects */
 				if (Gp_role != GP_ROLE_EXECUTE)
 				{
@@ -688,13 +678,8 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 					 */
 					PreventInTransactionBlock(isTopLevel, "DROP DATABASE");
 				}
-				dropdb(stmt->dbname, stmt->missing_ok);
+				DropDatabase(pstate, (DropdbStmt *) parsetree);
 			}
-=======
-			/* no event triggers for global objects */
-			PreventInTransactionBlock(isTopLevel, "DROP DATABASE");
-			DropDatabase(pstate, (DropdbStmt *) parsetree);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 			break;
 
 			/* Query-level asynchronous notification */


### PR DESCRIPTION
Resolve conflicts in src/backend/tcop/utility.c

1) Commit 14aec03 sorted the includes in src/backend/tcop/utility.c, while
previously GPDB-specific includes were already added to the same place.

2) Commit 1379fd5 replaced the dropdb function call to DropDatabase in
standard_ProcessUtility in src/backend/tcop/utility.c, while earlier commit
c7649f1 had already added GPDB-specific logic to that place.