### PR TITLE
Resolve conflicts in src/include/parser/parse_utilcmd.h

### DIFF
--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -22,16 +22,11 @@ struct AttrMap;					/* avoid including attmap.h here */
 
 
 extern List *transformCreateStmt(CreateStmt *stmt, const char *queryString);
-<<<<<<< HEAD
 extern List *transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString);
-extern List *transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
-									 const char *queryString);
-=======
 extern AlterTableStmt *transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 											   const char *queryString,
 											   List **beforeStmts,
 											   List **afterStmts);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 extern IndexStmt *transformIndexStmt(Oid relid, IndexStmt *stmt,
 									 const char *queryString);
 extern void transformRuleStmt(RuleStmt *stmt, const char *queryString,


### PR DESCRIPTION
Resolve conflicts in src/include/parser/parse_utilcmd.h

Commit 1281a5c changed the return type of the transformAlterTableStmt function
in src/include/parser/parse_utilcmd.h from List to AlterTableStmt, and added
two new arguments beforeStmts and afterStmts, while earlier commit a453004 had
already added a new function transformCreateExternalStmt before this place.