### PR TITLE
ADBDEV-7854: Add relation_toast_am and relation_fetch_toast_slice callbacks for AO tables

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -2158,6 +2158,7 @@ static const TableAmRoutine ao_column_methods = {
 	.relation_size = aoco_relation_size,
 	.relation_needs_toast_table = aoco_relation_needs_toast_table,
 	.relation_toast_am = aoco_relation_toast_am,
+	.relation_fetch_toast_slice = heap_fetch_toast_slice,
 
 	.relation_estimate_size = aoco_estimate_rel_size,
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1899,6 +1899,16 @@ aoco_relation_needs_toast_table(Relation rel)
 	return false;
 }
 
+static Oid
+aoco_relation_toast_am(Relation rel)
+{
+	/*
+	 * AO_COLUMN never used the toasting, don't create the toast table from
+	 * GPDB
+	 */
+	return InvalidOid;
+}
+
 /* ------------------------------------------------------------------------
  * Planner related callbacks for the heap AM
  * ------------------------------------------------------------------------
@@ -2147,6 +2157,7 @@ static const TableAmRoutine ao_column_methods = {
 
 	.relation_size = aoco_relation_size,
 	.relation_needs_toast_table = aoco_relation_needs_toast_table,
+	.relation_toast_am = aoco_relation_toast_am,
 
 	.relation_estimate_size = aoco_estimate_rel_size,
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1927,6 +1927,12 @@ appendonly_relation_needs_toast_table(Relation rel)
 	return (tuple_length > TOAST_TUPLE_THRESHOLD);
 }
 
+static Oid
+appendonly_relation_toast_am(Relation rel)
+{
+	return HEAP_TABLE_AM_OID;
+}
+
 /* ------------------------------------------------------------------------
  * Planner related callbacks for the appendonly AM
  * ------------------------------------------------------------------------
@@ -2159,6 +2165,7 @@ static const TableAmRoutine ao_row_methods = {
 
 	.relation_size = appendonly_relation_size,
 	.relation_needs_toast_table = appendonly_relation_needs_toast_table,
+	.relation_toast_am = appendonly_relation_toast_am,
 
 	.relation_estimate_size = appendonly_estimate_rel_size,
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -2166,6 +2166,7 @@ static const TableAmRoutine ao_row_methods = {
 	.relation_size = appendonly_relation_size,
 	.relation_needs_toast_table = appendonly_relation_needs_toast_table,
 	.relation_toast_am = appendonly_relation_toast_am,
+	.relation_fetch_toast_slice = heap_fetch_toast_slice,
 
 	.relation_estimate_size = appendonly_estimate_rel_size,
 


### PR DESCRIPTION
Add relation_toast_am and relation_fetch_toast_slice callbacks for AO tables

1) Commit 83322e3 added a new relation_toast_am callback to the TableAmRoutine
structure and its initialization to the heapam_methods global variable, as well
as its use in the table_relation_toast_am function and its use in the
create_toast_table function.

2) Commit ce242ae added a new relation_fetch_toast_slice callback to the
TableAmRoutine structure and its initialization to the global heapam_methods
variable, as well as its use in the table_relation_fetch_toast_slice function
and its use in the toast_fetch_datum and toast_fetch_datum_slice functions.

The patch adds the initialization of these callbacks to the AO table globals
ao_column_methods and ao_row_methods.