### PR TITLE
Fix access to rd_partdesc and rd_partkey attributes

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2576,4 +2576,24 @@ gpdb::GPDBLockRelationOid(Oid reloid, LOCKMODE lockmode)
 	GP_WRAP_END;
 }
 
+PartitionDesc
+gpdb::GPDBRelationGetPartitionDesc(Relation rel)
+{
+	GP_WRAP_START;
+	{
+		return RelationGetPartitionDesc(rel);
+	}
+	GP_WRAP_END;
+}
+
+PartitionKey
+gpdb::GPDBRelationGetPartitionKey(Relation rel)
+{
+	GP_WRAP_START;
+	{
+		return RelationGetPartitionKey(rel);
+	}
+	GP_WRAP_END;
+}
+
 // EOF

--- a/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
+++ b/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
@@ -70,7 +70,7 @@ CPartPruneStepsBuilder::CreatePartPruneInfoForOneLevel(CDXLNode *filterNode)
 {
 	PartitionedRelPruneInfo *pinfo = MakeNode(PartitionedRelPruneInfo);
 	pinfo->rtindex = m_rtindex;
-	pinfo->nparts = m_relation->rd_partdesc->nparts;
+	pinfo->nparts = gpdb::GPDBRelationGetPartitionDesc(m_relation)->nparts;
 
 	pinfo->subpart_map = (int *) palloc(sizeof(int) * pinfo->nparts);
 	pinfo->subplan_map = (int *) palloc(sizeof(int) * pinfo->nparts);
@@ -88,7 +88,7 @@ CPartPruneStepsBuilder::CreatePartPruneInfoForOneLevel(CDXLNode *filterNode)
 		{
 			// partition did survive pruning
 			pinfo->subplan_map[i] = part_ptr;
-			pinfo->relid_map[i] = m_relation->rd_partdesc->oids[i];
+			pinfo->relid_map[i] = gpdb::GPDBRelationGetPartitionDesc(m_relation)->oids[i];
 			pinfo->present_parts = bms_add_member(pinfo->present_parts, i);
 			++part_ptr;
 		}
@@ -114,7 +114,7 @@ CPartPruneStepsBuilder::PartPruneStepFromScalarCmp(CDXLNode *node, int *step_id,
 	GPOS_ASSERT(nullptr != node);
 	CDXLScalarComp *dxlop = CDXLScalarComp::Cast(node->GetOperator());
 	Oid opno = CMDIdGPDB::CastMdid(dxlop->MDId())->Oid();
-	Oid opfamily = m_relation->rd_partkey->partopfamily[0 /* col */];
+	Oid opfamily = gpdb::GPDBRelationGetPartitionKey(m_relation)->partopfamily[0 /* col */];
 
 	// GPDB_12_MERGE_FIXME: This *should* be StrategyNumber, but IndexOpProperties takes an INT
 	INT strategy;
@@ -144,7 +144,7 @@ CPartPruneStepsBuilder::PartPruneStepFromScalarCmp(CDXLNode *node, int *step_id,
 	// to be part of partitioning column opfamily above.
 	// ORCA doesn't support multi-key (a.k.a composite) partition keys. So these
 	// lists will be of size 1.
-	step->cmpfns = ListMake1Oid(m_relation->rd_partkey->partsupfunc[0].fn_oid);
+	step->cmpfns = ListMake1Oid(gpdb::GPDBRelationGetPartitionKey(m_relation)->partsupfunc[0].fn_oid);
 	step->exprs = ListMake1(expr);
 
 	return gpdb::LAppend(steps_list, (PartitionPruneStep *) step);

--- a/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
+++ b/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
@@ -88,7 +88,8 @@ CPartPruneStepsBuilder::CreatePartPruneInfoForOneLevel(CDXLNode *filterNode)
 		{
 			// partition did survive pruning
 			pinfo->subplan_map[i] = part_ptr;
-			pinfo->relid_map[i] = gpdb::GPDBRelationGetPartitionDesc(m_relation)->oids[i];
+			pinfo->relid_map[i] =
+				gpdb::GPDBRelationGetPartitionDesc(m_relation)->oids[i];
 			pinfo->present_parts = bms_add_member(pinfo->present_parts, i);
 			++part_ptr;
 		}
@@ -114,7 +115,8 @@ CPartPruneStepsBuilder::PartPruneStepFromScalarCmp(CDXLNode *node, int *step_id,
 	GPOS_ASSERT(nullptr != node);
 	CDXLScalarComp *dxlop = CDXLScalarComp::Cast(node->GetOperator());
 	Oid opno = CMDIdGPDB::CastMdid(dxlop->MDId())->Oid();
-	Oid opfamily = gpdb::GPDBRelationGetPartitionKey(m_relation)->partopfamily[0 /* col */];
+	Oid opfamily = gpdb::GPDBRelationGetPartitionKey(m_relation)
+					   ->partopfamily[0 /* col */];
 
 	// GPDB_12_MERGE_FIXME: This *should* be StrategyNumber, but IndexOpProperties takes an INT
 	INT strategy;
@@ -144,7 +146,8 @@ CPartPruneStepsBuilder::PartPruneStepFromScalarCmp(CDXLNode *node, int *step_id,
 	// to be part of partitioning column opfamily above.
 	// ORCA doesn't support multi-key (a.k.a composite) partition keys. So these
 	// lists will be of size 1.
-	step->cmpfns = ListMake1Oid(gpdb::GPDBRelationGetPartitionKey(m_relation)->partsupfunc[0].fn_oid);
+	step->cmpfns = ListMake1Oid(
+		gpdb::GPDBRelationGetPartitionKey(m_relation)->partsupfunc[0].fn_oid);
 	step->exprs = ListMake1(expr);
 
 	return gpdb::LAppend(steps_list, (PartitionPruneStep *) step);

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -409,12 +409,12 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 	{
 		// FIXME_GPDB_12_MERGE_FIXME: misestimate (most likely underestimate) the number of leaf partitions
 		// ORCA doesn't really care, except to determine whether to sort before inserting
-		num_leaf_partitions = rel->rd_partdesc->nparts;
+		num_leaf_partitions = gpdb::GPDBRelationGetPartitionDesc(rel.get())->nparts;
 		partition_oids = GPOS_NEW(mp) IMdIdArray(mp);
 
-		for (int i = 0; i < rel->rd_partdesc->nparts; ++i)
+		for (int i = 0; i < gpdb::GPDBRelationGetPartitionDesc(rel.get())->nparts; ++i)
 		{
-			Oid oid = rel->rd_partdesc->oids[i];
+			Oid oid = gpdb::GPDBRelationGetPartitionDesc(rel.get())->oids[i];
 			partition_oids->Append(GPOS_NEW(mp)
 									   CMDIdGPDB(IMDId::EmdidRel, oid));
 			if (gpdb::RelIsPartitioned(oid))
@@ -2403,7 +2403,7 @@ CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(CMemoryPool *mp,
 	*part_keys = GPOS_NEW(mp) ULongPtrArray(mp);
 	*part_types = GPOS_NEW(mp) CharPtrArray(mp);
 
-	PartitionKeyData *partkey = rel->rd_partkey;
+	PartitionKeyData *partkey = gpdb::GPDBRelationGetPartitionKey(rel);
 
 	if (1 < partkey->partnatts)
 	{
@@ -2894,13 +2894,13 @@ CTranslatorRelcacheToDXL::RetrieveStorageTypeForPartitionedTable(Relation rel)
 {
 	IMDRelation::Erelstoragetype rel_storage_type =
 		IMDRelation::ErelstorageSentinel;
-	if (rel->rd_partdesc->nparts == 0)
+	if (gpdb::GPDBRelationGetPartitionDesc(rel)->nparts == 0)
 	{
 		return IMDRelation::ErelstorageHeap;
 	}
-	for (int i = 0; i < rel->rd_partdesc->nparts; ++i)
+	for (int i = 0; i < gpdb::GPDBRelationGetPartitionDesc(rel)->nparts; ++i)
 	{
-		Oid oid = rel->rd_partdesc->oids[i];
+		Oid oid = gpdb::GPDBRelationGetPartitionDesc(rel)->oids[i];
 		gpdb::RelationWrapper child_rel = gpdb::GetRelation(oid);
 		IMDRelation::Erelstoragetype child_storage =
 			RetrieveRelStorageType(child_rel.get());

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -409,10 +409,12 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 	{
 		// FIXME_GPDB_12_MERGE_FIXME: misestimate (most likely underestimate) the number of leaf partitions
 		// ORCA doesn't really care, except to determine whether to sort before inserting
-		num_leaf_partitions = gpdb::GPDBRelationGetPartitionDesc(rel.get())->nparts;
+		num_leaf_partitions =
+			gpdb::GPDBRelationGetPartitionDesc(rel.get())->nparts;
 		partition_oids = GPOS_NEW(mp) IMdIdArray(mp);
 
-		for (int i = 0; i < gpdb::GPDBRelationGetPartitionDesc(rel.get())->nparts; ++i)
+		for (int i = 0;
+			 i < gpdb::GPDBRelationGetPartitionDesc(rel.get())->nparts; ++i)
 		{
 			Oid oid = gpdb::GPDBRelationGetPartitionDesc(rel.get())->oids[i];
 			partition_oids->Append(GPOS_NEW(mp)

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -660,6 +660,10 @@ void GPDBMemoryContextDelete(MemoryContext context);
 
 List *GetRelChildIndexes(Oid reloid);
 
+PartitionDesc GPDBRelationGetPartitionDesc(Relation rel);
+
+PartitionKey GPDBRelationGetPartitionKey(Relation rel);
+
 void GPDBLockRelationOid(Oid reloid, int lockmode);
 
 }  //namespace gpdb


### PR DESCRIPTION
Fix access to rd_partdesc and rd_partkey attributes

Commit 5b93123 replaced immediate access to rd_partdesc and rd_partkey
attributes with deferred access, adding new functions RelationGetPartitionDesc
and RelationGetPartitionKey for this, we need to do the same in GPDB-specific
code.