### PR TITLE
Protect object creation from dropping referenced objects

### DIFF
--- a/src/test/isolation2/expected/dependency.out
+++ b/src/test/isolation2/expected/dependency.out
@@ -1,0 +1,1352 @@
+-- Test cases when a parallel transaction drops a dependency object
+-- while current transaction is yet not committed.
+
+-- Case 1. Function dependency on the schema.
+create schema test_1_schema;
+CREATE SCHEMA
+
+1: begin;
+BEGIN
+1: create function test_1_schema.test_1_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE FUNCTION
+
+-- Check that we didn't add extra locks. Here we lock only namespace, so the count is 1.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  select count(1), l.gp_segment_id from pg_locks l join pg_locks r using (locktype, classid, objid) where r.pid = pg_backend_pid() and r.locktype = 'object' group by 2 order by 2;
+ count | gp_segment_id 
+-------+---------------
+ 1     | -1            
+ 1     | 0             
+ 1     | 1             
+ 1     | 2             
+(4 rows)
+
+2&: drop schema test_1_schema;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop schema test_1_schema because other objects depend on it
+DETAIL:  function test_1_schema.test_1_function() depends on schema test_1_schema
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_1_schema.test_1_function();
+ test_1_function 
+-----------------
+ test            
+(1 row)
+
+drop schema test_1_schema cascade;
+DROP SCHEMA
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create schema test_1_schema;
+CREATE SCHEMA
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop schema test_1_schema;
+DROP SCHEMA
+1&: create function test_1_schema.test_1_function() returns text as $$ select 'test'::text; /**/ $$ language sql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  namespace ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 2. Function dependency on the return type.
+create type test_2_type as (a int);
+CREATE TYPE
+
+1: begin;
+BEGIN
+1: create function test_2_function() returns setof test_2_type as $$ select i from generate_series(1,5)i; /**/ $$ language sql;
+CREATE FUNCTION
+
+-- Check that we didn't add extra locks. Here we lock namespace ('public') and type, so the count is 2.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  select count(1), l.gp_segment_id from pg_locks l join pg_locks r using (locktype, classid, objid) where r.pid = pg_backend_pid() and r.locktype = 'object' group by 2 order by 2;
+ count | gp_segment_id 
+-------+---------------
+ 2     | -1            
+ 2     | 0             
+ 2     | 1             
+ 2     | 2             
+(4 rows)
+
+2&: drop type test_2_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_2_type because other objects depend on it
+DETAIL:  function test_2_function() depends on type test_2_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_2_function();
+ test_2_function 
+-----------------
+ (1)             
+ (2)             
+ (3)             
+ (4)             
+ (5)             
+(5 rows)
+
+drop type test_2_type cascade;
+DROP TYPE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_2_type as (a int);
+CREATE TYPE
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_2_type;
+DROP TYPE
+1&: create function test_2_function() returns setof test_2_type as $$ select i from generate_series(1,5)i; /**/ $$ language sql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 3. Function dependency on the parameter type.
+create type test_3_type as enum ('one', 'two');
+CREATE TYPE
+
+1: begin;
+BEGIN
+1: create function test_3_function(a test_3_type) returns text as $$ select 'Return ' || a; /**/ $$ language sql;
+CREATE FUNCTION
+
+2&: drop type test_3_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_3_type because other objects depend on it
+DETAIL:  function test_3_function(test_3_type) depends on type test_3_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_3_function('one');
+ test_3_function 
+-----------------
+ Return one      
+(1 row)
+
+drop type test_3_type cascade;
+DROP TYPE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_3_type as enum ('one', 'two');
+CREATE TYPE
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_3_type;
+DROP TYPE
+1&: create function test_3_function(a test_3_type) returns text as $$ select 'Return ' || a; /**/ $$ language sql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 4. Function dependency on the language.
+create language plpython3u;
+CREATE LANGUAGE
+
+1: begin;
+BEGIN
+1: create function test_4_function() returns text as $$ return "test" $$ language plpython3u;
+CREATE FUNCTION
+
+2&: drop language plpython3u;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop language plpython3u because other objects depend on it
+DETAIL:  function test_4_function() depends on language plpython3u
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_4_function();
+ test_4_function 
+-----------------
+ test            
+(1 row)
+
+drop language plpython3u cascade;
+DROP LANGUAGE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create language plpython3u;
+CREATE LANGUAGE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop language plpython3u;
+DROP LANGUAGE
+1&: create function test_4_function() returns text as $$ return "test" $$ language plpython3u;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  language ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 5. Function dependency on the parameter default expression.
+create function test5_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+1: create function test_5_function(a text default test5_default_value_function()) returns text as $$ begin return a; /**/ end $$ language plpgsql;
+CREATE FUNCTION
+
+2&: drop function test5_default_value_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test5_default_value_function() because other objects depend on it
+DETAIL:  function test_5_function(text) depends on function test5_default_value_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select test_5_function();
+ test_5_function 
+-----------------
+ test            
+(1 row)
+
+drop function test5_default_value_function() cascade;
+DROP FUNCTION
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test5_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test5_default_value_function();
+DROP FUNCTION
+1&: create function test_5_function(a text default test5_default_value_function()) returns text as $$ begin return a; /**/ end $$ language plpgsql;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  procedure ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 6. Table dependency on the column default expression.
+create function test_6_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+1: create table test_6_table(a text default test_6_default_value_function());
+CREATE TABLE
+
+2&: drop function test_6_default_value_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test_6_default_value_function() because other objects depend on it
+DETAIL:  default value for column a of table test_6_table depends on function test_6_default_value_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_6_table default values;
+INSERT 0 1
+1: select * from test_6_table;
+ a    
+------
+ test 
+(1 row)
+
+drop function test_6_default_value_function() cascade;
+DROP FUNCTION
+drop table test_6_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_6_default_value_function() returns text as $$ select 'test'::text; /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test_6_default_value_function();
+DROP FUNCTION
+1&: create table test_6_table(a text default test_6_default_value_function());  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  procedure ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 7. Table dependency on the column type.
+create type test_7_type as enum ('one', 'two');
+CREATE TYPE
+
+1: begin;
+BEGIN
+1: create table test_7_table(a test_7_type);
+CREATE TABLE
+
+2&: drop type test_7_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_7_type because other objects depend on it
+DETAIL:  column a of table test_7_table depends on type test_7_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_7_table;
+ a 
+---
+(0 rows)
+
+drop type test_7_type cascade;
+DROP TYPE
+drop table test_7_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_7_type as enum ('one', 'two');
+CREATE TYPE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_7_type;
+DROP TYPE
+1&: create table test_7_table(a test_7_type);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 8. Table dependency on the collation.
+create collation test_8_collation (locale="en_US.utf8");
+CREATE COLLATION
+
+1: begin;
+BEGIN
+1: create table test_8_table(a text collate test_8_collation);
+CREATE TABLE
+1: insert into test_8_table values('data');
+INSERT 0 1
+
+2&: drop collation test_8_collation;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop collation test_8_collation because other objects depend on it
+DETAIL:  column a of table test_8_table depends on collation test_8_collation
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_8_table where a < 'test';
+ a    
+------
+ data 
+(1 row)
+
+drop collation test_8_collation cascade;
+DROP COLLATION
+drop table test_8_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create collation test_8_collation (locale="en_US.utf8");
+CREATE COLLATION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop collation test_8_collation;
+DROP COLLATION
+1&: create table test_8_table(a text collate test_8_collation);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  collation ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 9. Text search configuration dependency on the parser.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+CREATE TEXT SEARCH PARSER
+
+1: begin;
+BEGIN
+1: create text search configuration test_9_configuration(parser = test_9_parser);
+CREATE TEXT SEARCH CONFIGURATION
+
+2&: drop text search parser test_9_parser;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop text search parser test_9_parser because other objects depend on it
+DETAIL:  text search configuration test_9_configuration depends on text search parser test_9_parser
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select count(1) from ts_debug('public.test_9_configuration', 'test');
+ count 
+-------
+ 1     
+(1 row)
+
+drop text search parser test_9_parser cascade;
+DROP TEXT SEARCH PARSER
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+CREATE TEXT SEARCH PARSER
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop text search parser test_9_parser;
+DROP TEXT SEARCH PARSER
+1&: create text search configuration test_9_configuration(parser = test_9_parser);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  text search parser ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 10. Text search dictionary dependency on the template.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+CREATE TEXT SEARCH TEMPLATE
+
+1: begin;
+BEGIN
+1: create text search dictionary test_10_dictionary(template = test_10_template);
+CREATE TEXT SEARCH DICTIONARY
+
+2&: drop text search template test_10_template;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop text search template test_10_template because other objects depend on it
+DETAIL:  text search dictionary test_10_dictionary depends on text search template test_10_template
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select ts_lexize('public.test_10_dictionary', 'test');
+ ts_lexize 
+-----------
+ ['test']  
+(1 row)
+
+drop text search template test_10_template cascade;
+DROP TEXT SEARCH TEMPLATE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+CREATE TEXT SEARCH TEMPLATE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop text search template test_10_template;
+DROP TEXT SEARCH TEMPLATE
+1&: create text search dictionary test_10_dictionary(template = test_10_template);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  text search template ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 11. Server dependency on the foreign data wrapper.
+create foreign data wrapper test_11_fdw;
+CREATE FOREIGN DATA WRAPPER
+
+1: begin;
+BEGIN
+1: create server test_11_server foreign data wrapper test_11_fdw;
+CREATE SERVER
+
+2&: drop foreign data wrapper test_11_fdw;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop foreign-data wrapper test_11_fdw because other objects depend on it
+DETAIL:  server test_11_server depends on foreign-data wrapper test_11_fdw
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: alter server test_11_server options (servername 'test_server');
+ALTER SERVER
+
+drop foreign data wrapper test_11_fdw cascade;
+DROP FOREIGN DATA WRAPPER
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create foreign data wrapper test_11_fdw;
+CREATE FOREIGN DATA WRAPPER
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop foreign data wrapper test_11_fdw;
+DROP FOREIGN DATA WRAPPER
+1&: create server test_11_server foreign data wrapper test_11_fdw;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  foreign data wrapper ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 12. User mapping dependency on the server.
+create foreign data wrapper test_12_fdw;
+CREATE FOREIGN DATA WRAPPER
+create server test_12_server foreign data wrapper test_12_fdw;
+CREATE SERVER
+
+1: begin;
+BEGIN
+1: create user mapping for public server test_12_server;
+CREATE USER MAPPING
+
+2&: drop server test_12_server;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop server test_12_server because other objects depend on it
+DETAIL:  user mapping for public on server test_12_server depends on server test_12_server
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+SELECT srvname, usename FROM pg_user_mappings ORDER BY 1, 2;
+ srvname        | usename 
+----------------+---------
+ test_12_server | public  
+(1 row)
+
+drop server test_12_server cascade;
+DROP SERVER
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create server test_12_server foreign data wrapper test_12_fdw;
+CREATE SERVER
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop server test_12_server;
+DROP SERVER
+1&: create user mapping for public server test_12_server;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  server ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+drop foreign data wrapper test_12_fdw;
+DROP FOREIGN DATA WRAPPER
+
+-- Case 13. External table dependency on the protocol.
+create or replace function write_to_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_export' language c stable no sql;
+CREATE FUNCTION
+create or replace function read_from_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_import' language c stable no sql;
+CREATE FUNCTION
+
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE PROTOCOL
+! echo 1 > /tmp/test_13.txt;
+
+
+1: begin;
+BEGIN
+1: create readable external table test_13_ext_table(a int) location('demoprot:///tmp/test_13.txt') format 'text';
+CREATE EXTERNAL TABLE
+
+2&: drop protocol demoprot;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop protocol demoprot because other objects depend on it
+DETAIL:  foreign table test_13_ext_table depends on protocol demoprot
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_13_ext_table;
+ a 
+---
+ 1 
+ 1 
+ 1 
+(3 rows)
+
+! rm /tmp/test_13.txt;
+
+
+drop protocol demoprot cascade;
+DROP PROTOCOL
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE PROTOCOL
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop protocol demoprot;
+DROP PROTOCOL
+1&: create readable external table test_13_ext_table(a int) location('demoprot://test.txt') format 'text';  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  protocol ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+drop function write_to_file();
+DROP FUNCTION
+drop function read_from_file();
+DROP FUNCTION
+
+-- Case 14. Text search configuration dependency on the text search dictionary
+create text search dictionary test_14_dict ( template = simple );
+CREATE TEXT SEARCH DICTIONARY
+
+1: begin;
+BEGIN
+1: create text search configuration test_14_config (parser = default);
+CREATE TEXT SEARCH CONFIGURATION
+1: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;
+ALTER TEXT SEARCH CONFIGURATION
+
+2&: drop text search dictionary test_14_dict;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop text search dictionary test_14_dict because other objects depend on it
+DETAIL:  text search configuration test_14_config depends on text search dictionary test_14_dict
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select count(1) from ts_debug('public.test_14_config', 'test');
+ count 
+-------
+ 1     
+(1 row)
+
+drop text search dictionary test_14_dict cascade;
+DROP TEXT SEARCH DICTIONARY
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search dictionary test_14_dict ( template = simple );
+CREATE TEXT SEARCH DICTIONARY
+
+1: begin;
+BEGIN
+1: create text search configuration test_14_config (parser = default);
+CREATE TEXT SEARCH CONFIGURATION
+2: begin;
+BEGIN
+2: drop text search dictionary test_14_dict;
+DROP TEXT SEARCH DICTIONARY
+1&: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  text search dictionary ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 15. Table dependency on the operator.
+create function test_15_function(text, text) returns text as $$ begin return $1 || $2;  /**/ end;  /**/ $$ language plpgsql;
+CREATE FUNCTION
+
+create operator ~*~ ( procedure = test_15_function, leftarg = text, rightarg = text, commutator = ~*~ );
+CREATE OPERATOR
+
+1: begin;
+BEGIN
+1: create table test_15_table(a text default 'a' ~*~ 'b');
+CREATE TABLE
+
+2&: drop operator ~*~ (text, text);  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop operator ~*~(text,text) because other objects depend on it
+DETAIL:  default value for column a of table test_15_table depends on operator ~*~(text,text)
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_15_table values (default);
+INSERT 0 1
+
+drop operator ~*~ (text, text) cascade;
+DROP OPERATOR
+drop table test_15_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator ~*~ ( procedure = test_15_function, leftarg = text, rightarg = text, commutator = ~*~ );
+CREATE OPERATOR
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop operator ~*~ (text, text);
+DROP OPERATOR
+1&: create table test_15_table(a text default 'a' ~*~ 'b');  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  operator ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+drop function test_15_function(text, text);
+DROP FUNCTION
+
+-- Case 16. Index dependency on the operator class.
+create function test_16_idx_func(int, int) returns int as $$ begin return $1 - $2;  /**/ end;  /**/ $$ language plpgsql immutable;
+CREATE FUNCTION
+
+create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_idx_func(int, int);
+CREATE OPERATOR CLASS
+
+create table test_16_table(a int);
+CREATE TABLE
+
+1: begin;
+BEGIN
+1: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);
+CREATE INDEX
+
+2&: drop operator class test_16_op_class using btree;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop operator class test_16_op_class for access method btree because other objects depend on it
+DETAIL:  index idx_test_16_table depends on operator class test_16_op_class for access method btree
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_16_table where a = 0;
+ a 
+---
+(0 rows)
+
+drop operator class test_16_op_class using btree cascade;
+DROP OPERATOR CLASS
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator class test_16_op_class for type int using btree as operator 1 =(int, int), function 1 test_16_idx_func(int, int);
+CREATE OPERATOR CLASS
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop operator class test_16_op_class using btree;
+DROP OPERATOR CLASS
+1&: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  operator class ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+drop function test_16_idx_func(int, int);
+DROP FUNCTION
+drop table test_16_table;
+DROP TABLE
+
+-- Case 17. Operator class dependency on the operator family.
+create function test_17_eq(int, int) returns int as $$ begin return 1;  /**/ end;  /**/ $$ language plpgsql immutable;
+CREATE FUNCTION
+
+create operator family test_17_op_family using btree;
+CREATE OPERATOR FAMILY
+
+1: begin;
+BEGIN
+1: create operator class test_17_op_class for type int using btree family test_17_op_family as operator 1 =(int, int), function 1 test_17_eq(int, int);
+CREATE OPERATOR CLASS
+
+2&: drop operator family test_17_op_family using btree;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+DROP OPERATOR FAMILY
+
+-- Count below should be 0, as 'drop operator family' automatically drops
+-- all its operator classes.
+1: select count(*) from pg_opclass where opcname = 'test_17_op_class';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator family test_17_op_family using btree;
+CREATE OPERATOR FAMILY
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop operator family test_17_op_family using btree;
+DROP OPERATOR FAMILY
+1&: create operator class test_17_op_class for type int using btree family test_17_op_family as operator 1 =(int, int), function 1 test_17_eq(int, int);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  operator family ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+drop function test_17_eq(int, int);
+DROP FUNCTION
+
+-- Case 18. View dependency on the function.
+create function test_18_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+1: create view test_18_view as select test_18_function();
+CREATE VIEW
+
+2&: drop function test_18_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test_18_function() because other objects depend on it
+DETAIL:  view test_18_view depends on function test_18_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_18_view;
+ test_18_function 
+------------------
+ test             
+(1 row)
+
+drop function test_18_function() cascade;
+DROP FUNCTION
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_18_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test_18_function();
+DROP FUNCTION
+1&: create view test_18_view as select test_18_function();  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  procedure ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 19. Materialized view dependency on the function.
+create function test_19_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+1: create materialized view test_19_view as select test_19_function();
+SELECT 1
+
+2&: drop function test_19_function();  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop function test_19_function() because other objects depend on it
+DETAIL:  materialized view test_19_view depends on function test_19_function()
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_19_view;
+ test_19_function 
+------------------
+ test             
+(1 row)
+
+drop function test_19_function() cascade;
+DROP FUNCTION
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_19_function() returns text as $$ select 'test'::text;  /**/ $$ language sql;
+CREATE FUNCTION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop function test_19_function();
+DROP FUNCTION
+1&: create materialized view test_19_view as select test_19_function();  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  procedure ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 20. Table dependency on the column type (with ALTER COLUMN).
+create type test_20_type as enum ('one', 'two');
+CREATE TYPE
+create table test_20_table(a text);
+CREATE TABLE
+
+1: begin;
+BEGIN
+1: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;
+ALTER TABLE
+
+2&: drop type test_20_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_20_type because other objects depend on it
+DETAIL:  column a of table test_20_table depends on type test_20_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_20_table;
+ a 
+---
+(0 rows)
+
+drop type test_20_type cascade;
+DROP TYPE
+drop table test_20_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_20_type as enum ('one', 'two');
+CREATE TYPE
+create table test_20_table(a text);
+CREATE TABLE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop type test_20_type;
+DROP TYPE
+1&: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 21. Rule dependency on the table.
+create table test_21_table_1(a int);
+CREATE TABLE
+create table test_21_table_2(a int);
+CREATE TABLE
+
+1: begin;
+BEGIN
+1: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);
+CREATE RULE
+
+2&: drop table test_21_table_2;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop table test_21_table_2 because other objects depend on it
+DETAIL:  rule test_21_rule on table test_21_table_1 depends on table test_21_table_2
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_21_table_1 values (0);
+INSERT 0 1
+1: select * from test_21_table_2;
+ a 
+---
+ 1 
+(1 row)
+
+drop rule test_21_rule on test_21_table_1;
+DROP RULE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop table test_21_table_2;
+DROP TABLE
+1&: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  relation "test_21_table_2" does not exist
+LINE 1: ... insert to test_21_table_1 do instead insert into test_21_ta...
+                                                             ^
+1: end;
+ROLLBACK
+
+drop table test_21_table_1;
+DROP TABLE
+
+-- Case 22. Table dependency on the sequence.
+create sequence test_22_seq;
+CREATE SEQUENCE
+
+1: begin;
+BEGIN
+1: create table test_22_table(id int default nextval('test_22_seq'));
+CREATE TABLE
+
+2&: drop sequence test_22_seq;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop sequence test_22_seq because other objects depend on it
+DETAIL:  default value for column id of table test_22_table depends on sequence test_22_seq
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: insert into test_22_table default values;
+INSERT 0 1
+
+drop sequence test_22_seq cascade;
+DROP SEQUENCE
+drop table test_22_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create sequence test_22_seq;
+CREATE SEQUENCE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop sequence test_22_seq;
+DROP SEQUENCE
+1&: create table test_22_table(id int default nextval('test_22_seq'));  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  sequence ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 23. Table dependency on the column type with REPEATABLE READ isolation level.
+create type test_23_type as enum ('one', 'two');
+CREATE TYPE
+
+1: begin;
+BEGIN
+1: set transaction isolation level repeatable read;
+SET
+1: create table test_23_table(a test_23_type);
+CREATE TABLE
+
+2&: drop type test_23_type;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop type test_23_type because other objects depend on it
+DETAIL:  column a of table test_23_table depends on type test_23_type
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_23_table;
+ a 
+---
+(0 rows)
+
+drop type test_23_type cascade;
+DROP TYPE
+drop table test_23_table;
+DROP TABLE
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_23_type as enum ('one', 'two');
+CREATE TYPE
+
+1: begin;
+BEGIN
+1: set transaction isolation level repeatable read;
+SET
+2: begin;
+BEGIN
+2: set transaction isolation level repeatable read;
+SET
+2: drop type test_23_type;
+DROP TYPE
+1&: create table test_23_table(a test_23_type);  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  type ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 24. Table dependency on the access method.
+create access method test_24_am type table handler heap_tableam_handler;
+CREATE ACCESS METHOD
+
+1: begin;
+BEGIN
+1: create table test_24_table(a int) using test_24_am;
+CREATE TABLE
+
+2&: drop access method test_24_am;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+ERROR:  cannot drop access method test_24_am because other objects depend on it
+DETAIL:  table test_24_table depends on access method test_24_am
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+
+1: select * from test_24_table;
+ a 
+---
+(0 rows)
+
+drop access method test_24_am cascade;
+DROP ACCESS METHOD
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create access method test_24_am type table handler heap_tableam_handler;
+CREATE ACCESS METHOD
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop access method test_24_am;
+DROP ACCESS METHOD
+1&: create table test_24_table(a int) using test_24_am;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  access method ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+-- Case 25. Mapping between relations and publications dependencies.
+-- Check if publication is dropped.
+create table test_25_table(a int);
+CREATE TABLE
+create publication test_25_publication;
+CREATE PUBLICATION
+
+1: begin;
+BEGIN
+1: alter publication test_25_publication add table test_25_table;
+ALTER PUBLICATION
+
+2&: drop publication test_25_publication;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+DROP PUBLICATION
+
+1: select count(1) from pg_publication_rel where prrelid = 'public.test_25_table'::regclass;
+ count 
+-------
+ 0     
+(1 row)
+
+drop table test_25_table;
+DROP TABLE
+
+-- Check if relation is dropped.
+create table test_25_table(a int);
+CREATE TABLE
+create publication test_25_publication;
+CREATE PUBLICATION
+
+1: begin;
+BEGIN
+1: alter publication test_25_publication add table test_25_table;
+ALTER PUBLICATION
+
+2&: drop table test_25_table;  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+DROP TABLE
+
+1: select count(1) from pg_publication_rel where prpubid in (select oid from pg_publication where pubname = 'test_25_publication');
+ count 
+-------
+ 0     
+(1 row)
+
+drop publication test_25_publication;
+DROP PUBLICATION
+
+-- Check if dependency is dropped before the creation of the dependent object.
+-- Check if publication is dropped.
+create table test_25_table(a int);
+CREATE TABLE
+create publication test_25_publication;
+CREATE PUBLICATION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop publication test_25_publication;
+DROP PUBLICATION
+1&: alter publication test_25_publication add table test_25_table;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  publication ##### was concurrently dropped
+1: end;
+ROLLBACK
+
+drop table test_25_table;
+DROP TABLE
+
+-- Check if relation is dropped.
+create table test_25_table(a int);
+CREATE TABLE
+create publication test_25_publication;
+CREATE PUBLICATION
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+2: drop table test_25_table;
+DROP TABLE
+1&: alter publication test_25_publication add table test_25_table;  <waiting ...>
+
+2: commit;
+COMMIT
+1<:  <... completed>
+ERROR:  relation "test_25_table" does not exist
+1: end;
+ROLLBACK
+
+drop publication test_25_publication;
+DROP PUBLICATION
+
+-- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
+create schema test_schema;
+CREATE SCHEMA
+create type test_type as enum ('one', 'two');
+CREATE TYPE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+2: drop type test_type;
+DROP TYPE
+1&: create function test_schema.test_function(a test_type) returns text as $$ select 'Return ' || a;  /**/ $$ language sql;  <waiting ...>
+2&: drop schema test_schema;  <waiting ...>
+
+
+1: rollback;
+ROLLBACK
+2: rollback;
+ROLLBACK
+
+drop schema test_schema;
+DROP SCHEMA
+drop type test_type;
+DROP TYPE

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -377,3 +377,4 @@ test: brin_heap
 test: uao/brin_chain_row uao/brin_chain_column
 
 test: lock_status
+test: dependency

--- a/src/test/isolation2/sql/dependency.sql
+++ b/src/test/isolation2/sql/dependency.sql
@@ -1,0 +1,897 @@
+-- Test cases when a parallel transaction drops a dependency object
+-- while current transaction is yet not committed.
+
+-- Case 1. Function dependency on the schema.
+create schema test_1_schema;
+
+1: begin;
+1: create function test_1_schema.test_1_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+-- Check that we didn't add extra locks. Here we lock only namespace, so the count is 1.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  select count(1), l.gp_segment_id
+from pg_locks l
+join pg_locks r using (locktype, classid, objid)
+where r.pid = pg_backend_pid() and r.locktype = 'object'
+group by 2 order by 2;
+
+2&: drop schema test_1_schema;
+
+1: commit;
+
+2<:
+
+1: select test_1_schema.test_1_function();
+
+drop schema test_1_schema cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create schema test_1_schema;
+1: begin;
+2: begin;
+2: drop schema test_1_schema;
+1&: create function test_1_schema.test_1_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 2. Function dependency on the return type.
+create type test_2_type as (a int);
+
+1: begin;
+1: create function test_2_function() returns setof test_2_type as $$
+    select i from generate_series(1,5)i; /**/
+$$ language sql;
+
+-- Check that we didn't add extra locks. Here we lock namespace ('public') and type, so the count is 2.
+-- Do this check only for the first couple of tests in order not to overcomplicate the remaining.
+1:  select count(1), l.gp_segment_id
+from pg_locks l
+join pg_locks r using (locktype, classid, objid)
+where r.pid = pg_backend_pid() and r.locktype = 'object'
+group by 2 order by 2;
+
+2&: drop type test_2_type;
+
+1: commit;
+
+2<:
+
+1: select test_2_function();
+
+drop type test_2_type cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_2_type as (a int);
+1: begin;
+2: begin;
+2: drop type test_2_type;
+1&: create function test_2_function() returns setof test_2_type as $$
+    select i from generate_series(1,5)i; /**/
+$$ language sql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 3. Function dependency on the parameter type.
+create type test_3_type as enum ('one', 'two');
+
+1: begin;
+1: create function test_3_function(a test_3_type) returns text as $$
+    select 'Return ' || a; /**/
+$$ language sql;
+
+2&: drop type test_3_type;
+
+1: commit;
+
+2<:
+
+1: select test_3_function('one');
+
+drop type test_3_type cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_3_type as enum ('one', 'two');
+1: begin;
+2: begin;
+2: drop type test_3_type;
+1&: create function test_3_function(a test_3_type) returns text as $$
+    select 'Return ' || a; /**/
+$$ language sql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 4. Function dependency on the language.
+-- start_ignore
+drop language if exists plpython3u cascade;
+-- end_ignore
+create language plpython3u;
+
+1: begin;
+1: create function test_4_function() returns text as $$
+	return "test"
+$$ language plpython3u;
+
+2&: drop language plpython3u;
+
+1: commit;
+
+2<:
+
+1: select test_4_function();
+
+drop language plpython3u cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create language plpython3u;
+
+1: begin;
+2: begin;
+2: drop language plpython3u;
+1&: create function test_4_function() returns text as $$
+	return "test"
+$$ language plpython3u;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 5. Function dependency on the parameter default expression.
+create function test5_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+1: create function test_5_function(a text default test5_default_value_function()) returns text as
+$$
+begin
+	return a; /**/
+end
+$$ language plpgsql;
+
+2&: drop function test5_default_value_function();
+
+1: commit;
+
+2<:
+
+1: select test_5_function();
+
+drop function test5_default_value_function() cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test5_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test5_default_value_function();
+1&: create function test_5_function(a text default test5_default_value_function()) returns text as
+$$
+begin
+	return a; /**/
+end
+$$ language plpgsql;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 6. Table dependency on the column default expression.
+create function test_6_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+1: create table test_6_table(a text default test_6_default_value_function());
+
+2&: drop function test_6_default_value_function();
+
+1: commit;
+
+2<:
+
+1: insert into test_6_table default values;
+1: select * from test_6_table;
+
+drop function test_6_default_value_function() cascade;
+drop table test_6_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_6_default_value_function() returns text as $$
+    select 'test'::text; /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test_6_default_value_function();
+1&: create table test_6_table(a text default test_6_default_value_function());
+
+2: commit;
+1<:
+1: end;
+
+-- Case 7. Table dependency on the column type.
+create type test_7_type as enum ('one', 'two');
+
+1: begin;
+1: create table test_7_table(a test_7_type);
+
+2&: drop type test_7_type;
+
+1: commit;
+
+2<:
+
+1: select * from test_7_table;
+
+drop type test_7_type cascade;
+drop table test_7_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_7_type as enum ('one', 'two');
+
+1: begin;
+2: begin;
+2: drop type test_7_type;
+1&: create table test_7_table(a test_7_type);
+
+2: commit;
+1<:
+1: end;
+
+-- Case 8. Table dependency on the collation.
+create collation test_8_collation (locale="en_US.utf8");
+
+1: begin;
+1: create table test_8_table(a text collate test_8_collation);
+1: insert into test_8_table values('data');
+
+2&: drop collation test_8_collation;
+
+1: commit;
+
+2<:
+
+1: select * from test_8_table where a < 'test';
+
+drop collation test_8_collation cascade;
+drop table test_8_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create collation test_8_collation (locale="en_US.utf8");
+
+1: begin;
+2: begin;
+2: drop collation test_8_collation;
+1&: create table test_8_table(a text collate test_8_collation);
+
+2: commit;
+1<:
+1: end;
+
+-- Case 9. Text search configuration dependency on the parser.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+
+1: begin;
+1: create text search configuration test_9_configuration(parser = test_9_parser);
+
+2&: drop text search parser test_9_parser;
+
+1: commit;
+
+2<:
+
+1: select count(1) from ts_debug('public.test_9_configuration', 'test');
+
+drop text search parser test_9_parser cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search parser test_9_parser(start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
+
+1: begin;
+2: begin;
+2: drop text search parser test_9_parser;
+1&: create text search configuration test_9_configuration(parser = test_9_parser);
+
+2: commit;
+1<:
+1: end;
+
+-- Case 10. Text search dictionary dependency on the template.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+
+1: begin;
+1: create text search dictionary test_10_dictionary(template = test_10_template);
+
+2&: drop text search template test_10_template;
+
+1: commit;
+
+2<:
+
+1: select ts_lexize('public.test_10_dictionary', 'test');
+
+drop text search template test_10_template cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search template test_10_template(init = dsimple_init, lexize = dsimple_lexize);
+
+1: begin;
+2: begin;
+2: drop text search template test_10_template;
+1&: create text search dictionary test_10_dictionary(template = test_10_template);
+
+2: commit;
+1<:
+1: end;
+
+-- Case 11. Server dependency on the foreign data wrapper.
+create foreign data wrapper test_11_fdw;
+
+1: begin;
+1: create server test_11_server foreign data wrapper test_11_fdw;
+
+2&: drop foreign data wrapper test_11_fdw;
+
+1: commit;
+
+2<:
+
+1: alter server test_11_server options (servername 'test_server');
+
+drop foreign data wrapper test_11_fdw cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create foreign data wrapper test_11_fdw;
+
+1: begin;
+2: begin;
+2: drop foreign data wrapper test_11_fdw;
+1&: create server test_11_server foreign data wrapper test_11_fdw;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 12. User mapping dependency on the server.
+create foreign data wrapper test_12_fdw;
+create server test_12_server foreign data wrapper test_12_fdw;
+
+1: begin;
+1: create user mapping for public server test_12_server;
+
+2&: drop server test_12_server;
+
+1: commit;
+
+2<:
+
+SELECT srvname, usename FROM pg_user_mappings ORDER BY 1, 2;
+
+drop server test_12_server cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create server test_12_server foreign data wrapper test_12_fdw;
+
+1: begin;
+2: begin;
+2: drop server test_12_server;
+1&: create user mapping for public server test_12_server;
+
+2: commit;
+1<:
+1: end;
+
+drop foreign data wrapper test_12_fdw;
+
+-- Case 13. External table dependency on the protocol.
+create or replace function write_to_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_export' language c stable no sql;
+create or replace function read_from_file() returns integer as '$libdir/gpextprotocol.so', 'demoprot_import' language c stable no sql;
+
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+! echo 1 > /tmp/test_13.txt;
+
+1: begin;
+1: create readable external table test_13_ext_table(a int) location('demoprot:///tmp/test_13.txt') format 'text';
+
+2&: drop protocol demoprot;
+
+1: commit;
+
+2<:
+
+1: select * from test_13_ext_table;
+
+! rm /tmp/test_13.txt;
+
+drop protocol demoprot cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create protocol demoprot (readfunc = 'read_from_file', writefunc = 'write_to_file');
+
+1: begin;
+2: begin;
+2: drop protocol demoprot;
+1&: create readable external table test_13_ext_table(a int) location('demoprot://test.txt') format 'text';
+
+2: commit;
+1<:
+1: end;
+
+drop function write_to_file();
+drop function read_from_file();
+
+-- Case 14. Text search configuration dependency on the text search dictionary
+create text search dictionary test_14_dict ( template = simple );
+
+1: begin;
+1: create text search configuration test_14_config (parser = default);
+1: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;
+
+2&: drop text search dictionary test_14_dict;
+
+1: commit;
+
+2<:
+
+1: select count(1) from ts_debug('public.test_14_config', 'test');
+
+drop text search dictionary test_14_dict cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create text search dictionary test_14_dict ( template = simple );
+
+1: begin;
+1: create text search configuration test_14_config (parser = default);
+2: begin;
+2: drop text search dictionary test_14_dict;
+1&: alter text search configuration test_14_config alter mapping for asciiword with test_14_dict;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 15. Table dependency on the operator.
+create function test_15_function(text, text) returns text as $$
+begin
+	return $1 || $2;  /**/
+end;  /**/
+$$ language plpgsql;
+
+create operator ~*~ (
+    procedure = test_15_function,
+    leftarg = text,
+    rightarg = text,
+    commutator = ~*~
+);
+
+1: begin;
+1: create table test_15_table(a text default 'a' ~*~ 'b');
+
+2&: drop operator ~*~ (text, text);
+
+1: commit;
+
+2<:
+
+1: insert into test_15_table values (default);
+
+drop operator ~*~ (text, text) cascade;
+drop table test_15_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator ~*~ (
+    procedure = test_15_function,
+    leftarg = text,
+    rightarg = text,
+    commutator = ~*~
+);
+
+1: begin;
+2: begin;
+2: drop operator ~*~ (text, text);
+1&: create table test_15_table(a text default 'a' ~*~ 'b');
+
+2: commit;
+1<:
+1: end;
+
+drop function test_15_function(text, text);
+
+-- Case 16. Index dependency on the operator class.
+create function test_16_idx_func(int, int) returns int as $$
+begin
+    return $1 - $2;  /**/
+end;  /**/
+$$ language plpgsql immutable;
+
+create operator class test_16_op_class for type int using btree as
+    operator 1 =(int, int),
+    function 1 test_16_idx_func(int, int);
+
+create table test_16_table(a int);
+
+1: begin;
+1: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);
+
+2&: drop operator class test_16_op_class using btree;
+
+1: commit;
+
+2<:
+
+1: select * from test_16_table where a = 0;
+
+drop operator class test_16_op_class using btree cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator class test_16_op_class for type int using btree as
+    operator 1 =(int, int),
+    function 1 test_16_idx_func(int, int);
+
+1: begin;
+2: begin;
+2: drop operator class test_16_op_class using btree;
+1&: create index idx_test_16_table on test_16_table using btree (a test_16_op_class);
+
+2: commit;
+1<:
+1: end;
+
+drop function test_16_idx_func(int, int);
+drop table test_16_table;
+
+-- Case 17. Operator class dependency on the operator family.
+create function test_17_eq(int, int) returns int as $$
+begin
+    return 1;  /**/
+end;  /**/
+$$ language plpgsql immutable;
+
+create operator family test_17_op_family using btree;
+
+1: begin;
+1: create operator class test_17_op_class for type int using btree family test_17_op_family as
+    operator 1 =(int, int),
+    function 1 test_17_eq(int, int);
+
+2&: drop operator family test_17_op_family using btree;
+
+1: commit;
+
+2<:
+
+-- Count below should be 0, as 'drop operator family' automatically drops
+-- all its operator classes.
+1: select count(*) from pg_opclass where opcname = 'test_17_op_class';
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create operator family test_17_op_family using btree;
+
+1: begin;
+2: begin;
+2: drop operator family test_17_op_family using btree;
+1&: create operator class test_17_op_class for type int using btree family test_17_op_family as
+    operator 1 =(int, int),
+    function 1 test_17_eq(int, int);
+
+2: commit;
+1<:
+1: end;
+
+drop function test_17_eq(int, int);
+
+-- Case 18. View dependency on the function.
+create function test_18_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+1: create view test_18_view as select test_18_function();
+
+2&: drop function test_18_function();
+
+1: commit;
+
+2<:
+
+1: select * from test_18_view;
+
+drop function test_18_function() cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_18_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test_18_function();
+1&: create view test_18_view as select test_18_function();
+
+2: commit;
+1<:
+1: end;
+
+-- Case 19. Materialized view dependency on the function.
+create function test_19_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+1: create materialized view test_19_view as select test_19_function();
+
+2&: drop function test_19_function();
+
+1: commit;
+
+2<:
+
+1: select * from test_19_view;
+
+drop function test_19_function() cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create function test_19_function() returns text as $$
+    select 'test'::text;  /**/
+$$ language sql;
+
+1: begin;
+2: begin;
+2: drop function test_19_function();
+1&: create materialized view test_19_view as select test_19_function();
+
+2: commit;
+1<:
+1: end;
+
+-- Case 20. Table dependency on the column type (with ALTER COLUMN).
+create type test_20_type as enum ('one', 'two');
+create table test_20_table(a text);
+
+1: begin;
+1: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;
+
+2&: drop type test_20_type;
+
+1: commit;
+
+2<:
+
+1: select * from test_20_table;
+
+drop type test_20_type cascade;
+drop table test_20_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_20_type as enum ('one', 'two');
+create table test_20_table(a text);
+
+1: begin;
+2: begin;
+2: drop type test_20_type;
+1&: alter table test_20_table alter column a set data type test_20_type using a::test_20_type;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 21. Rule dependency on the table.
+create table test_21_table_1(a int);
+create table test_21_table_2(a int);
+
+1: begin;
+1: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);
+
+2&: drop table test_21_table_2;
+
+1: commit;
+
+2<:
+
+1: insert into test_21_table_1 values (0);
+1: select * from test_21_table_2;
+
+drop rule test_21_rule on test_21_table_1;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+1: begin;
+2: begin;
+2: drop table test_21_table_2;
+1&: create rule test_21_rule as on insert to test_21_table_1 do instead insert into test_21_table_2 values (1);
+
+2: commit;
+1<:
+1: end;
+
+drop table test_21_table_1;
+
+-- Case 22. Table dependency on the sequence.
+create sequence test_22_seq;
+
+1: begin;
+1: create table test_22_table(id int default nextval('test_22_seq'));
+
+2&: drop sequence test_22_seq;
+
+1: commit;
+
+2<:
+
+1: insert into test_22_table default values;
+
+drop sequence test_22_seq cascade;
+drop table test_22_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create sequence test_22_seq;
+
+1: begin;
+2: begin;
+2: drop sequence test_22_seq;
+1&: create table test_22_table(id int default nextval('test_22_seq'));
+
+2: commit;
+1<:
+1: end;
+
+-- Case 23. Table dependency on the column type with REPEATABLE READ isolation level.
+create type test_23_type as enum ('one', 'two');
+
+1: begin;
+1: set transaction isolation level repeatable read;
+1: create table test_23_table(a test_23_type);
+
+2&: drop type test_23_type;
+
+1: commit;
+
+2<:
+
+1: select * from test_23_table;
+
+drop type test_23_type cascade;
+drop table test_23_table;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create type test_23_type as enum ('one', 'two');
+
+1: begin;
+1: set transaction isolation level repeatable read;
+2: begin;
+2: set transaction isolation level repeatable read;
+2: drop type test_23_type;
+1&: create table test_23_table(a test_23_type);
+
+2: commit;
+1<:
+1: end;
+
+-- Case 24. Table dependency on the access method.
+create access method test_24_am type table handler heap_tableam_handler;
+
+1: begin;
+1: create table test_24_table(a int) using test_24_am;
+
+2&: drop access method test_24_am;
+
+1: commit;
+
+2<:
+
+1: select * from test_24_table;
+
+drop access method test_24_am cascade;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+create access method test_24_am type table handler heap_tableam_handler;
+
+1: begin;
+2: begin;
+2: drop access method test_24_am;
+1&: create table test_24_table(a int) using test_24_am;
+
+2: commit;
+1<:
+1: end;
+
+-- Case 25. Mapping between relations and publications dependencies.
+-- Check if publication is dropped.
+create table test_25_table(a int);
+create publication test_25_publication;
+
+1: begin;
+1: alter publication test_25_publication add table test_25_table;
+
+2&: drop publication test_25_publication;
+
+1: commit;
+
+2<:
+
+1: select count(1) from pg_publication_rel where prrelid = 'public.test_25_table'::regclass;
+
+drop table test_25_table;
+
+-- Check if relation is dropped.
+create table test_25_table(a int);
+create publication test_25_publication;
+
+1: begin;
+1: alter publication test_25_publication add table test_25_table;
+
+2&: drop table test_25_table;
+
+1: commit;
+
+2<:
+
+1: select count(1) from pg_publication_rel where prpubid in (select oid from pg_publication where pubname = 'test_25_publication');
+
+drop publication test_25_publication;
+
+-- Check if dependency is dropped before the creation of the dependent object.
+-- Check if publication is dropped.
+create table test_25_table(a int);
+create publication test_25_publication;
+
+1: begin;
+2: begin;
+2: drop publication test_25_publication;
+1&: alter publication test_25_publication add table test_25_table;
+
+2: commit;
+1<:
+1: end;
+
+drop table test_25_table;
+
+-- Check if relation is dropped.
+create table test_25_table(a int);
+create publication test_25_publication;
+
+1: begin;
+2: begin;
+2: drop table test_25_table;
+1&: alter publication test_25_publication add table test_25_table;
+
+2: commit;
+1<:
+1: end;
+
+drop publication test_25_publication;
+
+-- Test deadlock scenario. It should be resolved by the deadlock detection algorithm.
+create schema test_schema;
+create type test_type as enum ('one', 'two');
+
+1: begin;
+2: begin;
+
+2: drop type test_type;
+1&: create function test_schema.test_function(a test_type) returns text as $$
+    select 'Return ' || a;  /**/
+$$ language sql;
+2&: drop schema test_schema;
+
+-- start_ignore
+1<:
+2<:
+-- end_ignore
+
+1: rollback;
+2: rollback;
+
+drop schema test_schema;
+drop type test_type;


### PR DESCRIPTION
Protect object creation from dropping referenced objects (#1854)

Problem description:
If an object had been created inside a transaction and it had a dependency on
some other object (like schema, custom data type, etc), and that referenced
object had been dropped from another transaction before the first transaction
had been committed, the new object was broken.

Ex. steps:
```
Session 1: create type test_type as enum ('one', 'two');
Session 1: begin;
Session 1: create table test_table(a test_type);
Session 2: drop type test_type;
Session 1: commit;
Session 1: select * from test_table;
```
gave result:
```
ERROR:  cache lookup failed for type 16385 (lsyscache.c:2796)
```

The issue reproduced for all dependencies that are registered in 'pg_depend'.

Root cause:
No protection from stealing the objects that are marked as dependencies in
'pg_depend' before the transaction is committed.

Fix:
Lock the referenced object with AccessShareLock when the dependency is created.
Lock is done only for 'normal' dependencies (which means here 'normal
relationship between separately-created objects', when the dependent object may
be dropped without affecting the referenced object, while the referenced object
may only be dropped with CASCADE, in which case the dependent object is dropped
too) and 'auto' (meaning that the dependent object can be dropped separately
from the referenced object, and should be automatically dropped if the
referenced object is dropped).
After the lock is released, do a recheck of the object's presence and error out
if the object was dropped while we waited for the lock.

(cherry picked from commit 769ddb3)

Changes comparing to the original commit:
 - 'plpythonu' language is replaced with 'plpython3u' in the test;
 - commands output is updated to comply with 7x in the test;
 - support for dependencies on access methods and publications is added (they
were not presented in 6x).
 
--------

DO REBASE