### PR TITLE
Fix compilation of src/backend/parser/parse_clause.c

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -657,6 +657,7 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 					A_Const *arg_val;
 					List *qualified_name_list;
 					RangeVar *rel;
+					RangeTblEntry *rte;
 
 					arg_val = linitial(fc->args);
 					if (!IsA(&arg_val->val, String))

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -657,7 +657,7 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 					A_Const *arg_val;
 					List *qualified_name_list;
 					RangeVar *rel;
-					RangeTblEntry *rte;
+					ParseNamespaceItem *nsitem;
 
 					arg_val = linitial(fc->args);
 					if (!IsA(&arg_val->val, String))
@@ -670,12 +670,12 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 					rel = makeRangeVarFromNameList(qualified_name_list);
 					rel->location = arg_val->location;
 
-					rte = addRangeTableEntry(pstate, rel, r->alias, false, true);
+					nsitem = addRangeTableEntry(pstate, rel, r->alias, false, true);
 
 					/* Now we set our special attribute in the rte. */
-					rte->forceDistRandom = true;
+					nsitem->p_rte->forceDistRandom = true;
 
-					return rte;
+					return nsitem;
 				}
 				else
 				{


### PR DESCRIPTION
Fix compilation of src/backend/parser/parse_clause.c

Commit 5815696 removed local variable rte in transformRangeFunction, and also
changed the return type of the addRangeTableEntry function from RangeTblEntry
to ParseNamespaceItem, we also need to do this in the GPDB-specific code.