### PR TITLE
Stabilize alter_db_set_tablespace test

### DIFF
--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -655,6 +655,9 @@ SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configura
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 
+-- Wait for primaries to recover after panics
+SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
+
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
 

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -1068,6 +1068,13 @@ SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configura
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 1802)
 ERROR:  fault triggered, fault name:'start_prepare' fault type:'panic'  (seg0 127.0.0.1:25432 pid=61308)
+-- Wait for primaries to recover after panics
+SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
+ ?column? 
+----------
+ t
+(1 row)
+
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
  gp_segment_id | db_name  |    tablespace_name     


### PR DESCRIPTION
Stabilize alter_db_set_tablespace test

The alter_db_set_tablespace test is flaky on CI because the panicking segment
is sometimes slow to recover. The patch adds a wait for recovery.