### PR TITLE
Fix compilation of src/backend/executor/execMain.c

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4097,7 +4097,7 @@ attrMap(TupleConversionMap *map, AttrNumber anum)
 	{
 		for (int i = 0; i < map->outdesc->natts; i++)
 		{
-			if (map->attrMap[i] == anum)
+			if (map->attrMap->attnums[i] == anum)
 				return i + 1;
 		}
 	}


### PR DESCRIPTION
Fix compilation of src/backend/executor/execMain.c

Commit e1551f9 renamed the attrMap field type in the TupleConversionMap
structure from AttrNumber to AttrMap, we need to do the same in GPDB-specific
places.