### PR TITLE
Resolve conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302507011
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202001151
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+#define CATALOG_VERSION_NO	302507141
 
 #endif


### PR DESCRIPTION
Resolve conflicts in src/include/catalog/catversion.h

Commit a166d40 updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.