### PR TITLE
Fix compilation of src/backend/parser/analyze.c

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1129,7 +1129,7 @@ transformOnConflictClause(ParseState *pstate,
 	if (onConflictClause->action == ONCONFLICT_UPDATE)
 	{
 		Relation	targetrel = pstate->p_target_relation;
-		RangeTblEntry    *rte = pstate->p_target_rangetblentry;
+		RangeTblEntry    *rte = pstate->p_target_nsitem->p_rte; /* GPDB */
 		ParseNamespaceItem *exclNSItem;
 		RangeTblEntry *exclRte;
 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2792,14 +2792,14 @@ transformCurrentOfExpr(ParseState *pstate, CurrentOfExpr *cexpr)
 	 * early here to avoid having to deal with error cases later:
 	 * rewriting/planning against views, for example.
 	 */
-	Assert(pstate->p_target_rangetblentry != NULL);
-	(void) isSimplyUpdatableRelation(pstate->p_target_rangetblentry->relid, false);
+	Assert(pstate->p_target_nsitem->p_rte != NULL);
+	(void) isSimplyUpdatableRelation(pstate->p_target_nsitem->p_rte->relid, false);
 
 	/* CURRENT OF can only appear at top level of UPDATE/DELETE */
 	Assert(pstate->p_target_nsitem != NULL);
 	cexpr->cvarno = pstate->p_target_nsitem->p_rtindex;
 
-	cexpr->target_relid = pstate->p_target_rangetblentry->relid;
+	cexpr->target_relid = pstate->p_target_nsitem->p_rte->relid;
 
 	/*
 	 * Check to see if the cursor name matches a parameter of type REFCURSOR.


### PR DESCRIPTION
Fix compilation of src/backend/parser/analyze.c

Commit 5815696 replaced the p_target_rangetblentry and p_target_rtindex fields
in the ParseState structure with a new p_target_nsitem field, we need to change
this in GPDB-specific places.