### PR TITLE
Resolve conflicts in src/backend/commands/explain.c

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -4351,10 +4351,10 @@ ExplainSubPlans(List *plans, List *ancestors,
 		else
 		{
 			/*
-			* Treat the SubPlan node as an ancestor of the plan node(s) within
-			* it, so that ruleutils.c can find the referents of subplan
-			* parameters.
-			*/
+			 * Treat the SubPlan node as an ancestor of the plan node(s) within
+			 * it, so that ruleutils.c can find the referents of subplan
+			 * parameters.
+			 */
 			ancestors = lcons(sp, ancestors);
 
 			ExplainNode(sps->planstate, ancestors,

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -3,13 +3,9 @@
  * explain.c
  *	  Explain query execution plans
  *
-<<<<<<< HEAD
  * Portions Copyright (c) 2005-2010, Greenplum inc
  * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
- * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
-=======
  * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * Portions Copyright (c) 1994-5, Regents of the University of California
  *
  * IDENTIFICATION
@@ -1113,12 +1109,11 @@ ExplainPrintJIT(ExplainState *es, int jit_flags,
 	if (!ji || ji->created_functions == 0)
 		return;
 
-<<<<<<< HEAD
 	if (!gp_explain_jit)
-=======
+		return;
+
 	/* don't print per-worker info if we're supposed to hide that */
 	if (for_workers && es->hide_workers)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 		return;
 
 	/* calculate total time */
@@ -4337,7 +4332,6 @@ ExplainSubPlans(List *plans, List *ancestors,
 		es->printed_subplans = bms_add_member(es->printed_subplans,
 											  sp->plan_id);
 
-<<<<<<< HEAD
 		/* Subplan might have its own root slice */
 		if (sliceTable && qDispSliceId > 0)
 		{
@@ -4355,7 +4349,7 @@ ExplainSubPlans(List *plans, List *ancestors,
 			appendStringInfo(es->str, "\n");
 		}
 		else
-=======
+		{
 		/*
 		 * Treat the SubPlan node as an ancestor of the plan node(s) within
 		 * it, so that ruleutils.c can find the referents of subplan
@@ -4363,11 +4357,11 @@ ExplainSubPlans(List *plans, List *ancestors,
 		 */
 		ancestors = lcons(sp, ancestors);
 
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 		ExplainNode(sps->planstate, ancestors,
 					relationship, sp->plan_name, es);
 
 		ancestors = list_delete_first(ancestors);
+		}
 	}
 
 	es->currentSlice = saved_slice;

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2968,8 +2968,8 @@ show_tuple_split_keys(TupleSplitState *tstate, List *ancestors,
 	bool		useprefix;
 	List	   *result = NIL;
 	/* Set up deparsing context */
-	context = set_deparse_context_planstate(es->deparse_cxt,
-											(Node *) tstate,
+	context = set_deparse_context_plan(es->deparse_cxt,
+											tstate->ss.ps.plan,
 											ancestors);
 	useprefix = (list_length(es->rtable) > 1 || es->verbose);
 

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -4350,17 +4350,17 @@ ExplainSubPlans(List *plans, List *ancestors,
 		}
 		else
 		{
-		/*
-		 * Treat the SubPlan node as an ancestor of the plan node(s) within
-		 * it, so that ruleutils.c can find the referents of subplan
-		 * parameters.
-		 */
-		ancestors = lcons(sp, ancestors);
+			/*
+			* Treat the SubPlan node as an ancestor of the plan node(s) within
+			* it, so that ruleutils.c can find the referents of subplan
+			* parameters.
+			*/
+			ancestors = lcons(sp, ancestors);
 
-		ExplainNode(sps->planstate, ancestors,
-					relationship, sp->plan_name, es);
+			ExplainNode(sps->planstate, ancestors,
+						relationship, sp->plan_name, es);
 
-		ancestors = list_delete_first(ancestors);
+			ancestors = list_delete_first(ancestors);
 		}
 	}
 

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -2117,8 +2117,8 @@ show_motion_keys(PlanState *planstate, List *hashExpr, int nkeys, AttrNumber *ke
 		return;
 
 	/* Set up deparse context */
-	context = set_deparse_context_planstate(es->deparse_cxt,
-											(Node *) planstate,
+	context = set_deparse_context_plan(es->deparse_cxt,
+											planstate->plan,
 											ancestors);
 
     /* Merge Receive ordering key */


### PR DESCRIPTION
Resolve conflicts in src/backend/commands/explain.c

1) Commit 7559d8e updated the copyrights, while the GPDB-specific copyrights
had already been added to this location.

2) Commit b925a00 added a conditional return to src/backend/commands/explain.c
in the ExplainPrintJIT function, while the earlier commit 32fba77 had already
added a similar return to the same location.

3) Commit 6ef77cf added an add and remove to the ancestors list in
src/backend/commands/explain.c in the ExplainSubPlans function, while the
earlier commit added an UNUSED output to the same location.

4) Commit 6ef77cf renamed the function set_deparse_context_planstate to
set_deparse_context_plan and changed the planstate argument to plan in it, we
need to do the same in GPDB-specific places.