### PR TITLE
Fix compilation log_parameters_on_error and wal_receiver_create_temp_slot GUCs

### DIFF
--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -91,6 +91,7 @@
 		"log_btree_build_stats",
 		"log_dispatch_stats",
 		"log_duration",
+		"log_parameters_on_error",
 		"log_error_verbosity",
 		"log_executor_stats",
 		"log_min_duration_sample",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -49,6 +49,7 @@
 		"data_directory",
 		"data_directory_mode",
 		"data_sync_retry",
+		"wal_receiver_create_temp_slot",
 		"db_user_namespace",
 		"deadlock_timeout",
 		"debug_abort_after_distributed_prepared",


### PR DESCRIPTION
Fix compilation log_parameters_on_error and wal_receiver_create_temp_slot GUCs

1) Commit ba79cb5 added a new log_parameters_on_error GUC, we need to add it to
the sync_guc_names_array GPDB-specific list.

2) Commit 3297308 added a new wal_receiver_create_temp_slot GUC, we need to add
it to the unsync_guc_names_array GPDB-specific list.