### PR TITLE
Resolve conflicts in src/backend/utils/adt/ruleutils.c

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -4588,10 +4588,10 @@ set_deparse_plan(deparse_namespace *dpns, Plan *plan)
 	 * first child plan is the OUTER referent; this is to support RETURNING
 	 * lists containing references to non-target relations.
 	 */
-<<<<<<< HEAD
-	if (IsA(ps, AppendState))
-		dpns->outer_planstate = ((AppendState *) ps)->appendplans[0];
-	else if (IsA(ps, SequenceState))
+	if (IsA(plan, Append))
+		dpns->outer_plan = linitial(((Append *) plan)->appendplans);
+	else if (IsA(plan, Sequence))
+	{
 		/*
 		 * A Sequence node returns tuples from the *last* child node only.
 		 * The other subplans can even have a different, incompatible tuple
@@ -4599,19 +4599,13 @@ set_deparse_plan(deparse_namespace *dpns, Plan *plan)
 		 * as the first subplan, and the Dynamic Table Scan as the second
 		 * subplan.
 		 */
-		dpns->outer_planstate = ((SequenceState *) ps)->subplans[1];
-	else if (IsA(ps, MergeAppendState))
-		dpns->outer_planstate = ((MergeAppendState *) ps)->mergeplans[0];
-	else if (IsA(ps, ModifyTableState))
-		dpns->outer_planstate = ((ModifyTableState *) ps)->mt_plans[0];
-=======
-	if (IsA(plan, Append))
-		dpns->outer_plan = linitial(((Append *) plan)->appendplans);
+		Assert(list_length(((Sequence *) plan)->subplans) == 2);
+		dpns->outer_plan = llast(((Sequence *) plan)->subplans);
+	}
 	else if (IsA(plan, MergeAppend))
 		dpns->outer_plan = linitial(((MergeAppend *) plan)->mergeplans);
 	else if (IsA(plan, ModifyTable))
 		dpns->outer_plan = linitial(((ModifyTable *) plan)->plans);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 	else
 		dpns->outer_plan = outerPlan(plan);
 
@@ -4629,29 +4623,23 @@ set_deparse_plan(deparse_namespace *dpns, Plan *plan)
 	 * to reuse OUTER, it's used for RETURNING in some modify table cases,
 	 * although not INSERT .. CONFLICT).
 	 */
-<<<<<<< HEAD
-	if (IsA(ps, SubqueryScanState))
-		dpns->inner_planstate = ((SubqueryScanState *) ps)->subplan;
-	else if (IsA(ps, CteScanState))
-		dpns->inner_planstate = ((CteScanState *) ps)->cteplanstate;
-	else if (IsA(ps, SequenceState))
-		/*
-		 * Set the inner_plan to a sequences first child only if it is a
-		 * partition selector. This is a specific fix to enable Explain’s of
-		 * query plans that have a Partition Selector
-		 */
-		dpns->inner_planstate = ((SequenceState *) ps)->subplans[0];
-	else if (IsA(ps, ModifyTableState))
-		dpns->inner_planstate = ps;
-=======
 	if (IsA(plan, SubqueryScan))
 		dpns->inner_plan = ((SubqueryScan *) plan)->subplan;
 	else if (IsA(plan, CteScan))
 		dpns->inner_plan = list_nth(dpns->subplans,
 									((CteScan *) plan)->ctePlanId - 1);
+	else if (IsA(plan, Sequence))
+	{
+		/*
+		 * Set the inner_plan to a sequences first child only if it is a
+		 * partition selector. This is a specific fix to enable Explain’s of
+		 * query plans that have a Partition Selector
+		 */
+		Assert(list_length(((Sequence *) plan)->subplans) == 2);
+		dpns->inner_plan = linitial(((Sequence *) plan)->subplans);
+	}
 	else if (IsA(plan, ModifyTable))
 		dpns->inner_plan = plan;
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 	else
 		dpns->inner_plan = innerPlan(plan);
 
@@ -7137,14 +7125,7 @@ get_name_for_var_field(Var *var, int fieldno,
 
 		tle = get_tle_by_resno(dpns->outer_tlist, varattno);
 		if (!tle)
-<<<<<<< HEAD
-		{
-			elog(ERROR, "bogus varattno for OUTER_VAR var: %d", var->varattno);
-			return NULL;
-		}
-=======
 			elog(ERROR, "bogus varattno for OUTER_VAR var: %d", varattno);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 		Assert(netlevelsup == 0);
 		push_child_plan(dpns, dpns->outer_plan, &save_dpns);
@@ -7192,13 +7173,8 @@ get_name_for_var_field(Var *var, int fieldno,
 	}
 	else
 	{
-<<<<<<< HEAD
-		elog(WARNING, "bogus varno: %d", var->varno);
-		return psprintf("<BOGUS %d>", var->varattno);
-=======
-		elog(ERROR, "bogus varno: %d", varno);
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
-		return NULL;			/* keep compiler quiet */
+		elog(WARNING, "bogus varno: %d", varno);
+		return psprintf("<BOGUS %d>", varattno);
 	}
 
     if (rte == NULL)

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -9656,13 +9656,13 @@ get_dqa_expr(DQAExpr *dqa_expr,deparse_context *context)
 	StringInfo	buf = context->buf;
 	Bitmapset *bm = dqa_expr->agg_args_id_bms;
 	deparse_namespace *dnps = (deparse_namespace *) linitial(context->namespaces);
-	struct PlanState *planstate = dnps->planstate;
+	struct Plan *plan = dnps->plan;
 
 	resetStringInfo(buf);
 	appendStringInfoChar(buf, '(');
 	while ((id = bms_next_member(bm, id)) >= 0)
 	{
-		TargetEntry *te = get_sortgroupref_tle((Index)id, planstate->plan->targetlist);
+		TargetEntry *te = get_sortgroupref_tle((Index)id, plan->targetlist);
 		char	   *exprstr;
 
 		if (!te)

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -4640,6 +4640,8 @@ set_deparse_plan(deparse_namespace *dpns, Plan *plan)
 	}
 	else if (IsA(plan, ModifyTable))
 		dpns->inner_plan = plan;
+	else if (IsA(plan, ShareInputScan))
+		dpns->inner_plan = outerPlan(plan);
 	else
 		dpns->inner_plan = innerPlan(plan);
 

--- a/src/test/regress/expected/create_view.out
+++ b/src/test/regress/expected/create_view.out
@@ -1819,22 +1819,22 @@ select pg_get_viewdef('tt25v', true);
 -- also check cases seen only in EXPLAIN
 explain (verbose, costs off)
 select * from tt24v;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Hash Join
-   Output: (cte.r).column2, ((ROW("*VALUES*".column1, "*VALUES*".column2))).column2
-   Hash Cond: (((ROW("*VALUES*".column1, "*VALUES*".column2))).column1 = (cte.r).column1)
-   CTE cte
-     ->  Values Scan on "*VALUES*_1"
-           Output: ROW("*VALUES*_1".column1, "*VALUES*_1".column2)
+   Output: (share0_ref1.r).column2, ((ROW("*VALUES*".column1, "*VALUES*".column2))).column2
+   Hash Cond: (((ROW("*VALUES*".column1, "*VALUES*".column2))).column1 = (share0_ref1.r).column1)
    ->  Limit
          Output: (ROW("*VALUES*".column1, "*VALUES*".column2))
          ->  Values Scan on "*VALUES*"
                Output: ROW("*VALUES*".column1, "*VALUES*".column2)
    ->  Hash
-         Output: cte.r
-         ->  CTE Scan on cte
-               Output: cte.r
+         Output: share0_ref1.r
+         ->  Shared Scan (share slice:id 0:0)
+               Output: share0_ref1.r
+               ->  Values Scan on "*VALUES*_1"
+                     Output: ROW("*VALUES*_1".column1, "*VALUES*_1".column2)
+ Optimizer: Postgres query optimizer
 (14 rows)
 
 explain (verbose, costs off)
@@ -1874,7 +1874,7 @@ select pg_get_viewdef('tt26v', true);
      v.x + (v.y + v.z) AS c6,                          +
      v.x + (v.y # v.z) AS c7,                          +
      v.x > v.y AND (v.y > v.z OR v.x > v.z) AS c8,     +
-     v.x > v.y OR v.y > v.z AND NOT v.x > v.z AS c9,   +
+     v.x > v.y OR (v.y > v.z AND NOT v.x > v.z) AS c9, +
      ((v.x, v.y) <> ALL ( VALUES (1,2), (3,4))) AS c10,+
      ((v.x, v.y) <= ANY ( VALUES (1,2), (3,4))) AS c11 +
     FROM ( VALUES (1,2,3)) v(x, y, z);

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1781,6 +1781,105 @@ select pg_get_ruledef(oid, true) from pg_rewrite
      43 AS col_b;
 (1 row)
 
+-- test extraction of FieldSelect field names (get_name_for_var_field)
+create view tt24v as
+with cte as materialized (select r from (values(1,2),(3,4)) r)
+select (r).column2 as col_a, (rr).column2 as col_b from
+  cte join (select rr from (values(1,7),(3,8)) rr limit 2) ss
+  on (r).column1 = (rr).column1;
+select pg_get_viewdef('tt24v', true);
+                       pg_get_viewdef                       
+------------------------------------------------------------
+  WITH cte AS MATERIALIZED (                               +
+          SELECT r.*::record AS r                          +
+            FROM ( VALUES (1,2), (3,4)) r                  +
+         )                                                 +
+  SELECT (cte.r).column2 AS col_a,                         +
+     (ss.rr).column2 AS col_b                              +
+    FROM cte                                               +
+      JOIN ( SELECT rr.*::record AS rr                     +
+            FROM ( VALUES (1,7), (3,8)) rr                 +
+          LIMIT 2) ss ON (cte.r).column1 = (ss.rr).column1;
+(1 row)
+
+create view tt25v as
+with cte as materialized (select pg_get_keywords() k)
+select (k).word from cte;
+select pg_get_viewdef('tt25v', true);
+             pg_get_viewdef             
+----------------------------------------
+  WITH cte AS MATERIALIZED (           +
+          SELECT pg_get_keywords() AS k+
+         )                             +
+  SELECT (cte.k).word AS word          +
+    FROM cte;
+(1 row)
+
+-- also check cases seen only in EXPLAIN
+explain (verbose, costs off)
+select * from tt24v;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Hash Join
+   Output: (share0_ref1.r).column2, ((ROW("*VALUES*".column1, "*VALUES*".column2))).column2
+   Hash Cond: (((ROW("*VALUES*".column1, "*VALUES*".column2))).column1 = (share0_ref1.r).column1)
+   ->  Limit
+         Output: (ROW("*VALUES*".column1, "*VALUES*".column2))
+         ->  Values Scan on "*VALUES*"
+               Output: ROW("*VALUES*".column1, "*VALUES*".column2)
+   ->  Hash
+         Output: share0_ref1.r
+         ->  Shared Scan (share slice:id 0:0)
+               Output: share0_ref1.r
+               ->  Values Scan on "*VALUES*_1"
+                     Output: ROW("*VALUES*_1".column1, "*VALUES*_1".column2)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+explain (verbose, costs off)
+select (r).column2 from (select r from (values(1,2),(3,4)) r limit 1) ss;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Subquery Scan on ss
+   Output: (ss.r).column2
+   ->  Limit
+         Output: (ROW("*VALUES*".column1, "*VALUES*".column2))
+         ->  Values Scan on "*VALUES*"
+               Output: ROW("*VALUES*".column1, "*VALUES*".column2)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- test pretty-print parenthesization rules, and SubLink deparsing
+create view tt26v as
+select x + y + z as c1,
+       (x * y) + z as c2,
+       x + (y * z) as c3,
+       (x + y) * z as c4,
+       x * (y + z) as c5,
+       x + (y + z) as c6,
+       x + (y # z) as c7,
+       (x > y) AND (y > z OR x > z) as c8,
+       (x > y) OR (y > z AND NOT (x > z)) as c9,
+       (x,y) <> ALL (values(1,2),(3,4)) as c10,
+       (x,y) <= ANY (values(1,2),(3,4)) as c11
+from (values(1,2,3)) v(x,y,z);
+select pg_get_viewdef('tt26v', true);
+                     pg_get_viewdef                     
+--------------------------------------------------------
+  SELECT v.x + v.y + v.z AS c1,                        +
+     v.x * v.y + v.z AS c2,                            +
+     v.x + v.y * v.z AS c3,                            +
+     (v.x + v.y) * v.z AS c4,                          +
+     v.x * (v.y + v.z) AS c5,                          +
+     v.x + (v.y + v.z) AS c6,                          +
+     v.x + (v.y # v.z) AS c7,                          +
+     v.x > v.y AND (v.y > v.z OR v.x > v.z) AS c8,     +
+     v.x > v.y OR (v.y > v.z AND NOT v.x > v.z) AS c9, +
+     ((v.x, v.y) <> ALL ( VALUES (1,2), (3,4))) AS c10,+
+     ((v.x, v.y) <= ANY ( VALUES (1,2), (3,4))) AS c11 +
+    FROM ( VALUES (1,2,3)) v(x, y, z);
+(1 row)
+
 -- clean up all the random objects we made above
 DROP SCHEMA temp_view_test CASCADE;
 NOTICE:  drop cascades to 27 other objects
@@ -1812,7 +1911,7 @@ drop cascades to view aliased_view_2
 drop cascades to view aliased_view_3
 drop cascades to view aliased_view_4
 DROP SCHEMA testviewschm2 CASCADE;
-NOTICE:  drop cascades to 64 other objects
+NOTICE:  drop cascades to 67 other objects
 DETAIL:  drop cascades to table t1
 drop cascades to view temporal1
 drop cascades to view temporal2
@@ -1877,3 +1976,6 @@ drop cascades to view tt20v
 drop cascades to view tt21v
 drop cascades to view tt22v
 drop cascades to view tt23v
+drop cascades to view tt24v
+drop cascades to view tt25v
+drop cascades to view tt26v


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/adt/ruleutils.c

1) Commit 6ef77cf in src/backend/utils/adt/ruleutils.c renamed the function
set_deparse_planstate to set_deparse_plan and its argument ps of type PlanState
to plan of type Plan, while earlier commit c7649f1 added GPDB-specific handling
of SequenceState.

2) Commit 9ce77d7 in src/backend/utils/adt/ruleutils.c in the function
get_name_for_var_field changed var->varattno to varattno when issuing an error
message, while earlier commit 25a9039 added a NULL return in the same place.

3) Commit 9ce77d7 in src/backend/utils/adt/ruleutils.c in
get_name_for_var_field function changed var->varno to varno when issuing an
error message, while earlier commit 25a9039 changed the error to a warning, and
also added a return.

4) Commit 6ef77cf changed the planstate field in the deparse_namespace
structure to plan, we need to do the same in GPDB-specific places.

5) Commit 6ef77cf in src/backend/utils/adt/ruleutils.c in deparse_namespace
structure renamed planstate, outer_planstate and inner_planstate fields to
plan, outer_plan and inner_plan fields, and set_deparse_planstate function to
set_deparse_plan function, which fills these fields. This patch adds handling
of GPDB-specific ShareInputScan node.

6) Commit 830d1c7 added in src/test/regress/sql/create_view.sql, we need to
adapt their output for GPDB and add it to ORCA.
