### PR TITLE
Resolve conflicts in src/include/catalog/index.h

### DIFF
--- a/src/include/catalog/index.h
+++ b/src/include/catalog/index.h
@@ -117,13 +117,10 @@ extern IndexInfo *BuildDummyIndexInfo(Relation index);
 extern bool CompareIndexInfo(IndexInfo *info1, IndexInfo *info2,
 							 Oid *collations1, Oid *collations2,
 							 Oid *opfamilies1, Oid *opfamilies2,
-<<<<<<< HEAD
-							 AttrNumber *attmap, int maplen);
-=======
 							 AttrMap *attmap);
 
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 extern void BuildSpeculativeIndexInfo(Relation index, IndexInfo *ii);
+
 extern void FormIndexDatum(IndexInfo *indexInfo,
 						   TupleTableSlot *slot,
 						   EState *estate,


### PR DESCRIPTION
Resolve conflicts in src/include/catalog/index.h

Commit e1551f9 changed the type of the attmap argument in the CompareIndexInfo
function in src/include/catalog/index.h from AttrNumber to AttrMap and removed
the maplen argument, while an earlier commit removed the empty line between the
BuildSpeculativeIndexInfo and FormIndexDatum functions.