### PR TITLE
Resolve conflicts in src/backend/parser/parse_relation.c

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1733,7 +1733,8 @@ addRangeTableEntryForSubquery(ParseState *pstate,
 	 * Build a ParseNamespaceItem, but don't add it to the pstate's namespace
 	 * list --- caller must do that if appropriate.
 	 */
-	return buildNSItemFromLists(rte, list_length(pstate->p_rtable),
+	return buildNSItemFromLists(rte,
+								pstate != NULL ? list_length(pstate->p_rtable) : 0,
 								coltypes, coltypmods, colcollations);
 }
 

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -3,13 +3,9 @@
  * parse_relation.c
  *	  parser support routines dealing with relations
  *
-<<<<<<< HEAD
  * Portions Copyright (c) 2006-2008, Greenplum inc
  * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
- * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
-=======
  * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * Portions Copyright (c) 1994, Regents of the University of California
  *
  *
@@ -44,9 +40,7 @@
 #include "utils/syscache.h"
 #include "utils/varlena.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
-=======
 
 /*
  * Support for fuzzily matching columns.
@@ -63,7 +57,6 @@ typedef struct
 	RangeTblEntry *rsecond;		/* RTE of second */
 	AttrNumber	second;			/* Second closest attribute so far */
 } FuzzyAttrMatchState;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 #define MAX_FUZZY_DISTANCE				3
 
@@ -861,19 +854,9 @@ scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte,
 			 */
 			if (SearchSysCacheExists2(ATTNUM,
 									  ObjectIdGetDatum(rte->relid),
-<<<<<<< HEAD
 									  Int16GetDatum(attnum)) &&
 				get_rel_relkind(rte->relid) != RELKIND_VIEW)
-			{
-				var = make_var(pstate, rte, attnum, location);
-				/* Require read access to the column */
-				markVarForSelectPriv(pstate, var, rte);
-				result = (Node *) var;
-			}
-=======
-									  Int16GetDatum(attnum)))
 				result = attnum;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 		}
 	}
 
@@ -3429,208 +3412,6 @@ get_rte_attribute_name(RangeTblEntry *rte, AttrNumber attnum)
 }
 
 /*
-<<<<<<< HEAD
- * get_rte_attribute_type
- *		Get attribute type/typmod/collation information from a RangeTblEntry
- */
-void
-get_rte_attribute_type(RangeTblEntry *rte, AttrNumber attnum,
-					   Oid *vartype, int32 *vartypmod, Oid *varcollid)
-{
-	switch (rte->rtekind)
-	{
-		case RTE_RELATION:
-			{
-				/* Plain relation RTE --- get the attribute's type info */
-				HeapTuple	tp;
-				Form_pg_attribute att_tup;
-
-				tp = SearchSysCache2(ATTNUM,
-									 ObjectIdGetDatum(rte->relid),
-									 Int16GetDatum(attnum));
-				if (!HeapTupleIsValid(tp))	/* shouldn't happen */
-					elog(ERROR, "cache lookup failed for attribute %d of relation %u",
-						 attnum, rte->relid);
-				att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-
-				/*
-				 * If dropped column, pretend it ain't there.  See notes in
-				 * scanRTEForColumn.
-				 */
-				if (att_tup->attisdropped)
-					ereport(ERROR,
-							(errcode(ERRCODE_UNDEFINED_COLUMN),
-							 errmsg("column \"%s\" of relation \"%s\" does not exist",
-									NameStr(att_tup->attname),
-									get_rel_name(rte->relid))));
-				*vartype = att_tup->atttypid;
-				*vartypmod = att_tup->atttypmod;
-				*varcollid = att_tup->attcollation;
-				ReleaseSysCache(tp);
-			}
-			break;
-		case RTE_SUBQUERY:
-			{
-				/* Subselect RTE --- get type info from subselect's tlist */
-				TargetEntry *te = get_tle_by_resno(rte->subquery->targetList,
-												   attnum);
-
-				if (te == NULL || te->resjunk)
-					elog(ERROR, "subquery %s does not have attribute %d",
-						 rte->eref->aliasname, attnum);
-				*vartype = exprType((Node *) te->expr);
-				*vartypmod = exprTypmod((Node *) te->expr);
-				*varcollid = exprCollation((Node *) te->expr);
-			}
-			break;
-		case RTE_TABLEFUNCTION:
-		case RTE_FUNCTION:
-			{
-				/* Function RTE */
-				ListCell   *lc;
-				int			atts_done = 0;
-
-				/* Identify which function covers the requested column */
-				foreach(lc, rte->functions)
-				{
-					RangeTblFunction *rtfunc = (RangeTblFunction *) lfirst(lc);
-
-					if (attnum > atts_done &&
-						attnum <= atts_done + rtfunc->funccolcount)
-					{
-						TypeFuncClass functypclass;
-						Oid			funcrettype;
-						TupleDesc	tupdesc;
-
-						attnum -= atts_done;	/* now relative to this func */
-						functypclass = get_expr_result_type(rtfunc->funcexpr,
-															&funcrettype,
-															&tupdesc);
-
-						if (functypclass == TYPEFUNC_COMPOSITE ||
-							functypclass == TYPEFUNC_COMPOSITE_DOMAIN)
-						{
-							/* Composite data type, e.g. a table's row type */
-							Form_pg_attribute att_tup;
-
-							Assert(tupdesc);
-							Assert(attnum <= tupdesc->natts);
-							att_tup = TupleDescAttr(tupdesc, attnum - 1);
-
-							/*
-							 * If dropped column, pretend it ain't there.  See
-							 * notes in scanRTEForColumn.
-							 */
-							if (att_tup->attisdropped)
-								ereport(ERROR,
-										(errcode(ERRCODE_UNDEFINED_COLUMN),
-										 errmsg("column \"%s\" of relation \"%s\" does not exist",
-												NameStr(att_tup->attname),
-												rte->eref->aliasname)));
-							*vartype = att_tup->atttypid;
-							*vartypmod = att_tup->atttypmod;
-							*varcollid = att_tup->attcollation;
-						}
-						else if (functypclass == TYPEFUNC_SCALAR)
-						{
-							/* Base data type, i.e. scalar */
-							*vartype = funcrettype;
-							*vartypmod = -1;
-							*varcollid = exprCollation(rtfunc->funcexpr);
-						}
-						else if (functypclass == TYPEFUNC_RECORD)
-						{
-							*vartype = list_nth_oid(rtfunc->funccoltypes,
-													attnum - 1);
-							*vartypmod = list_nth_int(rtfunc->funccoltypmods,
-													  attnum - 1);
-							*varcollid = list_nth_oid(rtfunc->funccolcollations,
-													  attnum - 1);
-						}
-						else
-						{
-							/*
-							 * addRangeTableEntryForFunction should've caught
-							 * this
-							 */
-							elog(ERROR, "function in FROM has unsupported return type");
-						}
-						return;
-					}
-					atts_done += rtfunc->funccolcount;
-				}
-
-				/* If we get here, must be looking for the ordinality column */
-				if (rte->funcordinality && attnum == atts_done + 1)
-				{
-					*vartype = INT8OID;
-					*vartypmod = -1;
-					*varcollid = InvalidOid;
-					return;
-				}
-
-				/* this probably can't happen ... */
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_COLUMN),
-						 errmsg("column %d of relation \"%s\" does not exist",
-								attnum,
-								rte->eref->aliasname)));
-			}
-			break;
-		case RTE_JOIN:
-			{
-				/*
-				 * Join RTE --- get type info from join RTE's alias variable
-				 */
-				Node	   *aliasvar;
-
-				Assert(attnum > 0 && attnum <= list_length(rte->joinaliasvars));
-				aliasvar = (Node *) list_nth(rte->joinaliasvars, attnum - 1);
-				Assert(aliasvar != NULL);
-				*vartype = exprType(aliasvar);
-				*vartypmod = exprTypmod(aliasvar);
-				*varcollid = exprCollation(aliasvar);
-			}
-			break;
-		case RTE_TABLEFUNC:
-		case RTE_VALUES:
-		case RTE_CTE:
-		case RTE_NAMEDTUPLESTORE:
-			{
-				/*
-				 * tablefunc, VALUES, CTE, or ENR RTE --- get type info from
-				 * lists in the RTE
-				 */
-				Assert(attnum > 0 && attnum <= list_length(rte->coltypes));
-				*vartype = list_nth_oid(rte->coltypes, attnum - 1);
-				*vartypmod = list_nth_int(rte->coltypmods, attnum - 1);
-				*varcollid = list_nth_oid(rte->colcollations, attnum - 1);
-
-				/* For ENR, better check for dropped column */
-				if (!OidIsValid(*vartype))
-					ereport(ERROR,
-							(errcode(ERRCODE_UNDEFINED_COLUMN),
-							 errmsg("column %d of relation \"%s\" does not exist",
-									attnum,
-									rte->eref->aliasname)));
-			}
-			break;
-		case RTE_RESULT:
-			/* this probably can't happen ... */
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_COLUMN),
-					 errmsg("column %d of relation \"%s\" does not exist",
-							attnum,
-							rte->eref->aliasname)));
-			break;
-		default:
-			elog(ERROR, "unrecognized RTE kind: %d", (int) rte->rtekind);
-	}
-}
-
-/*
-=======
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * get_rte_attribute_is_dropped
  *		Check whether attempted attribute ref is to a dropped column
  */


### PR DESCRIPTION
Resolve conflicts in src/backend/parser/parse_relation.c

1) Commit 7559d8e updated copyrights, where GPDB-specific copyrights had
already been added.

2) Commit b541e9a added a new FuzzyAttrMatchState structure to
src/backend/parser/parse_relation.c, while earlier commit b120194 had already
added cdb/cdbvars.h to the same location.

3) Commit b541e9a changed part of the code in
src/backend/parser/parse_relation.c in the scanRTEForColumn function to assign
result = attnum, while earlier commits e5d1779 and 2383d6d had already added an
additional condition to the same location.

4) Commit 5815696 removed the get_rte_attribute_type function in
src/backend/parser/parse_relation.c, while the earlier commit 6b0e52b had
already added handling of the RTE_TABLEFUNCTION case to this function.

5) Commit 5815696 added at the end of the addRangeTableEntryForSubquery
function a call to the buildNSItemFromLists function with unconditional
dereferencing of the pstate pointer, which can be NULL, for example, when
calling the addRangeTableEntryForSubquery function from the
add_notin_subquery_rte function, in addition, there is already a check for this
pointer being NULL above, we need to add a similar check in the new place.