### PR TITLE
Resolve conflicts in src/backend/utils/misc/guc.c

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -88,11 +88,7 @@
 #include "tsearch/ts_cache.h"
 #include "utils/builtins.h"
 #include "utils/bytea.h"
-<<<<<<< HEAD
 #include "utils/faultinjector.h"
-#include "utils/guc_tables.h"
-=======
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 #include "utils/float.h"
 #include "utils/guc_tables.h"
 #include "utils/memutils.h"
@@ -1844,11 +1840,7 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
-<<<<<<< HEAD
 		{"allow_system_table_mods", PGC_USERSET, CUSTOM_OPTIONS,
-=======
-		{"allow_system_table_mods", PGC_SUSET, DEVELOPER_OPTIONS,
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 			gettext_noop("Allows modifications of the structure of system tables."),
 			NULL,
 			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/misc/guc.c

1) Commit 14aec03 sorted out the includes in src/backend/utils/misc/guc.c,
while previously GPDB-specific includes were already added to the same place.

2) Commit c4a7a39 replaced the allow_system_table_mods PGC_POSTMASTER option in
GUC with PGC_SUSET in src/backend/utils/misc/guc.c, while earlier commit
6b0e52b had already replaced the PGC_POSTMASTER option with PGC_USERSET in this
GUC.