### PR TITLE
Resolve conflicts in src/backend/optimizer/plan/planner.c

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -3,13 +3,9 @@
  * planner.c
  *	  The query optimizer external interface.
  *
-<<<<<<< HEAD
  * Portions Copyright (c) 2005-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
- * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
-=======
  * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  *
@@ -677,7 +673,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	Assert(glob->resultRelations == NIL);
 	Assert(parse == root->parse);
 	Assert(glob->rootResultRelations == NIL);
-<<<<<<< HEAD
+	Assert(glob->appendRelations == NIL);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -691,9 +687,6 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 			motion_sanity_check(root, top_plan);
 	}
 
-=======
-	Assert(glob->appendRelations == NIL);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 	top_plan = set_plan_references(root, top_plan);
 	/* ... and the subplans (both regular subplans and initplans) */
 	Assert(list_length(glob->subplans) == list_length(glob->subroots));


### PR DESCRIPTION
Resolve conflicts in src/backend/optimizer/plan/planner.c

1) Commit 7559d8e updated copyrights, where GPDB-specific copyrights had
already been added.

2) Commit 6ef77cf added an assertion in src/backend/optimizer/plan/planner.c in
the standard_planner function, while an earlier commit 6b0e52b had already
added GPDB-specific code in the same place.