### PR TITLE
Resolve conflicts in src/backend/catalog/toasting.c

### DIFF
--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -263,12 +263,9 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 										   toast_typid,
 										   InvalidOid,
 										   rel->rd_rel->relowner,
-<<<<<<< HEAD
 										   RelationIsAoRows(rel) ?
-										   HEAP_TABLE_AM_OID :rel->rd_rel->relam,
-=======
+										   HEAP_TABLE_AM_OID :
 										   table_relation_toast_am(rel),
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 										   tupdesc,
 										   NIL,
 										   RELKIND_TOASTVALUE,


### PR DESCRIPTION
Resolve conflicts in src/backend/catalog/toasting.c

Commit 83322e3 changed the dereference of pointers to the call to
table_relation_toast_am in src/backend/catalog/toasting.c in the
create_toast_table function, while the earlier commit 19cd1cf added
GPDB-specific code to the same place.