### PR TITLE
Resolve conflicts in src/backend/optimizer/plan/subselect.c

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -6,13 +6,9 @@
  * This module deals with SubLinks and CTEs, but not subquery RTEs (i.e.,
  * not sub-SELECT-in-FROM cases).
  *
-<<<<<<< HEAD
  * Portions Copyright (c) 2005-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
- * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
-=======
  * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  * IDENTIFICATION
@@ -1543,20 +1539,12 @@ convert_ANY_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 	 * If the subquery is correlated, i.e. it refers to any Vars of the
 	 * parent query, mark it as lateral.
 	 */
-<<<<<<< HEAD
-	rte = addRangeTableEntryForSubquery(pstate,
-										subselect,
-										makeAlias("ANY_subquery", NIL),
-										correlated,	/* lateral */
-										false);
-=======
 	nsitem = addRangeTableEntryForSubquery(pstate,
 										   subselect,
 										   makeAlias("ANY_subquery", NIL),
-										   false,
+										   correlated,	/* lateral */
 										   false);
 	rte = nsitem->p_rte;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 	parse->rtable = lappend(parse->rtable, rte);
 	rtindex = list_length(parse->rtable);
 


### PR DESCRIPTION
Resolve conflicts in src/backend/optimizer/plan/subselect.c

1) Commit 7559d8e updated copyrights, where GPDB-specific copyrights had
already been added.

2) Commit 5815696 added a new local variable nsitem and its usage in the
function convert_ANY_sublink_to_join in src/backend/optimizer/plan/subselect.c,
while earlier commit c7649f1 had already added the correlated argument when
calling the function addRangeTableEntryForSubquery in the same place.