### PR TITLE
ADBDEV-7771: Fix incorrect behavior of gp_percentile_* functions

### DIFF
--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -1513,6 +1513,16 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 {
 	int64        first_row;
 	int64        second_row;
+	/*
+	 * Note: 'proargtypes' for this function in pg_proc.dat has 4 arguments.
+	 * There are actually 5 arguments coming in here - the result of the
+	 * previous call and 4 main arguments.
+	 */
+	if (PG_NARGS() != 5)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("wrong number of arguments to gp_percentile_cont_transition()"),
+				 errhint("expected 5, got %d", PG_NARGS())));
 
 	/* Return state for NULL inputs of val*/
 	if (PG_ARGISNULL(1) && !PG_ARGISNULL(0))
@@ -1559,6 +1569,10 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 	else if(*cnt <= second_row && second_row < *cnt + peer_count)
 	{
 		return_state = lerpfunc(prev_state, val, proportion);
+	}
+	else if (PG_ARGISNULL(0))
+	{
+		fcinfo->isnull = true;
 	}
 	*cnt = *cnt + peer_count;
 
@@ -1616,6 +1630,16 @@ Datum
 gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 {
 	int64        rownum;
+	/*
+	 * Note: 'proargtypes' for this function in pg_proc.dat has 4 arguments.
+	 * There are actually 5 arguments coming in here - the result of the
+	 * previous call and 4 main arguments.
+	 */
+	if (PG_NARGS() != 5)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("wrong number of arguments to gp_percentile_disc_transition()"),
+				 errhint("expected 5, got %d", PG_NARGS())));
 
 	/* Return state for NULL inputs of val*/
 	if (PG_ARGISNULL(1) && !PG_ARGISNULL(0))
@@ -1655,6 +1679,10 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 	if(*cnt <= rownum && rownum < *cnt + peer_count)
 	{
 		return_state = val;
+	}
+	else if (PG_ARGISNULL(0))
+	{
+		fcinfo->isnull = true;
 	}
 
 	*cnt = *cnt + peer_count;

--- a/src/test/regress/expected/qp_functions_idf.out
+++ b/src/test/regress/expected/qp_functions_idf.out
@@ -180,6 +180,21 @@ select c, percentile_cont(0.9999) within group (order by ts2::timestamptz -ts1::
  10 | @ 1469 days 19 hours 59 mins 50 secs
 (10 rows)
 
+select percentile_cont(0.9999) within group (order by tstz1) from perctint;
+      percentile_cont      
+---------------------------
+ 2006-01-02 05:50:07.06-08
+(1 row)
+
+select gp_percentile_cont('2006-01-01 13:10:13'::timestamptz, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+ 
+(1 row)
+
+select gp_percentile_cont_timestamptz_transition(NULL::timestamptz, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
 -- DATE
 -- The test frame work now does not sort the output of
 -- `select ... order by` statement. This is not enough.
@@ -395,6 +410,21 @@ select c, percentile_cont(0.9999) within group (order by ts2::timestamp - time '
  10 | 2010-01-19 22:58:37
 (10 rows)
 
+select percentile_cont(0.9999) within group (order by ts1) from perctint;
+    percentile_cont     
+------------------------
+ 2006-04-11 12:55:57.64
+(1 row)
+
+select gp_percentile_cont('2006-01-01 13:10:13'::timestamp, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+ 
+(1 row)
+
+select gp_percentile_cont_timestamp_transition(NULL::timestamp, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
 -- TIME
 select median(  time '01:00' + interval '3 hours') ;
   median   
@@ -481,6 +511,21 @@ select c, percentile_cont(0.9999) within group (order by ((days1 + days2) * 1.2)
  10 | @ 12 days 20 hours 28 mins 24 secs
 (10 rows)
 
+select percentile_cont(0.9999) within group (order by days1) from perctint;
+            percentile_cont             
+----------------------------------------
+ @ 99 days 124 hours 5 mins 8.8812 secs
+(1 row)
+
+select gp_percentile_cont('0 hour'::interval, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+ 
+(1 row)
+
+select gp_percentile_cont_interval_transition(NULL::interval, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
 --numeric types
 select b, percentile_cont(0.9876) within group( order by c::numeric - 2.8765::numeric) from perctnum group by b order by b limit 10;
  b | percentile_cont 
@@ -495,6 +540,21 @@ select b, percentile_cont(0.9876) within group( order by c::numeric - 2.8765::nu
  7 |    196.89031116
 (8 rows)
 
+select percentile_cont(0.95) within group( order by b) from perctnum;
+ percentile_cont 
+-----------------
+               7
+(1 row)
+
+select gp_percentile_cont(0::float8, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+                   
+(1 row)
+
+select gp_percentile_cont_float8_transition(NULL::float8, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
 select median( c::numeric + (0.2*0.99):: numeric) from perctnum;
   median   
 -----------
@@ -513,6 +573,21 @@ select percentile_cont(0.95) within group( order by c) from perctnum;
       190.090495
 (1 row)
 
+select percentile_disc(0.95) within group( order by c) from perctnum;
+ percentile_disc 
+-----------------
+        189.9905
+(1 row)
+
+select gp_percentile_disc(0::numeric, 0, 0, 0);
+ gp_percentile_disc 
+--------------------
+                   
+(1 row)
+
+select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_disc_transition()
+HINT:  expected 5, got 4
 --SQL with <> operator with IDF in HAVING clause
 select count(*),median(a) from perct group by b having median(b) <> 33 order by median(a);
  count | median 

--- a/src/test/regress/sql/qp_functions_idf.sql
+++ b/src/test/regress/sql/qp_functions_idf.sql
@@ -53,6 +53,12 @@ select c , median( tstz2 - tstz1 ) from perctint group by c order by c limit 10 
 
 select c, percentile_cont(0.9999) within group (order by ts2::timestamptz -ts1:: timestamptz) from perctint group by c order by 2 limit 10;
 
+select percentile_cont(0.9999) within group (order by tstz1) from perctint;
+
+select gp_percentile_cont('2006-01-01 13:10:13'::timestamptz, 0, 0, 0);
+
+select gp_percentile_cont_timestamptz_transition(NULL::timestamptz, 1, 1, 1);
+
 -- DATE
 
 -- The test frame work now does not sort the output of
@@ -93,6 +99,12 @@ select median(ts2::timestamp + time '   12:00'), percentile_cont(0.9999) within 
 
 select c, percentile_cont(0.9999) within group (order by ts2::timestamp - time '10:11:26' ) from perctint group by c  order by c limit 10;
 
+select percentile_cont(0.9999) within group (order by ts1) from perctint;
+
+select gp_percentile_cont('2006-01-01 13:10:13'::timestamp, 0, 0, 0);
+
+select gp_percentile_cont_timestamp_transition(NULL::timestamp, 1, 1, 1);
+
 -- TIME
 
 select median(  time '01:00' + interval '3 hours') ;
@@ -113,15 +125,33 @@ select c, percentile_cont(0.9999) within group (order by ((days1 -days2) / doubl
 
 select c, percentile_cont(0.9999) within group (order by ((days1 + days2) * 1.2) ) from perctint group by c order by c limit 10;
 
+select percentile_cont(0.9999) within group (order by days1) from perctint;
+
+select gp_percentile_cont('0 hour'::interval, 0, 0, 0);
+
+select gp_percentile_cont_interval_transition(NULL::interval, 1, 1, 1);
+
 --numeric types
 
 select b, percentile_cont(0.9876) within group( order by c::numeric - 2.8765::numeric) from perctnum group by b order by b limit 10;
+
+select percentile_cont(0.95) within group( order by b) from perctnum;
+
+select gp_percentile_cont(0::float8, 0, 0, 0);
+
+select gp_percentile_cont_float8_transition(NULL::float8, 1, 1, 1);
 
 select median( c::numeric + (0.2*0.99):: numeric) from perctnum;
 
 select percentile_cont(1.00) within group( order by b::float8 + (110 / 13)::float8) from perctnum; 
 
 select percentile_cont(0.95) within group( order by c) from perctnum;
+
+select percentile_disc(0.95) within group( order by c) from perctnum;
+
+select gp_percentile_disc(0::numeric, 0, 0, 0);
+
+select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
 
 --SQL with <> operator with IDF in HAVING clause
 


### PR DESCRIPTION
Fix incorrect behavior of gp_percentile_* functions (#1928)

Commit b90f952 added five GPDB-specific functions
gp_percentile_cont_float8_transition, gp_percentile_cont_interval_transition,
gp_percentile_cont_timestamp_transition,
gp_percentile_cont_timestamptz_transition and gp_percentile_disc_transition.

1) All these five functions use five arguments internally in the C
implementation, but they were added to the catalog in the file
src/include/catalog/pg_proc.dat with four arguments, which could lead to
incorrect results, assertions when freeing a null pointer and even segfaults
when dereferencing a null pointer. This patch adds the missing arguments.

2) All these five functions under certain conditions can return their first
argument, but if the first argument was NULL (and the NULL argument is passed
with the additional isnull flag), then when it was returned, all these five
functions lost the additional isnull flag, which could also lead to incorrect
results (for the non-varlena types of the first two arguments), and to
assertions when freeing a null pointer and even segfaults when dereferencing a
null pointer (for the varlena types). This patch adds saving of the additional
isnull flag, and now under the same conditions, all these five functions return
NULL.

The patch adds three tests for each of the five functions.

(cherry picked from commit 477b04a)

Changes in original commit:
- pg_proc.dat is not changed.
- added check in gp_percentile_\*\_transition functions.
- test is adapted.

Because changes to pg_proc.dat cause difficulties with cluster upgrades, this
file is left as is. However, in this case, the signature of
the gp_percentile_cont_transition and gp_percentile_disc_transition functions
in pg_proc.dat did not match the number of arguments they processed (they are
called from gp_percentile_\*\_\* functions). This led to an incorrect result or
segfault when calling these functions directly, since the number of arguments
passed was less than the number processed. So, we add check for matching the
number of input arguments (there must be 5). Now, direct calls to these
functions return an error.
This change does not affect 'percentile_* WITHIN GROUP' queries with the
ORCA optimizer.

Ticket: ADBDEV-7771

----------

Commits in the PR should be merged with a rebase mode to preserve authorship.