### PR TITLE
Fix logical_decoding_work_mem startup

### DIFF
--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -99,6 +99,7 @@
 		"log_min_messages",
 		"log_statement_stats",
 		"maintenance_work_mem",
+		"logical_decoding_work_mem",
 		"max_parallel_workers_per_gather",
 		"max_statement_mem",
 		"memory_profiler_dataset_id",


### PR DESCRIPTION
Fix logical_decoding_work_mem startup

The cec2edf commit added a new GUC logical_decoding_work_mem to
src/backend/utils/misc/guc.c, we need to add it to the GPDB-specific
sync_guc_name.h file.