### PR TITLE
Fix handling of AppendRelInfo type

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1835,6 +1835,9 @@ _outNode(StringInfo str, void *obj)
 			case T_RestrictInfo:
 				_outRestrictInfo(str, obj);
 				break;
+			case T_AppendRelInfo:
+				_outAppendRelInfo(str, obj);
+				break;
 
 			default:
 				elog(ERROR, "could not serialize unrecognized node type: %d",

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3044,6 +3044,7 @@ _outSpecialJoinInfo(StringInfo str, const SpecialJoinInfo *node)
 	WRITE_NODE_FIELD(semi_operators);
 	WRITE_NODE_FIELD(semi_rhs_exprs);
 }
+#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outAppendRelInfo(StringInfo str, const AppendRelInfo *node)
@@ -3060,6 +3061,7 @@ _outAppendRelInfo(StringInfo str, const AppendRelInfo *node)
 	WRITE_OID_FIELD(parent_reloid);
 }
 
+#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPlaceHolderInfo(StringInfo str, const PlaceHolderInfo *node)
 {

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2109,6 +2109,9 @@ readNodeBinary(void)
 			case T_RestrictInfo:
 				return_value = _readRestrictInfo();
 				break;
+			case T_AppendRelInfo:
+				return_value = _readAppendRelInfo();
+				break;
 			case T_ExtensibleNode:
 				return_value = _readExtensibleNode();
 				break;


### PR DESCRIPTION
Fix handling of AppendRelInfo type

Commit 6ef77cf added to src/backend/nodes/outfuncs.c in _outPlannedStmt and
_outPlannerGlobal functions writing AppendRelInfo type fields, and to
src/backend/nodes/readfuncs.c in _readPlannedStmt function reading
AppendRelInfo type fields, we need to add handling of this type to
GPDB-specific _outNode and readNodeBinary functions in GPDB-specific
src/backend/nodes/outfast.c and src/backend/nodes/readfast.c files.