### PR TITLE
Fix compilation of setrefs.c, nodeDynamicSeqscan.c, nodeDynamicIndexscan.c, nodeDynamicBitmapHeapscan.c, transform.c and cdbsubselect.c

### DIFF
--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -265,7 +265,7 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 		 *
 		 * 1. Ignore RelabelType nodes on top of both sides, like
 		 *    tlist_member_ignore_relabel() does.
-		 * 2. Ignore varnoold/varoattno fields in Var nodes, like
+		 * 2. Ignore varnosyn/varattnosyn fields in Var nodes, like
 		 *    tlist_member_match_var() does.
 		 * 3. Also Accept "naked" targetlists, without TargetEntry nodes
 		 *
@@ -404,10 +404,10 @@ cdbpullup_isExprCoveredByTargetlist(Expr *expr, List *targetlist)
  * vartypmod for the new Var node.  If 'oldexpr' is a Var node, all fields are
  * copied except for varno, varattno and varlevelsup.
  *
- * The parameter modifyOld determines if varnoold and varoattno are modified or
+ * The parameter modifyOld determines if varnosyn and varattnosyn are modified or
  * not. Rule of thumb is to use modifyOld = false if called before setrefs.
  *
- * Copying an existing Var node preserves its varnoold and varoattno fields,
+ * Copying an existing Var node preserves its varnosyn and varattnosyn fields,
  * which are used by EXPLAIN to display the table and column name.
  * Also these fields are tested by equal(), so they may need to be set
  * correctly for successful lookups by list_member(), tlist_member(),
@@ -427,8 +427,8 @@ cdbpullup_make_expr(Index varno, AttrNumber varattno, Expr *oldexpr, bool modify
 		var->varattno = varattno;
 		if (modifyOld)
 		{
-			var->varoattno = varattno;
-			var->varnoold = varno;
+			var->varattnosyn = varattno;
+			var->varnosyn = varno;
 		}
 		var->varlevelsup = 0;
 		return (Expr *) var;
@@ -452,8 +452,8 @@ cdbpullup_make_expr(Index varno, AttrNumber varattno, Expr *oldexpr, bool modify
 					  exprTypmod((Node *) oldexpr),
 					  exprCollation((Node *) oldexpr),
 					  0);
-		var->varnoold = varno;	/* assuming it wasn't ever a plain Var */
-		var->varoattno = varattno;
+		var->varnosyn = varno;	/* assuming it wasn't ever a plain Var */
+		var->varattnosyn = varattno;
 		return (Expr *) var;
 	}
 }								/* cdbpullup_make_var */

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -814,7 +814,7 @@ mutate_targetlist(List *tlist)
 static int
 add_notin_subquery_rte(Query *parse, Query *subselect)
 {
-	RangeTblEntry *subq_rte;
+	ParseNamespaceItem *subq_nsitem;
 	int			subq_indx;
 
 	/*
@@ -823,16 +823,16 @@ add_notin_subquery_rte(Query *parse, Query *subselect)
 	 * refer to other RTEs in the parent query.
 	 */
 	subselect->targetList = mutate_targetlist(subselect->targetList);
-	subq_rte = addRangeTableEntryForSubquery(NULL,	/* pstate */
+	subq_nsitem = addRangeTableEntryForSubquery(NULL,	/* pstate */
 											 subselect,
 											 makeAlias("NotIn_SUBQUERY", NIL),
 											 false, /* not lateral */
 											 false /* inFromClause */ );
-	parse->rtable = lappend(parse->rtable, subq_rte);
+	parse->rtable = lappend(parse->rtable, subq_nsitem->p_rte);
 
 	/* assume new rte is at end */
 	subq_indx = list_length(parse->rtable);
-	Assert(subq_rte == rt_fetch(subq_indx, parse->rtable));
+	Assert(subq_nsitem->p_rte == rt_fetch(subq_indx, parse->rtable));
 
 	return subq_indx;
 }
@@ -843,7 +843,7 @@ add_notin_subquery_rte(Query *parse, Query *subselect)
 static int
 add_expr_subquery_rte(Query *parse, Query *subselect)
 {
-	RangeTblEntry *subq_rte;
+	ParseNamespaceItem *subq_nsitem;
 	int			subq_indx;
 
 	/**
@@ -866,16 +866,16 @@ add_expr_subquery_rte(Query *parse, Query *subselect)
 	 * It is marked as lateral, because any correlation quals will
 	 * refer to other RTEs in the parent query.
 	 */
-	subq_rte = addRangeTableEntryForSubquery(NULL,	/* pstate */
+	subq_nsitem = addRangeTableEntryForSubquery(NULL,	/* pstate */
 											 subselect,
 											 makeAlias("Expr_SUBQUERY", NIL),
 											 true, /* lateral */
 											 false /* inFromClause */ );
-	parse->rtable = lappend(parse->rtable, subq_rte);
+	parse->rtable = lappend(parse->rtable, subq_nsitem->p_rte);
 
 	/* assume new rte is at end */
 	subq_indx = list_length(parse->rtable);
-	Assert(subq_rte == rt_fetch(subq_indx, parse->rtable));
+	Assert(subq_nsitem->p_rte == rt_fetch(subq_indx, parse->rtable));
 
 	return subq_indx;
 }

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1312,20 +1312,20 @@ fetch_targetlist_exprs(List *targetlist)
  *   BoolExpr [boolop=NOT_EXPR]
  *      BoolExpr [boolop=AND_EXPR]
  *        OpExpr [opno=96 opfuncid=65 opresulttype=16 opretset=false]
- *                Var [varno=1 varattno=1 vartype=23 varnoold=1 varoattno=1]
+ *                Var [varno=1 varattno=1 vartype=23 varnosyn=1 varattnosyn=1]
  *                Param [paramkind=PARAM_SUBLINK paramid=1 paramtype=23]
  *        OpExpr [opno=96 opfuncid=65 opresulttype=16 opretset=false]
- *                Var [varno=1 varattno=2 vartype=23 varnoold=1 varoattno=2]
+ *                Var [varno=1 varattno=2 vartype=23 varnosyn=1 varattnosyn=2]
  *                Param [paramkind=PARAM_SUBLINK paramid=2 paramtype=23]
  *
  *  For a two-col <> ALL query: select * from t1 where (a,b) <> (select a,b from t2)
  *  this testexpr should be:
  *  BoolExpr [boolop=OR_EXPR]
  *     OpExpr [opno=518 opfuncid=144 opresulttype=16 opretset=false]
- *              Var [varno=1 varattno=1 vartype=23 varnoold=1 varoattno=1]
+ *              Var [varno=1 varattno=1 vartype=23 varnosyn=1 varattnosyn=1]
  *              Param [paramkind=PARAM_SUBLINK paramid=1 paramtype=23]
  *      OpExpr [opno=518 opfuncid=144 opresulttype=16 opretset=false]
- *              Var [varno=1 varattno=2 vartype=23 varnoold=1 varoattno=2]
+ *              Var [varno=1 varattno=2 vartype=23 varnosyn=1 varattnosyn=2]
  *              Param [paramkind=PARAM_SUBLINK paramid=2 paramtype=23]
  *
  * This function fetches all the outer parts and put them in a list as the

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2339,7 +2339,7 @@ change_varattnos_varno_walker(Node *node, const AttrMapContext *attrMapCxt)
 			 * currently.
 			 */
 			Assert(attrMapCxt->newattno[var->varattno - 1] > 0);
-			var->varattno = var->varoattno = attrMapCxt->newattno[var->varattno - 1];
+			var->varattno = var->varattnosyn = attrMapCxt->newattno[var->varattno - 1];
 		}
 		return false;
 	}

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2314,7 +2314,7 @@ ExecGetReturningSlot(EState *estate, ResultRelInfo *relInfo)
  */
 typedef struct AttrMapContext
 {
-	const AttrNumber *newattno; /* The mapping table to remap the varattno */
+	const AttrMap *newattno;	/* The mapping table to remap the varattno */
 	Index		varno;			/* Which rte's varattno to re-map */
 } AttrMapContext;
 
@@ -2338,8 +2338,8 @@ change_varattnos_varno_walker(Node *node, const AttrMapContext *attrMapCxt)
 			 * referenced though stringToNode() doesn't create such a node
 			 * currently.
 			 */
-			Assert(attrMapCxt->newattno[var->varattno - 1] > 0);
-			var->varattno = var->varattnosyn = attrMapCxt->newattno[var->varattno - 1];
+			Assert(attrMapCxt->newattno->attnums[var->varattno - 1] > 0);
+			var->varattno = var->varattnosyn = attrMapCxt->newattno->attnums[var->varattno - 1];
 		}
 		return false;
 	}
@@ -2357,7 +2357,7 @@ change_varattnos_varno_walker(Node *node, const AttrMapContext *attrMapCxt)
  * Note that the passed node tree is modified in-place!
  */
 void
-change_varattnos_of_a_varno(Node *node, const AttrNumber *newattno, Index varno)
+change_varattnos_of_a_varno(Node *node, const AttrMap *newattno, Index varno)
 {
 	AttrMapContext attrMapCxt;
 

--- a/src/backend/executor/nodeDynamicBitmapHeapscan.c
+++ b/src/backend/executor/nodeDynamicBitmapHeapscan.c
@@ -125,7 +125,7 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 	Relation	lastScannedRel;
 	TupleDesc	partTupDesc;
 	TupleDesc	lastTupDesc;
-	AttrNumber *attMap;
+	AttrMap	   *attMap;
 	Oid		   pid;
 	Relation	currentRelation;
 
@@ -158,7 +158,7 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 	 * FIXME: should we use execute_attr_map_tuple instead? Seems like a
 	 * higher level abstraction that fits the bill
 	 */
-	attMap = convert_tuples_by_name_map_if_req(partTupDesc, lastTupDesc);
+	attMap = build_attrmap_by_name_if_req(partTupDesc, lastTupDesc);
 	table_close(lastScannedRel, AccessShareLock);
 
 	/* If attribute remapping is not necessary, then do not change the varattno */
@@ -172,7 +172,7 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 		 * the new varnos correspond to
 		 */
 		node->lastRelOid = pid;
-		pfree(attMap);
+		free_attrmap(attMap);
 	}
 
 	node->bhsState = ExecInitBitmapHeapScanForPartition(&plan->bitmapheapscan, estate, node->eflags,

--- a/src/backend/executor/nodeDynamicBitmapIndexscan.c
+++ b/src/backend/executor/nodeDynamicBitmapIndexscan.c
@@ -98,7 +98,7 @@ ExecInitDynamicBitmapIndexScan(DynamicBitmapIndexScan *node, EState *estate, int
 static void
 BitmapIndexScan_ReMapColumns(DynamicBitmapIndexScan *dbiScan, Oid oldOid, Oid newOid)
 {
-	AttrNumber *attMap;
+	AttrMap	   *attMap;
 
 	Assert(OidIsValid(newOid));
 
@@ -118,7 +118,7 @@ BitmapIndexScan_ReMapColumns(DynamicBitmapIndexScan *dbiScan, Oid oldOid, Oid ne
 		/* A bitmap index scan has no target list or quals */
 		// FIXME: no quals remapping?
 
-		pfree(attMap);
+		free_attrmap(attMap);
 	}
 }
 

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -96,7 +96,7 @@ static void
 DynamicIndexScan_ReMapColumns(DynamicIndexScan *dIndexScan, Oid oldOid, Oid newOid)
 {
 	IndexScan *indexScan = &dIndexScan->indexscan;
-	AttrNumber *attMap;
+	AttrMap	   *attMap;
 
 	Assert(OidIsValid(newOid));
 
@@ -123,7 +123,7 @@ DynamicIndexScan_ReMapColumns(DynamicIndexScan *dIndexScan, Oid oldOid, Oid newO
 		change_varattnos_of_a_varno((Node *) indexScan->indexqualorig,
 									attMap, indexScan->scan.scanrelid);
 
-		pfree(attMap);
+		free_attrmap(attMap);
 	}
 }
 
@@ -320,13 +320,13 @@ ExecReScanDynamicIndex(DynamicIndexScanState *node)
  *
  *             Returns NULL for identical mapping.
  */
-AttrNumber*
+AttrMap*
 IndexScan_GetColumnMapping(Oid oldOid, Oid newOid)
 {
 	if (oldOid == newOid)
 		return NULL;
 
-	AttrNumber	  *attMap;
+	AttrMap		  *attMap;
 
 	Relation oldRel = table_open(oldOid, AccessShareLock);
 	Relation newRel = table_open(newOid, AccessShareLock);
@@ -334,7 +334,7 @@ IndexScan_GetColumnMapping(Oid oldOid, Oid newOid)
 	TupleDesc oldTupDesc = oldRel->rd_att;
 	TupleDesc newTupDesc = newRel->rd_att;
 
-	attMap = convert_tuples_by_name_map_if_req(oldTupDesc, newTupDesc);
+	attMap = build_attrmap_by_name_if_req(oldTupDesc, newTupDesc);
 
 	table_close(oldRel, AccessShareLock);
 	table_close(newRel, AccessShareLock);

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -113,7 +113,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 	Relation	lastScannedRel;
 	TupleDesc	partTupDesc;
 	TupleDesc	lastTupDesc;
-	AttrNumber *attMap;
+	AttrMap	   *attMap;
 	Oid		   *pid;
 	Relation	currentRelation;
 
@@ -144,7 +144,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 	 * FIXME: should we use execute_attr_map_tuple instead? Seems like a
 	 * higher level abstraction that fits the bill
 	 */
-	attMap = convert_tuples_by_name_map_if_req(partTupDesc, lastTupDesc);
+	attMap = build_attrmap_by_name_if_req(partTupDesc, lastTupDesc);
 	table_close(lastScannedRel, AccessShareLock);
 
 	/* If attribute remapping is not necessary, then do not change the varattno */
@@ -158,7 +158,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 		 * the new varnos correspond to
 		 */
 		node->lastRelOid = *pid;
-		pfree(attMap);
+		free_attrmap(attMap);
 	}
 
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -210,8 +210,8 @@ CMappingColIdVarPlStmt::VarFromDXLNodeScId(const CDXLScalarIdent *dxlop)
 		if (IsA(target_entry->expr, Var))
 		{
 			Var *var = (Var *) target_entry->expr;
-			varno_old = var->varnoold;
-			attno_old = var->varoattno;
+			varno_old = var->varnosyn;
+			attno_old = var->varattnosyn;
 		}
 		else
 		{
@@ -226,9 +226,9 @@ CMappingColIdVarPlStmt::VarFromDXLNodeScId(const CDXLScalarIdent *dxlop)
 							 0	// varlevelsup
 	);
 
-	// set varnoold and varoattno since makeVar does not set them properly
-	var->varnoold = varno_old;
-	var->varoattno = attno_old;
+	// set varnosyn and varattnosyn since makeVar does not set them properly
+	var->varnosyn = varno_old;
+	var->varattnosyn = attno_old;
 
 	return var;
 }

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5017,8 +5017,8 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectListToHashTargetList(
 		if (IsA(te_child->expr, Var))
 		{
 			Var *pv = (Var *) te_child->expr;
-			idx_varnoold = pv->varnoold;
-			attno_old = pv->varoattno;
+			idx_varnoold = pv->varnosyn;
+			attno_old = pv->varattnosyn;
 		}
 		else
 		{
@@ -5033,8 +5033,8 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectListToHashTargetList(
 			);
 
 		// set old varno and varattno since makeVar does not set them
-		var->varnoold = idx_varnoold;
-		var->varoattno = attno_old;
+		var->varnosyn = idx_varnoold;
+		var->varattnosyn = attno_old;
 
 		CHAR *resname = CTranslatorUtils::CreateMultiByteCharStringFromWCString(
 			sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
@@ -6072,8 +6072,8 @@ CTranslatorDXLToPlStmt::TranslateNestLoopParamList(
 		Var *new_var =
 			gpdb::MakeVar(OUTER_VAR, target_entry->resno, old_var->vartype,
 						  old_var->vartypmod, 0 /*varlevelsup*/);
-		new_var->varnoold = old_var->varnoold;
-		new_var->varoattno = old_var->varoattno;
+		new_var->varnosyn = old_var->varnosyn;
+		new_var->varattnosyn = old_var->varattnosyn;
 
 		NestLoopParam *nest_params = MakeNode(NestLoopParam);
 		// right child context contains the param entry for the nest params col refs

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -794,8 +794,8 @@ var_for_grouped_window_expr(grouped_window_ctx * ctx, Node *expr, bool force)
 		var->vartypmod = exprTypmod((Node *) tle->expr);
 		var->varcollid = exprCollation((Node *) tle->expr);
 		var->varlevelsup = 0;
-		var->varnoold = 1;
-		var->varoattno = tle->resno;
+		var->varnosyn = 1;
+		var->varattnosyn = tle->resno;
 		var->location = 0;
 	}
 

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2555,10 +2555,11 @@ set_splitupdate_tlist_references(Plan *plan, int rtoffset)
 						 exprTypmod((Node *) oldvar),
 						 exprCollation((Node *) oldvar),
 						 0);
-		if (IsA(oldvar, Var))
+		if (IsA(oldvar, Var) &&
+			oldvar->varnosyn > 0)
 		{
-			newvar->varnosyn = oldvar->varno + rtoffset;
-			newvar->varattnosyn = oldvar->varattno;
+			newvar->varnosyn = oldvar->varnosyn + rtoffset;
+			newvar->varattnosyn = oldvar->varattnosyn;
 		}
 		else
 		{

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -226,8 +226,8 @@ static void set_plan_references_input_asserts(PlannerInfo *root, Plan *plan)
 
 #if 0
 		/* ModifyTable plans have a funny target list, set up just for EXPLAIN. */
-		if (!IsA(plan, ModifyTable) && var->varno != var->varnoold)
-			Assert(false && "Varno and varnoold do not agree!");
+		if (!IsA(plan, ModifyTable) && var->varno != var->varnosyn)
+			Assert(false && "Varno and varnosyn do not agree!");
 #endif
 	}
 }
@@ -2557,13 +2557,13 @@ set_splitupdate_tlist_references(Plan *plan, int rtoffset)
 						 0);
 		if (IsA(oldvar, Var))
 		{
-			newvar->varnoold = oldvar->varno + rtoffset;
-			newvar->varoattno = oldvar->varattno;
+			newvar->varnosyn = oldvar->varno + rtoffset;
+			newvar->varattnosyn = oldvar->varattno;
 		}
 		else
 		{
-			newvar->varnoold = 0;		/* wasn't ever a plain Var */
-			newvar->varoattno = 0;
+			newvar->varnosyn = 0;		/* wasn't ever a plain Var */
+			newvar->varattnosyn = 0;
 		}
 
 		tle = flatCopyTargetEntry(tle);

--- a/src/backend/optimizer/plan/transform.c
+++ b/src/backend/optimizer/plan/transform.c
@@ -310,13 +310,13 @@ make_sirvf_subquery(FuncExpr *fe)
 		funcclass == TYPEFUNC_RECORD)
 	{
 		Query	   *sub_sq = sq;
-		RangeTblEntry *rte;
+		ParseNamespaceItem *nsitem;
 		RangeTblRef *rtref;
 		int			attno;
 		Var		   *var;
 
 		// FIXME: does this need to be lateral?
-		rte = addRangeTableEntryForSubquery(NULL,
+		nsitem = addRangeTableEntryForSubquery(NULL,
 											sub_sq,
 											makeAlias("sirvf_sq", NIL),
 											false, /* isLateral? */
@@ -327,7 +327,7 @@ make_sirvf_subquery(FuncExpr *fe)
 		sq = makeNode(Query);
 		sq->commandType = CMD_SELECT;
 		sq->querySource = QSRC_PLANNER;
-		sq->rtable = list_make1(rte);
+		sq->rtable = list_make1(nsitem->p_rte);
 		sq->jointree = makeFromExpr(list_make1(rtref), NULL);
 		/*
 		 * XXX: I'm not sure if we need so set this in this middle subquery.

--- a/src/include/cdb/cdbpullup.h
+++ b/src/include/cdb/cdbpullup.h
@@ -34,7 +34,7 @@
  *      newvarlist -> an optional List of Expr which may contain Var nodes
  *              referencing the result of the projection.  The Var nodes in
  *              the new expr are copied from ones in this list if possible,
- *              to get their varnoold and varoattno settings.
+ *              to get their varnosyn and varattnosyn settings.
  *      newvarno = varno to be used in new Var nodes
  *
  * When calling this function on an expr which has NOT yet been transformed

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -660,5 +660,5 @@ extern ResultRelInfo *targetid_get_partition(Oid targetid, EState *estate, bool 
 extern ResultRelInfo *slot_get_partition(TupleTableSlot *slot, EState *estate, bool openIndices);
 
 extern void
-change_varattnos_of_a_varno(Node *node, const AttrNumber *newattno, Index varno);
+change_varattnos_of_a_varno(Node *node, const AttrMap *newattno, Index varno);
 #endif							/* EXECUTOR_H  */

--- a/src/include/executor/nodeDynamicIndexscan.h
+++ b/src/include/executor/nodeDynamicIndexscan.h
@@ -21,6 +21,6 @@ extern TupleTableSlot *ExecDynamicIndexScan(PlanState *node);
 extern void ExecEndDynamicIndexScan(DynamicIndexScanState *node);
 extern void ExecReScanDynamicIndex(DynamicIndexScanState *node);
 
-extern AttrNumber *IndexScan_GetColumnMapping(Oid oldOid, Oid newOid);
+extern AttrMap *IndexScan_GetColumnMapping(Oid oldOid, Oid newOid);
 
 #endif


### PR DESCRIPTION
Fix compilation of setrefs.c, nodeDynamicSeqscan.c, nodeDynamicIndexscan.c, nodeDynamicBitmapHeapscan.c, transform.c and cdbsubselect.c

1) Commit 9ce77d7 renamed the varnoold and varoattno fields in the Var
structure to varnosyn and varattnosyn, we need to do the same in GPDB-specific
places.

2) Commit e1551f9 renamed convert_tuples_by_name_map_if_req to
build_attrmap_by_name_if_req and changed return type from AttrNumber to
AttrMap, we need to do the same in GPDB-specific places.

3) Commit 5815696 changed the return type of the addRangeTableEntryForSubquery
function from RangeTblEntry to ParseNamespaceItem, we also need to do this in
the GPDB-specific code.