### PR TITLE
Resolve conflicts in src/backend/access/rmgrdesc/nbtdesc.c

### DIFF
--- a/src/backend/access/rmgrdesc/nbtdesc.c
+++ b/src/backend/access/rmgrdesc/nbtdesc.c
@@ -120,14 +120,9 @@ btree_desc(StringInfo buf, XLogReaderState *record)
 			{
 				xl_btree_delete *xlrec = (xl_btree_delete *) rec;
 
-<<<<<<< HEAD
-				appendStringInfo(buf, "%d items, latest removed xid %u",
-								 xlrec->nitems, xlrec->latestRemovedXid);
-				out_delete(buf, record);
-=======
 				appendStringInfo(buf, "latestRemovedXid %u; ndeleted %u",
 								 xlrec->latestRemovedXid, xlrec->ndeleted);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+				out_delete(buf, record);
 				break;
 			}
 		case XLOG_BTREE_MARK_PAGE_HALFDEAD:


### PR DESCRIPTION
Resolve conflicts in src/backend/access/rmgrdesc/nbtdesc.c

Commit d2e5e20 changed the description for the delete message in
src/backend/access/rmgrdesc/nbtdesc.c in the btree_desc function, while an
earlier commit c7649f1 had already added a call to the out_delete function to
the same place.