### PR TITLE
Resolve conflicts in src/test/regress/expected/btree_index.out

### DIFF
--- a/src/test/regress/expected/btree_index.out
+++ b/src/test/regress/expected/btree_index.out
@@ -202,9 +202,7 @@ select proname from pg_proc where proname ilike 'ri%foo' order by 1;
 reset enable_seqscan;
 reset enable_indexscan;
 reset enable_bitmapscan;
-<<<<<<< HEAD
 reset enable_sort;
-=======
 -- Also check LIKE optimization with binary-compatible cases
 create temp table btree_bpchar (f1 text collate "C");
 create index on btree_bpchar(f1 bpchar_ops);
@@ -212,11 +210,13 @@ insert into btree_bpchar values ('foo'), ('fool'), ('bar'), ('quux');
 -- doesn't match index:
 explain (costs off)
 select * from btree_bpchar where f1 like 'foo';
-          QUERY PLAN           
--------------------------------
- Seq Scan on btree_bpchar
-   Filter: (f1 ~~ 'foo'::text)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on btree_bpchar
+         Filter: (f1 ~~ 'foo'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
 
 select * from btree_bpchar where f1 like 'foo';
  f1  
@@ -226,11 +226,13 @@ select * from btree_bpchar where f1 like 'foo';
 
 explain (costs off)
 select * from btree_bpchar where f1 like 'foo%';
-           QUERY PLAN           
---------------------------------
- Seq Scan on btree_bpchar
-   Filter: (f1 ~~ 'foo%'::text)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on btree_bpchar
+         Filter: (f1 ~~ 'foo%'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
 
 select * from btree_bpchar where f1 like 'foo%';
   f1  
@@ -242,13 +244,15 @@ select * from btree_bpchar where f1 like 'foo%';
 -- these do match the index:
 explain (costs off)
 select * from btree_bpchar where f1::bpchar like 'foo';
-                     QUERY PLAN                     
-----------------------------------------------------
- Bitmap Heap Scan on btree_bpchar
-   Filter: ((f1)::bpchar ~~ 'foo'::text)
-   ->  Bitmap Index Scan on btree_bpchar_f1_idx
-         Index Cond: ((f1)::bpchar = 'foo'::bpchar)
-(4 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Bitmap Heap Scan on btree_bpchar
+         Filter: ((f1)::bpchar ~~ 'foo'::text)
+         ->  Bitmap Index Scan on btree_bpchar_f1_idx
+               Index Cond: ((f1)::bpchar = 'foo'::bpchar)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select * from btree_bpchar where f1::bpchar like 'foo';
  f1  
@@ -258,13 +262,15 @@ select * from btree_bpchar where f1::bpchar like 'foo';
 
 explain (costs off)
 select * from btree_bpchar where f1::bpchar like 'foo%';
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Bitmap Heap Scan on btree_bpchar
-   Filter: ((f1)::bpchar ~~ 'foo%'::text)
-   ->  Bitmap Index Scan on btree_bpchar_f1_idx
-         Index Cond: (((f1)::bpchar >= 'foo'::bpchar) AND ((f1)::bpchar < 'fop'::bpchar))
-(4 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on btree_bpchar
+         Filter: ((f1)::bpchar ~~ 'foo%'::text)
+         ->  Bitmap Index Scan on btree_bpchar_f1_idx
+               Index Cond: (((f1)::bpchar >= 'foo'::bpchar) AND ((f1)::bpchar < 'fop'::bpchar))
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select * from btree_bpchar where f1::bpchar like 'foo%';
   f1  
@@ -273,7 +279,6 @@ select * from btree_bpchar where f1::bpchar like 'foo%';
  fool
 (2 rows)
 
->>>>>>> 55a1954da16e041f895e5c3a6abff13c5e3a4a2f
 --
 -- Test B-tree fast path (cache rightmost leaf page) optimization.
 --


### PR DESCRIPTION
Resolve conflicts in src/test/regress/expected/btree_index.out

Commit b3c265d added new tests to src/test/regress/sql/btree_index.sql, while
earlier commit 19cd1cf already added enable_sort GUC override to the same
place, also, we need to adapt the output for GPDB.