### PR TITLE
Resolve conflicts in src/backend/utils/misc/ps_status.c

### DIFF
--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -7,13 +7,9 @@
  *
  * src/backend/utils/misc/ps_status.c
  *
-<<<<<<< HEAD
  * Portions Copyright (c) 2005-2009, Greenplum inc
  * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
- * Copyright (c) 2000-2019, PostgreSQL Global Development Group
-=======
  * Copyright (c) 2000-2020, PostgreSQL Global Development Group
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  * various details abducted from various places
  *--------------------------------------------------------------------
  */
@@ -482,10 +478,13 @@ get_ps_display_from_position(size_t pos, int *displen)
 	}
 #endif
 
-<<<<<<< HEAD
+#ifndef PS_USE_NONE
 	*displen = (int) (ps_buffer_cur_len - real_act_prefix_size);
 
 	return ps_buffer + pos;
+#else
+	return "";
+#endif
 }
 
 /*
@@ -518,13 +517,4 @@ const char *
 get_real_act_ps_display(int *displen)
 {
 	return get_ps_display_from_position(real_act_prefix_size, displen);
-=======
-#ifndef PS_USE_NONE
-	*displen = (int) (ps_buffer_cur_len - ps_buffer_fixed_size);
-
-	return ps_buffer + ps_buffer_fixed_size;
-#else
-	return "";
-#endif
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 }


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/misc/ps_status.c

1) Commit 7559d8e updated copyrights, where GPDB-specific copyrights had
already been added.

2) Commit 8c6d30f added PS_USE_NONE ifdef in src/backend/utils/misc/ps_status.c
in get_ps_display function, while earlier commit 6b0e52b had already added
GPDB-specific functions nearby.