### PR TITLE
Resolve conflicts in configure.in

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -24,19 +24,11 @@ AC_INIT([Greenplum Database], [8.0.0-alpha.0], [support@greenplum.org])
 [PG_PACKAGE_VERSION=13alpha0]
 AC_SUBST(PG_PACKAGE_VERSION)
 
-<<<<<<< HEAD
-dnl m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
-dnl Untested combinations of 'autoconf' and PostgreSQL versions are not
-dnl recommended.  You can remove the check from 'configure.in' but it is then
-dnl your responsibility whether the result works or not.])])
-AC_COPYRIGHT([Copyright (c) 1996-2019, PostgreSQL Global Development Group])
-=======
 m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
 Untested combinations of 'autoconf' and PostgreSQL versions are not
 recommended.  You can remove the check from 'configure.in' but it is then
 your responsibility whether the result works or not.])])
 AC_COPYRIGHT([Copyright (c) 1996-2020, PostgreSQL Global Development Group])
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 AC_CONFIG_SRCDIR([src/backend/access/common/heaptuple.c])
 AC_CONFIG_AUX_DIR(config)
 AC_PREFIX_DEFAULT(/usr/local/gpdb)

--- a/configure.in
+++ b/configure.in
@@ -24,10 +24,10 @@ AC_INIT([Greenplum Database], [8.0.0-alpha.0], [support@greenplum.org])
 [PG_PACKAGE_VERSION=13alpha0]
 AC_SUBST(PG_PACKAGE_VERSION)
 
-m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
-Untested combinations of 'autoconf' and PostgreSQL versions are not
-recommended.  You can remove the check from 'configure.in' but it is then
-your responsibility whether the result works or not.])])
+dnl m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
+dnl Untested combinations of 'autoconf' and PostgreSQL versions are not
+dnl recommended.  You can remove the check from 'configure.in' but it is then
+dnl your responsibility whether the result works or not.])])
 AC_COPYRIGHT([Copyright (c) 1996-2020, PostgreSQL Global Development Group])
 AC_CONFIG_SRCDIR([src/backend/access/common/heaptuple.c])
 AC_CONFIG_AUX_DIR(config)


### PR DESCRIPTION
Resolve conflicts in configure.in

Commit 7559d8e updated the copyrights, while earlier commits 598f4b0 and
6b0e52b had already added the word dnl to the beginning of lines in the same
place.