### PR TITLE
Resolve conflicts in src/backend/postmaster/bgwriter.c

### DIFF
--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -84,6 +84,8 @@ int			BgWriterDelay = 200;
 static TimestampTz last_snapshot_ts;
 static XLogRecPtr last_snapshot_lsn = InvalidXLogRecPtr;
 
+/* Signal handler */
+static void bg_quickdie(SIGNAL_ARGS);
 
 /*
  * Main entry point for bgwriter process
@@ -105,7 +107,7 @@ BackgroundWriterMain(void)
 	pqsignal(SIGHUP, SignalHandlerForConfigReload);
 	pqsignal(SIGINT, SIG_IGN);
 	pqsignal(SIGTERM, SignalHandlerForShutdownRequest);
-	pqsignal(SIGQUIT, SignalHandlerForCrashExit);
+	pqsignal(SIGQUIT, bg_quickdie);
 	pqsignal(SIGALRM, SIG_IGN);
 	pqsignal(SIGPIPE, SIG_IGN);
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
@@ -342,64 +344,16 @@ BackgroundWriterMain(void)
 		prev_hibernate = can_hibernate;
 	}
 }
-<<<<<<< HEAD
 
-
-/* --------------------------------
- *		signal handler routines
- * --------------------------------
- */
 
 /*
- * bg_quickdie() occurs when signalled SIGQUIT by the postmaster.
- *
- * Some backend has bought the farm,
- * so we need to stop what we're doing and exit.
+ GPDB: We need this handler because it is the only one that needs a fault
+ injector for tests.
  */
 static void
 bg_quickdie(SIGNAL_ARGS)
 {
 	SIMPLE_FAULT_INJECTOR("fault_in_background_writer_quickdie");
 
-	/*
-	 * We DO NOT want to run proc_exit() or atexit() callbacks -- we're here
-	 * because shared memory may be corrupted, so we don't want to try to
-	 * clean up our transaction.  Just nail the windows shut and get out of
-	 * town.  The callbacks wouldn't be safe to run from a signal handler,
-	 * anyway.
-	 *
-	 * Note we do _exit(2) not _exit(0).  This is to force the postmaster into
-	 * a system reset cycle if someone sends a manual SIGQUIT to a random
-	 * backend.  This is necessary precisely because we don't clean up our
-	 * shared memory state.  (The "dead man switch" mechanism in pmsignal.c
-	 * should ensure the postmaster sees this as a crash, too, but no harm in
-	 * being doubly sure.)
-	 */
-	_exit(2);
+	SignalHandlerForCrashExit(postgres_signal_arg);
 }
-
-/* SIGHUP: set flag to re-read config file at next convenient time */
-static void
-BgSigHupHandler(SIGNAL_ARGS)
-{
-	int			save_errno = errno;
-
-	got_SIGHUP = true;
-	SetLatch(MyLatch);
-
-	errno = save_errno;
-}
-
-/* SIGTERM: set flag to shutdown and exit */
-static void
-ReqShutdownHandler(SIGNAL_ARGS)
-{
-	int			save_errno = errno;
-
-	shutdown_requested = true;
-	SetLatch(MyLatch);
-
-	errno = save_errno;
-}
-=======
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268


### PR DESCRIPTION
Resolve conflicts in src/backend/postmaster/bgwriter.c

Commit 1e53fe0 removed the BgSigHupHandler function from
src/backend/postmaster/bgwriter.c, and commit 7dbfea3 moved the
HandleBackgroundWriterInterrupts, bg_quickdie, and ReqShutdownHandler functions
from src/backend/postmaster/bgwriter.c to a new file
src/backend/postmaster/interrupt.c and renamed them to
HandleMainLoopInterrupts, SignalHandlerForCrashExit, and
SignalHandlerForShutdownRequest, while earlier commit 7bdad20 added a
SIMPLE_FAULT_INJECTOR call to bg_quickdie.