### PR TITLE
Resolve conflicts in src/backend/statistics/dependencies.c

### DIFF
--- a/src/backend/statistics/dependencies.c
+++ b/src/backend/statistics/dependencies.c
@@ -955,7 +955,9 @@ dependencies_clauselist_selectivity(PlannerInfo *root,
 	Bitmapset  *clauses_attnums = NULL;
 	Bitmapset **list_attnums;
 	int			listidx;
-<<<<<<< HEAD
+	MVDependencies    **dependencies = NULL;
+	int					ndependencies = 0;
+	int			i;
 	RangeTblEntry *rte = planner_rt_fetch(rel->relid, root);
 
 	/*
@@ -967,11 +969,6 @@ dependencies_clauselist_selectivity(PlannerInfo *root,
 	 */
 	if (rte->inh && rte->relkind != RELKIND_PARTITIONED_TABLE)
 		return 1.0;
-=======
-	MVDependencies    **dependencies = NULL;
-	int					ndependencies = 0;
-	int			i;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 	/* check if there's any stats that might be useful for us. */
 	if (!has_stats_of_kind(rel->statlist, STATS_EXT_DEPENDENCIES))


### PR DESCRIPTION
Resolve conflicts in src/backend/statistics/dependencies.c

Commit aaa6761 removed the local variable stat in
src/backend/statistics/dependencies.c in the function
dependencies_clauselist_selectivity, changed the type of the local variable
dependencies, and added two new local variables ndependencies and i, while the
earlier commit 14de72e added a conditional return to the same place.