### PR TITLE
Resolve conflicts in src/bin/pg_upgrade/check.c

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -955,7 +955,6 @@ check_for_isn_and_int8_passing_mismatch(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-<<<<<<< HEAD
 		gp_fatal_log(
 				"| Your installation contains \"contrib/isn\" functions which rely on the\n"
 				"| bigint data type.  Your old and new clusters pass bigint values\n"
@@ -964,15 +963,6 @@ check_for_isn_and_int8_passing_mismatch(ClusterInfo *cluster)
 				"| \"contrib/isn\" from the old cluster and restart the upgrade.  A list of\n"
 				"| the problem functions is in the file:\n"
 				"|     %s\n\n", output_path);
-=======
-		pg_fatal("Your installation contains \"contrib/isn\" functions which rely on the\n"
-				 "bigint data type.  Your old and new clusters pass bigint values\n"
-				 "differently so this cluster cannot currently be upgraded.  You can\n"
-				 "manually dump databases in the old cluster that use \"contrib/isn\"\n"
-				 "facilities, drop them, perform the upgrade, and then restore them.  A\n"
-				 "list of the problem functions is in the file:\n"
-				 "    %s\n\n", output_path);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 	}
 	else
 		check_ok();
@@ -1045,20 +1035,12 @@ check_for_tables_with_oids(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-<<<<<<< HEAD
 		gp_fatal_log(
 				"| Your installation contains tables declared WITH OIDS, which is not supported\n"
 				"| anymore. Consider removing the oid column using\n"
 				"|     ALTER TABLE ... SET WITHOUT OIDS;\n"
 				"| A list of tables with the problem is in the file:\n"
 				"|     %s\n\n", output_path);
-=======
-		pg_fatal("Your installation contains tables declared WITH OIDS, which is not\n"
-				 "supported anymore.  Consider removing the oid column using\n"
-				 "    ALTER TABLE ... SET WITHOUT OIDS;\n"
-				 "A list of tables with the problem is in the file:\n"
-				 "    %s\n\n", output_path);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 	}
 	else
 		check_ok();
@@ -1163,7 +1145,6 @@ check_for_reg_data_type_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-<<<<<<< HEAD
 		gp_fatal_log(
 				"| Your installation contains one of the reg* data types in user tables.\n"
 				"| These data types reference system OIDs that are not preserved by\n"
@@ -1171,14 +1152,6 @@ check_for_reg_data_type_usage(ClusterInfo *cluster)
 				"| remove the problem tables and restart the upgrade.  A list of the problem\n"
 				"| columns is in the file:\n"
 				"|     %s\n\n", output_path);
-=======
-		pg_fatal("Your installation contains one of the reg* data types in user tables.\n"
-				 "These data types reference system OIDs that are not preserved by\n"
-				 "pg_upgrade, so this cluster cannot currently be upgraded.  You can\n"
-				 "remove the problem tables and restart the upgrade.  A list of the\n"
-				 "problem columns is in the file:\n"
-				 "    %s\n\n", output_path);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 	}
 	else
 		check_ok();
@@ -1264,21 +1237,12 @@ check_for_jsonb_9_4_usage(ClusterInfo *cluster)
 	if (found)
 	{
 		pg_log(PG_REPORT, "fatal\n");
-<<<<<<< HEAD
 		gp_fatal_log(
 				"| Your installation contains the \"jsonb\" data type in user tables.\n"
 				"| The internal format of \"jsonb\" changed during 9.4 beta so this cluster cannot currently\n"
 				"| be upgraded.  You can remove the problem tables and restart the upgrade.  A list\n"
 				"| of the problem columns is in the file:\n"
 				"|     %s\n\n", output_path);
-=======
-		pg_fatal("Your installation contains the \"jsonb\" data type in user tables.\n"
-				 "The internal format of \"jsonb\" changed during 9.4 beta so this\n"
-				 "cluster cannot currently be upgraded.  You can remove the problem\n"
-				 "tables and restart the upgrade.  A list of the problem columns is\n"
-				 "in the file:\n"
-				 "    %s\n\n", output_path);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 	}
 	else
 		check_ok();


### PR DESCRIPTION
Resolve conflicts in src/bin/pg_upgrade/check.c

1) Commit f0b57ae changed the message in src/bin/pg_upgrade/check.c in the
function check_for_isn_and_int8_passing_mismatch, while earlier commit 9e89719
had already done this.

2) Commit 60b35b7 changed the messages in src/bin/pg_upgrade/check.c in the
functions check_for_tables_with_oids, check_for_reg_data_type_usage and
check_for_jsonb_9_4_usage, while earlier commit 9e89719 had already done this.