### PR TITLE
Add relation_toast_am and relation_fetch_toast_slice callbacks for AO tables

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1906,7 +1906,20 @@ aoco_relation_toast_am(Relation rel)
 	 * AO_COLUMN never used the toasting, don't create the toast table from
 	 * GPDB
 	 */
-	return InvalidOid;
+	Assert(0);
+	return InvalidOid;		/* keep compiler quiet */
+}
+
+static void
+aoco_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
+					   int32 sliceoffset, int32 slicelength,
+					   struct varlena *result)
+{
+	/*
+	 * AO_COLUMN never used the toasting, don't create the toast table from
+	 * GPDB
+	 */
+	Assert(0);
 }
 
 /* ------------------------------------------------------------------------
@@ -2158,7 +2171,7 @@ static const TableAmRoutine ao_column_methods = {
 	.relation_size = aoco_relation_size,
 	.relation_needs_toast_table = aoco_relation_needs_toast_table,
 	.relation_toast_am = aoco_relation_toast_am,
-	.relation_fetch_toast_slice = heap_fetch_toast_slice,
+	.relation_fetch_toast_slice = aoco_fetch_toast_slice,
 
 	.relation_estimate_size = aoco_estimate_rel_size,
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -2158,6 +2158,7 @@ static const TableAmRoutine ao_column_methods = {
 	.relation_size = aoco_relation_size,
 	.relation_needs_toast_table = aoco_relation_needs_toast_table,
 	.relation_toast_am = aoco_relation_toast_am,
+	.relation_fetch_toast_slice = heap_fetch_toast_slice,
 
 	.relation_estimate_size = aoco_estimate_rel_size,
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1899,6 +1899,16 @@ aoco_relation_needs_toast_table(Relation rel)
 	return false;
 }
 
+static Oid
+aoco_relation_toast_am(Relation rel)
+{
+	/*
+	 * AO_COLUMN never used the toasting, don't create the toast table from
+	 * GPDB
+	 */
+	return InvalidOid;
+}
+
 /* ------------------------------------------------------------------------
  * Planner related callbacks for the heap AM
  * ------------------------------------------------------------------------
@@ -2147,6 +2157,7 @@ static const TableAmRoutine ao_column_methods = {
 
 	.relation_size = aoco_relation_size,
 	.relation_needs_toast_table = aoco_relation_needs_toast_table,
+	.relation_toast_am = aoco_relation_toast_am,
 
 	.relation_estimate_size = aoco_estimate_rel_size,
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1907,7 +1907,7 @@ aoco_relation_toast_am(Relation rel)
 	 * GPDB
 	 */
 	Assert(0);
-	return InvalidOid;		/* keep compiler quiet */
+	ereport(ERROR, (errmsg("AO_COLUMN never used the toasting")));
 }
 
 static void
@@ -1920,6 +1920,7 @@ aoco_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 	 * GPDB
 	 */
 	Assert(0);
+	ereport(ERROR, (errmsg("AO_COLUMN never used the toasting")));
 }
 
 /* ------------------------------------------------------------------------

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1932,6 +1932,9 @@ appendonly_relation_toast_am(Relation rel)
 {
 	Assert(table_relation_needs_toast_table(rel));
 
+	/*
+	 * AO_ROW toast are stored in heap tables
+	 */
 	return HEAP_TABLE_AM_OID;
 }
 
@@ -1940,6 +1943,9 @@ appendonly_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 							 int32 sliceoffset, int32 slicelength,
 							 struct varlena *result)
 {
+	/*
+	 * AO_ROW toast are stored in heap tables
+	 */
 	return heap_fetch_toast_slice(toastrel, valueid, attrsize, sliceoffset,
 								  slicelength, result);
 }

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1927,6 +1927,12 @@ appendonly_relation_needs_toast_table(Relation rel)
 	return (tuple_length > TOAST_TUPLE_THRESHOLD);
 }
 
+static Oid
+appendonly_relation_toast_am(Relation rel)
+{
+	return HEAP_TABLE_AM_OID;
+}
+
 /* ------------------------------------------------------------------------
  * Planner related callbacks for the appendonly AM
  * ------------------------------------------------------------------------
@@ -2159,6 +2165,7 @@ static const TableAmRoutine ao_row_methods = {
 
 	.relation_size = appendonly_relation_size,
 	.relation_needs_toast_table = appendonly_relation_needs_toast_table,
+	.relation_toast_am = appendonly_relation_toast_am,
 
 	.relation_estimate_size = appendonly_estimate_rel_size,
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1933,7 +1933,7 @@ appendonly_relation_toast_am(Relation rel)
 	Assert(table_relation_needs_toast_table(rel));
 
 	/*
-	 * AO_ROW toasts are stored in heap tables
+	 * Toasts for AO_ROW tables are stored in heap tables
 	 */
 	return HEAP_TABLE_AM_OID;
 }
@@ -1944,7 +1944,7 @@ appendonly_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 							 struct varlena *result)
 {
 	/*
-	 * AO_ROW toasts are stored in heap tables
+	 * Toasts for AO_ROW tables are stored in heap tables
 	 */
 	return heap_fetch_toast_slice(toastrel, valueid, attrsize, sliceoffset,
 								  slicelength, result);

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1933,7 +1933,7 @@ appendonly_relation_toast_am(Relation rel)
 	Assert(table_relation_needs_toast_table(rel));
 
 	/*
-	 * AO_ROW toast are stored in heap tables
+	 * AO_ROW toasts are stored in heap tables
 	 */
 	return HEAP_TABLE_AM_OID;
 }
@@ -1944,7 +1944,7 @@ appendonly_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 							 struct varlena *result)
 {
 	/*
-	 * AO_ROW toast are stored in heap tables
+	 * AO_ROW toasts are stored in heap tables
 	 */
 	return heap_fetch_toast_slice(toastrel, valueid, attrsize, sliceoffset,
 								  slicelength, result);

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -2166,6 +2166,7 @@ static const TableAmRoutine ao_row_methods = {
 	.relation_size = appendonly_relation_size,
 	.relation_needs_toast_table = appendonly_relation_needs_toast_table,
 	.relation_toast_am = appendonly_relation_toast_am,
+	.relation_fetch_toast_slice = heap_fetch_toast_slice,
 
 	.relation_estimate_size = appendonly_estimate_rel_size,
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1930,7 +1930,18 @@ appendonly_relation_needs_toast_table(Relation rel)
 static Oid
 appendonly_relation_toast_am(Relation rel)
 {
+	Assert(table_relation_needs_toast_table(rel));
+
 	return HEAP_TABLE_AM_OID;
+}
+
+static void
+appendonly_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
+							 int32 sliceoffset, int32 slicelength,
+							 struct varlena *result)
+{
+	return heap_fetch_toast_slice(toastrel, valueid, attrsize, sliceoffset,
+								  slicelength, result);
 }
 
 /* ------------------------------------------------------------------------
@@ -2166,7 +2177,7 @@ static const TableAmRoutine ao_row_methods = {
 	.relation_size = appendonly_relation_size,
 	.relation_needs_toast_table = appendonly_relation_needs_toast_table,
 	.relation_toast_am = appendonly_relation_toast_am,
-	.relation_fetch_toast_slice = heap_fetch_toast_slice,
+	.relation_fetch_toast_slice = appendonly_fetch_toast_slice,
 
 	.relation_estimate_size = appendonly_estimate_rel_size,
 


### PR DESCRIPTION
Add relation_toast_am and relation_fetch_toast_slice callbacks for AO tables

1) Commit 83322e3 added a new relation_toast_am callback to the TableAmRoutine
structure and its initialization to the heapam_methods global variable, as well
as its use in the table_relation_toast_am function and its use in the
create_toast_table function.

2) Commit ce242ae added a new relation_fetch_toast_slice callback to the
TableAmRoutine structure and its initialization to the global heapam_methods
variable, as well as its use in the table_relation_fetch_toast_slice function
and its use in the toast_fetch_datum and toast_fetch_datum_slice functions.

The patch adds the initialization of these callbacks to the AO table globals
ao_column_methods and ao_row_methods.