### PR TITLE
Resolve conflicts in src/include/commands/explain.h

### DIFF
--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -49,7 +49,7 @@ typedef struct ExplainState
 	List	   *rtable_names;	/* alias names for RTEs */
 	List	   *deparse_cxt;	/* context list for deparsing expressions */
 	Bitmapset  *printed_subplans;	/* ids of SubPlans we've printed */
-<<<<<<< HEAD
+	bool		hide_workers;	/* set if we find an invisible Gather */
 
     /* CDB */
     struct CdbExplain_ShowStatCtx  *showstatctx;    /* EXPLAIN ANALYZE info */
@@ -57,9 +57,6 @@ typedef struct ExplainState
 	bool		subplanDispatchedSeparately;
 
 	PlanState  *parentPlanState;
-=======
-	bool		hide_workers;	/* set if we find an invisible Gather */
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 } ExplainState;
 
 /* Hook for plugins to get control in ExplainOneQuery() */


### PR DESCRIPTION
Resolve conflicts in src/include/commands/explain.h

Commit b925a00 added a new field hide_workers to the ExplainState structure in
src/include/commands/explain.h, while earlier commits 5ec5c30, 9f34425,
96c6d31, and 25a9039 had already added the GPDB-specific fields showstatctx,
currentSlice, subplanDispatchedSeparately, and parentPlanState to the same
location.