### PR TITLE
Resolve conflicts in src/backend/executor/execGrouping.c

### DIFF
--- a/src/backend/executor/execGrouping.c
+++ b/src/backend/executor/execGrouping.c
@@ -417,11 +417,8 @@ FindTupleHashEntry(TupleHashTable hashtable, TupleTableSlot *slot,
 }
 
 /*
-<<<<<<< HEAD
-=======
  * Compute the hash value for a tuple
  *
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * If tuple is NULL, use the input slot instead. This convention avoids the
  * need to materialize virtual input tuples unless they actually need to get
  * copied into the table.


### PR DESCRIPTION
Resolve conflicts in src/backend/executor/execGrouping.c

Commit 30d4772 updated the comment before the TupleHashTableHash function in
src/backend/executor/execGrouping.c, while the earlier commit 19cd1cf had
already refactored it into the TupleHashTableHash_internal function.