### PR TITLE
Resolve conflicts in src/include/executor/instrument.h

### DIFF
--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -4,13 +4,9 @@
  *	  definitions for run-time statistics collection
  *
  *
-<<<<<<< HEAD
  * Portions Copyright (c) 2006-2009, Greenplum inc
  * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
- * Copyright (c) 2001-2019, PostgreSQL Global Development Group
-=======
  * Copyright (c) 2001-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  *
  * src/include/executor/instrument.h
  *
@@ -62,21 +58,20 @@ typedef struct Instrumentation
 	bool		need_bufusage;	/* true if we need buffer usage data */
 	/* Info about current plan cycle: */
 	bool		running;		/* true if we've completed first tuple */
-<<<<<<< HEAD
-	instr_time	starttime;		/* Start time of current iteration of node */
-	instr_time	counter;		/* Accumulated runtime for this node */
-	double		firsttuple;		/* Time for first tuple of this cycle */
-	uint64		tuplecount;		/* Tuples emitted so far this cycle */
-	BufferUsage	bufusage_start;	/* Buffer usage at start */
+	instr_time	starttime;		/* start time of current iteration of node */
+	instr_time	counter;		/* accumulated runtime for this node */
+	double		firsttuple;		/* time for first tuple of this cycle */
+	uint64		tuplecount;		/* # of tuples emitted so far this cycle */
+	BufferUsage	bufusage_start;	/* buffer usage at start */
 	/* Accumulated statistics across all completed cycles: */
-	double		startup;		/* Total startup time (in seconds) */
-	double		total;			/* Total total time (in seconds) */
-	uint64		ntuples;		/* Total tuples produced */
-	double		ntuples2;		/* Secondary node-specific tuple counter */
+	double		startup;		/* total startup time (in seconds) */
+	double		total;			/* total total time (in seconds) */
+	uint64		ntuples;		/* total tuples produced */
+	double		ntuples2;		/* secondary node-specific tuple counter */
 	uint64		nloops;			/* # of run cycles for this node */
-	double		nfiltered1;		/* # tuples removed by scanqual or joinqual */
-	double		nfiltered2;		/* # tuples removed by "other" quals */
-	BufferUsage	bufusage;		/* Total buffer usage */
+	double		nfiltered1;		/* # of tuples removed by scanqual or joinqual */
+	double		nfiltered2;		/* # of tuples removed by "other" quals */
+	BufferUsage	bufusage;		/* total buffer usage */
 
 	double		execmemused;	/* CDB: executor memory used (bytes) */
 	double		workmemused;	/* CDB: work_mem actually used (bytes) */
@@ -89,22 +84,6 @@ typedef struct Instrumentation
 	const char *sortSpaceType;	/* CDB: Sort space type (Memory / Disk) */
 	long		sortSpaceUsed;	/* CDB: Memory / Disk used by sort(KBytes) */
 	struct CdbExplain_NodeSummary *cdbNodeSummary;	/* stats from all qExecs */
-=======
-	instr_time	starttime;		/* start time of current iteration of node */
-	instr_time	counter;		/* accumulated runtime for this node */
-	double		firsttuple;		/* time for first tuple of this cycle */
-	double		tuplecount;		/* # of tuples emitted so far this cycle */
-	BufferUsage bufusage_start; /* buffer usage at start */
-	/* Accumulated statistics across all completed cycles: */
-	double		startup;		/* total startup time (in seconds) */
-	double		total;			/* total time (in seconds) */
-	double		ntuples;		/* total tuples produced */
-	double		ntuples2;		/* secondary node-specific tuple counter */
-	double		nloops;			/* # of run cycles for this node */
-	double		nfiltered1;		/* # of tuples removed by scanqual or joinqual */
-	double		nfiltered2;		/* # of tuples removed by "other" quals */
-	BufferUsage bufusage;		/* total buffer usage */
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 } Instrumentation;
 
 typedef struct WorkerInstrumentation

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -65,7 +65,7 @@ typedef struct Instrumentation
 	BufferUsage	bufusage_start;	/* buffer usage at start */
 	/* Accumulated statistics across all completed cycles: */
 	double		startup;		/* total startup time (in seconds) */
-	double		total;			/* total total time (in seconds) */
+	double		total;			/* total time (in seconds) */
 	uint64		ntuples;		/* total tuples produced */
 	double		ntuples2;		/* secondary node-specific tuple counter */
 	uint64		nloops;			/* # of run cycles for this node */


### PR DESCRIPTION
Resolve conflicts in src/include/executor/instrument.h

1) Commit 7559d8e updated the copyrights, while earlier GPDB-specific
copyrights were added to this place.

2) Commit 42f3629 updated comments in the Instrumentation structure in
src/include/executor/instrument.h, while earlier commits 6b0e52b and 67db427
had already added GPDB-specific fields to this place.