### PR TITLE
Fix incorrect usage of validate_and_refill_options

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1594,8 +1594,7 @@ build_reloptions(Datum reloptions, bool validate,
 	fillRelOptions(rdopts, relopt_struct_size, options, numoptions,
 				   validate, relopt_elems, num_relopt_elems);
 
-	if (kind == RELOPT_KIND_APPENDOPTIMIZED || kind == RELOPT_KIND_BITMAP ||
-		kind == RELOPT_KIND_HEAP || kind == RELOPT_KIND_TOAST)
+	if (kind == RELOPT_KIND_APPENDOPTIMIZED)
 	{
 		/* ensure we allocated anougth memory for StdRdOptions */
 		Assert(relopt_struct_size == sizeof(StdRdOptions));

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1594,7 +1594,13 @@ build_reloptions(Datum reloptions, bool validate,
 	fillRelOptions(rdopts, relopt_struct_size, options, numoptions,
 				   validate, relopt_elems, num_relopt_elems);
 
-	validate_and_refill_options(rdopts, options, numoptions, kind, validate);
+	if (kind == RELOPT_KIND_APPENDOPTIMIZED || kind == RELOPT_KIND_BITMAP ||
+		kind == RELOPT_KIND_HEAP || kind == RELOPT_KIND_TOAST)
+	{
+		/* ensure we allocated anougth memory for StdRdOptions */
+		Assert(relopt_struct_size == sizeof(StdRdOptions));
+		validate_and_refill_options(rdopts, options, numoptions, kind, validate);
+	}
 
 	free_options_deep(options, numoptions);
 

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -36,11 +36,6 @@
 #include "nodes/makefuncs.h"
 
 /*
- * Helper macro used for validation
- */
-#define KIND_IS_APPENDOPTIMIZED(kind) (((kind) & RELOPT_KIND_APPENDOPTIMIZED) != 0)
-
-/*
  * GPDB reloptions specification.
  */
 
@@ -840,15 +835,12 @@ validate_and_adjust_options(StdRdOptions *result,
 	relopt_value *complevel_opt;
 	relopt_value *checksum_opt;
 
+	Assert(kind == RELOPT_KIND_APPENDOPTIMIZED);
+
 	/* blocksize */
 	blocksize_opt = get_option_set(options, num_options, SOPT_BLOCKSIZE);
 	if (blocksize_opt != NULL)
 	{
-		if (!KIND_IS_APPENDOPTIMIZED(kind) && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"blocksize\" in a non relation object is not supported")));
-
 		result->blocksize = blocksize_opt->values.int_val;
 
 		if (result->blocksize < MIN_APPENDONLY_BLOCK_SIZE ||
@@ -870,11 +862,6 @@ validate_and_adjust_options(StdRdOptions *result,
 	comptype_opt = get_option_set(options, num_options, SOPT_COMPTYPE);
 	if (comptype_opt != NULL)
 	{
-		if (!KIND_IS_APPENDOPTIMIZED(kind) && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"compresstype\" in a non relation object is not supported")));
-
 		if (!compresstype_is_valid(comptype_opt->values.string_val))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
@@ -889,11 +876,6 @@ validate_and_adjust_options(StdRdOptions *result,
 	complevel_opt = get_option_set(options, num_options, SOPT_COMPLEVEL);
 	if (complevel_opt != NULL)
 	{
-		if (!KIND_IS_APPENDOPTIMIZED(kind) && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"compresslevel\" in a non relation object is not supported")));
-
 		result->compresslevel = complevel_opt->values.int_val;
 
 		if (result->compresstype[0] &&
@@ -1005,11 +987,6 @@ validate_and_adjust_options(StdRdOptions *result,
 	checksum_opt = get_option_set(options, num_options, SOPT_CHECKSUM);
 	if (checksum_opt != NULL)
 	{
-		if (!KIND_IS_APPENDOPTIMIZED(kind) && validate)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("usage of parameter \"checksum\" in a non relation object is not supported")));
-
 		result->checksum = checksum_opt->values.bool_val;
 	}
 
@@ -1024,9 +1001,9 @@ void
 validate_and_refill_options(StdRdOptions *result, relopt_value *options,
 							int numrelopts, relopt_kind kind, bool validate)
 {
-	if (validate &&
-		ao_storage_opts_changed &&
-		KIND_IS_APPENDOPTIMIZED(kind))
+	Assert(kind == RELOPT_KIND_APPENDOPTIMIZED);
+
+	if (validate && ao_storage_opts_changed)
 	{
 		if (!(get_option_set(options, numrelopts, SOPT_BLOCKSIZE)))
 			result->blocksize = ao_storage_opts.blocksize;
@@ -1050,6 +1027,8 @@ parse_validate_reloptions(StdRdOptions *result, Datum reloptions,
 {
 	relopt_value *options;
 	int			num_options;
+
+	Assert(kind == RELOPT_KIND_APPENDOPTIMIZED);
 
 	options = parseRelOptions(reloptions, validate, kind, &num_options);
 


### PR DESCRIPTION
Fix incorrect usage of validate_and_refill_options

Commit 3534fa2 split out part of default_reloptions in
src/backend/access/common/reloptions.c into a new function build_reloptions,
and changed the memory allocation for the StdRdOptions structure to a
variable-size memory allocation, so that this new function can be used with
different structures, while the GPDB-specific validate_and_refill_options
function, previously called from default_reloptions and now from
build_reloptions, always expects a pointer to an already allocated StdRdOptions
structure as its first argument. Although before the specified commit, the
default_reloptions function, and therefore the validate_and_refill_options
function, was called for different types, this GPDB-specific
validate_and_refill_options function is valid only for AO tables, i.e. for the
RELOPT_KIND_APPENDOPTIMIZED type, so this patch adds the corresponding check to
the new build_reloptions function. Also, assertions are added and unnecessary
conditions and macros are removed.