### PR TITLE
Resolve conflicts in src/backend/libpq/be-secure-gssapi.c

### DIFF
--- a/src/backend/libpq/be-secure-gssapi.c
+++ b/src/backend/libpq/be-secure-gssapi.c
@@ -3,11 +3,7 @@
  * be-secure-gssapi.c
  *  GSSAPI encryption support
  *
-<<<<<<< HEAD
- * Portions Copyright (c) 2018-2019, PostgreSQL Global Development Group
-=======
  * Portions Copyright (c) 2018-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  *
  * IDENTIFICATION
  *  src/backend/libpq/be-secure-gssapi.c
@@ -219,12 +215,9 @@ be_gssapi_write(Port *port, void *ptr, size_t len)
 
 		memcpy(PqGSSSendBuffer + PqGSSSendLength, output.value, output.length);
 		PqGSSSendLength += output.length;
-<<<<<<< HEAD
 
 		/* Release buffer storage allocated by GSSAPI */
 		gss_release_buffer(&minor, &output);
-=======
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 	}
 
 	/* If we get here, our counters should all match up. */
@@ -601,14 +594,10 @@ secure_open_gssapi(Port *port)
 				 */
 				if (ret < 0 &&
 					!(errno == EWOULDBLOCK || errno == EAGAIN || errno == EINTR))
-<<<<<<< HEAD
 				{
 					gss_release_buffer(&minor, &output);
 					return -1;
 				}
-=======
-					return -1;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 				/* Wait and retry if we couldn't write yet */
 				if (ret <= 0)


### PR DESCRIPTION
Resolve conflicts in src/backend/libpq/be-secure-gssapi.c

1) Commit 7559d8e updated copyrights, where GPDB-specific copyrights had
already been added.

2) Commit 2c0cdc8 changed in src/backend/libpq/be-secure-gssapi.c in the
be_gssapi_write function PqGSSSendPointer to PqGSSSendLength, while earlier
commit 42d0473 had already done this, and commit 505f676 added a buffer
deallocation to the same location.

3) Commit 2c0cdc8 added a conditional return on errors in
src/backend/libpq/be-secure-gssapi.c in secure_open_gssapi function, while
earlier commit 42d0473 already did this, and commit 505f676 added buffer
freeing in the same place.