### PR TITLE
ADBDEV-7842: Fix gp_default_storage_options affecting reorganize for heap tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14786,6 +14786,16 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			*/
 			cs->options = build_ao_rel_storage_opts(cs->options, rel);
 		}
+		if (!isTmpTableAo)
+		{
+			/*
+			 * Same but for heap tables, we have to manually specify
+			 * appendonly=false to avoid being affected by
+			 * gp_default_storage_options.
+			 */
+			if (!reloptions_has_opt(cs->options, "appendonly"))
+				cs->options = lappend(cs->options, makeDefElem("appendonly", (Node *) makeString(pstrdup("false"))));
+		}
 
 		if (RelationIsAoCols(rel) && useExistingColumnAttributes)
 			col_encs = RelationGetUntransformedAttributeOptions(rel);

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -52,3 +52,113 @@ select count(*) > 0 as has_different_distribution from
  t
 (1 row)
 
+-- ALTER TABLE SET also shouldn't change table access method because of
+-- changes in gp_default_storage_options.
+-- Heap -> AOCO
+create table tb_heap(id int, s1 text, s2 text);
+insert into tb_heap select v, v::text, v::text FROM generate_series(1, 100) v;
+alter table tb_heap drop column s1;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_heap set with (reorganize = true);
+select max(id) from tb_heap;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_heap';
+ relstorage 
+------------
+ h
+(1 row)
+
+-- Heap -> AO
+alter table tb_heap drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_heap set with (reorganize = true);
+select max(id) from tb_heap;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_heap';
+ relstorage 
+------------
+ h
+(1 row)
+
+-- AOCO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+create table tb_aoco(id int, s1 text, s2 text);
+insert into tb_aoco select v, v::text, v::text FROM generate_series(1, 100) v;
+alter table tb_aoco drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_aoco set with (reorganize = true);
+select max(id) from tb_aoco;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_aoco';
+ relstorage 
+------------
+ c
+(1 row)
+
+-- AOCO -> AO
+alter table tb_aoco drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_aoco set with (reorganize = true);
+select max(id) from tb_aoco;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_aoco';
+ relstorage 
+------------
+ c
+(1 row)
+
+-- AO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+create table tb_ao(id int, s1 text, s2 text);
+insert into tb_ao select v, v::text, v::text FROM generate_series(1, 100) v;
+alter table tb_ao drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_ao set with (reorganize = true);
+select max(id) from tb_ao;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_ao';
+ relstorage 
+------------
+ a
+(1 row)
+
+-- AO -> AOCO
+alter table tb_ao drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_ao set with (reorganize = true);
+select max(id) from tb_ao;
+ max 
+-----
+ 100
+(1 row)
+
+select relstorage from pg_class where relname = 'tb_ao';
+ relstorage 
+------------
+ a
+(1 row)
+
+-- Cleanup
+drop table tb_heap;
+drop table tb_aoco;
+drop table tb_ao;

--- a/src/test/regress/sql/alter_table_set.sql
+++ b/src/test/regress/sql/alter_table_set.sql
@@ -37,3 +37,70 @@ select count(*) > 0 as has_different_distribution from
 select count(*) > 0 as has_different_distribution from
 (select gp_segment_id, * from ats_dist_by_d except
 	select gp_segment_id, * from ats_expected_by_d) t;
+
+-- ALTER TABLE SET also shouldn't change table access method because of
+-- changes in gp_default_storage_options.
+
+-- Heap -> AOCO
+create table tb_heap(id int, s1 text, s2 text);
+insert into tb_heap select v, v::text, v::text FROM generate_series(1, 100) v;
+
+alter table tb_heap drop column s1;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_heap set with (reorganize = true);
+
+select max(id) from tb_heap;
+select relstorage from pg_class where relname = 'tb_heap';
+
+-- Heap -> AO
+alter table tb_heap drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_heap set with (reorganize = true);
+
+select max(id) from tb_heap;
+select relstorage from pg_class where relname = 'tb_heap';
+
+-- AOCO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+create table tb_aoco(id int, s1 text, s2 text);
+insert into tb_aoco select v, v::text, v::text FROM generate_series(1, 100) v;
+
+alter table tb_aoco drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_aoco set with (reorganize = true);
+
+select max(id) from tb_aoco;
+select relstorage from pg_class where relname = 'tb_aoco';
+
+-- AOCO -> AO
+alter table tb_aoco drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+alter table tb_aoco set with (reorganize = true);
+
+select max(id) from tb_aoco;
+select relstorage from pg_class where relname = 'tb_aoco';
+
+-- AO -> Heap
+set gp_default_storage_options = 'appendonly=true, orientation=row';
+create table tb_ao(id int, s1 text, s2 text);
+insert into tb_ao select v, v::text, v::text FROM generate_series(1, 100) v;
+
+alter table tb_ao drop column s1;
+set gp_default_storage_options = 'appendonly=false';
+alter table tb_ao set with (reorganize = true);
+
+select max(id) from tb_ao;
+select relstorage from pg_class where relname = 'tb_ao';
+
+-- AO -> AOCO
+alter table tb_ao drop column s2;
+set gp_default_storage_options = 'appendonly=true, orientation=column';
+alter table tb_ao set with (reorganize = true);
+
+select max(id) from tb_ao;
+select relstorage from pg_class where relname = 'tb_ao';
+
+-- Cleanup
+drop table tb_heap;
+drop table tb_aoco;
+drop table tb_ao;


### PR DESCRIPTION
Fix gp_default_storage_options affecting reorganize for heap tables

During ALTER TABLE ... SET WITH (reorganize = true), if additional options are
not present, default values are taken from gp_default_storage_options. This
might cause tables to change access method if appendonly option is added. This
patch adds a fix for heap tables, adding appendonly=false to options
explicitly. This also adds tests for various combinations of access method and
gp_default_storage_options, ensuring that reorganize never changes the access
method.
