### PR TITLE
Resolve conflicts in src/backend/storage/smgr/md.c

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1408,17 +1408,11 @@ _mdnblocks(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 int
 mdsyncfiletag(const FileTag *ftag, char *path)
 {
-<<<<<<< HEAD
 	SMgrRelation reln = smgropen(ftag->rnode, InvalidBackendId, 0);
-	MdfdVec    *v;
-	char	   *p;
-=======
-	SMgrRelation reln = smgropen(ftag->rnode, InvalidBackendId);
 	File		file;
 	bool		need_to_close;
 	int			result,
 				save_errno;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 	/* See if we already have the file open, or need to open it. */
 	if (ftag->segno < reln->md_num_open_segs[ftag->forknum])


### PR DESCRIPTION
Resolve conflicts in src/backend/storage/smgr/md.c

Commits 7bb3102 and 7c85be0 refactored local variables in mdsyncfiletag
function in src/backend/storage/smgr/md.c, while earlier commit 19cd1cf added
third argument to smgropen function call in the same place.