### PR TITLE
Allow usage of SIMPLE_FAULT_INJECTOR as an expression

### DIFF
--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -120,7 +120,7 @@ extern bool am_faulthandler;
 	FaultInjector_InjectFaultIfSet(FaultName, DDLNotSpecified, "", "")
 #else
 #define am_faulthandler false
-#define SIMPLE_FAULT_INJECTOR(FaultName)
+#define SIMPLE_FAULT_INJECTOR(FaultName) (FaultInjectorTypeNotSpecified)
 #endif
 
 #endif	/* FAULTINJECTOR_H */


### PR DESCRIPTION
Allow usage of SIMPLE_FAULT_INJECTOR as an expression.

Some extensions are using SIMPLE_FAULT_INJECTOR macro as an expression but 
do not define FAULT_INJECTOR macro, which result in compilation error. 

Although it's expected to surround all fault injector usage with 
#ifdef FAULT_INJECTOR, this commit defines default value for 
SIMPLE_FAULT_INJECTOR to prevent compilation error when extension did not do it.