### PR TITLE
Resolve conflicts in src/backend/executor/functions.c

### DIFF
--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -177,19 +177,17 @@ static Datum postquel_get_single_result(TupleTableSlot *slot,
 										MemoryContext resultcontext);
 static void sql_exec_error_callback(void *arg);
 static void ShutdownSQLFunction(Datum arg);
-<<<<<<< HEAD
-static bool querytree_safe_for_qe_walker(Node *expr, void *context);
-=======
 static bool coerce_fn_result_column(TargetEntry *src_tle,
 									Oid res_type, int32 res_typmod,
 									bool tlist_is_modifiable,
 									List **upper_tlist,
 									bool *upper_tlist_nontrivial);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 static void sqlfunction_startup(DestReceiver *self, int operation, TupleDesc typeinfo);
 static bool sqlfunction_receive(TupleTableSlot *slot, DestReceiver *self);
 static void sqlfunction_shutdown(DestReceiver *self);
 static void sqlfunction_destroy(DestReceiver *self);
+
+static bool querytree_safe_for_qe_walker(Node *expr, void *context);
 
 static bool
 querytree_safe_for_qe_walker(Node *expr, void *context)


### PR DESCRIPTION
Resolve conflicts in src/backend/executor/functions.c

Commit 913bbd8 added a new function coerce_fn_result_column to
src/backend/executor/functions.c, while earlier commit 32f099f had already
added querytree_safe_for_qe_walker to the same location.