### PR TITLE
Resolve conflicts in src/test/isolation/specs/vacuum-skip-locked.spec

### DIFF
--- a/src/test/isolation/specs/vacuum-skip-locked.spec
+++ b/src/test/isolation/specs/vacuum-skip-locked.spec
@@ -9,15 +9,12 @@ setup
 	CREATE TABLE part1 PARTITION OF parted FOR VALUES IN (1);
 	ALTER TABLE part1 SET (autovacuum_enabled = false);
 	CREATE TABLE part2 PARTITION OF parted FOR VALUES IN (2);
-<<<<<<< HEAD
+	ALTER TABLE part2 SET (autovacuum_enabled = false);
 
 	CREATE TABLE parted_ao (a INT) using ao_column
 		distributed by (a) PARTITION BY LIST (a);
 	CREATE TABLE part1_ao PARTITION OF parted_ao FOR VALUES IN (1);
 	CREATE TABLE part2_ao PARTITION OF parted_ao FOR VALUES IN (2);
-=======
-	ALTER TABLE part2 SET (autovacuum_enabled = false);
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 }
 
 teardown


### PR DESCRIPTION
Resolve conflicts in src/test/isolation/specs/vacuum-skip-locked.spec

Commit 3db0598 added disabling autovacuum for partitions part1 and part2 of the
parted table to the file src/test/isolation/specs/vacuum-skip-locked.spec,
while the earlier commit 2e7cafc already added to this test the creation of the
AO table parted_ao and two partitions part1_ao and part2_ao for it.