### PR TITLE
Fix compilation of src/backend/utils/resscheduler/resqueue.c

### DIFF
--- a/src/include/c.h
+++ b/src/include/c.h
@@ -1143,6 +1143,7 @@ typedef union PGAlignedXLogBlock
 #define STATUS_OK				(0)
 #define STATUS_ERROR			(-1)
 #define STATUS_EOF				(-2)
+#define STATUS_FOUND			(1)
 #define STATUS_WAITING			(2)
 
 /*


### PR DESCRIPTION
Fix compilation of src/backend/utils/resscheduler/resqueue.c

Commit c096a80 removed the STATUS_FOUND define, changing its usage to true, and
the usage of the STATUS_OK define to false, but the GPDB-specific
ResLockCheckLimit function uses three different statuses to return, so we need
to revert the STATUS_FOUND define.