### PR TITLE
Resolve conflicts in tests caused by fixing aliases

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1057,56 +1057,32 @@ explain (costs off)
  Result
    InitPlan 1 (returns $0)  (slice1)
      ->  Limit
-<<<<<<< HEAD
            ->  Gather Motion 3:1  (slice2; segments: 3)
                  Merge Key: minmaxtest.f1
                  ->  Merge Append
                        Sort Key: minmaxtest.f1
-                       ->  Index Only Scan using minmaxtesti on minmaxtest
+                       ->  Index Only Scan using minmaxtesti on minmaxtest minmaxtest_1
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan using minmaxtest1i on minmaxtest1 minmaxtest_1
+                       ->  Index Only Scan using minmaxtest1i on minmaxtest1 minmaxtest_2
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2 minmaxtest_2
+                       ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2 minmaxtest_3
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan using minmaxtest3i on minmaxtest3 minmaxtest_3
+                       ->  Index Only Scan using minmaxtest3i on minmaxtest3 minmaxtest_4
    InitPlan 2 (returns $1)  (slice3)
      ->  Limit
            ->  Gather Motion 3:1  (slice4; segments: 3)
-                 Merge Key: minmaxtest_4.f1
+                 Merge Key: minmaxtest_5.f1
                  ->  Merge Append
-                       Sort Key: minmaxtest_4.f1 DESC
-                       ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_4
+                       Sort Key: minmaxtest_5.f1 DESC
+                       ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_6
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest_5
+                       ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest_7
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest_6
+                       ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest_8
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest_7
+                       ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest_9
  Optimizer: Postgres query optimizer
 (28 rows)
-=======
-           ->  Merge Append
-                 Sort Key: minmaxtest.f1
-                 ->  Index Only Scan using minmaxtesti on minmaxtest minmaxtest_1
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan using minmaxtest1i on minmaxtest1 minmaxtest_2
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2 minmaxtest_3
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan using minmaxtest3i on minmaxtest3 minmaxtest_4
-   InitPlan 2 (returns $1)
-     ->  Limit
-           ->  Merge Append
-                 Sort Key: minmaxtest_5.f1 DESC
-                 ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_6
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest_7
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest_8
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest_9
-(23 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select min(f1), max(f1) from minmaxtest;
  min | max 
@@ -1121,42 +1097,17 @@ explain (costs off)
                                 QUERY PLAN                                
 --------------------------------------------------------------------------
  Unique
-<<<<<<< HEAD
    Group Key: (min(minmaxtest.f1)), (max(minmaxtest.f1))
-=======
-   InitPlan 1 (returns $0)
-     ->  Limit
-           ->  Merge Append
-                 Sort Key: minmaxtest.f1
-                 ->  Index Only Scan using minmaxtesti on minmaxtest minmaxtest_1
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan using minmaxtest1i on minmaxtest1 minmaxtest_2
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2 minmaxtest_3
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan using minmaxtest3i on minmaxtest3 minmaxtest_4
-   InitPlan 2 (returns $1)
-     ->  Limit
-           ->  Merge Append
-                 Sort Key: minmaxtest_5.f1 DESC
-                 ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_6
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest_7
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest_8
-                       Index Cond: (f1 IS NOT NULL)
-                 ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest_9
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
    ->  Sort
          Sort Key: (min(minmaxtest.f1)), (max(minmaxtest.f1))
          ->  Finalize Aggregate
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Partial Aggregate
                            ->  Append
-                                 ->  Seq Scan on minmaxtest
-                                 ->  Seq Scan on minmaxtest1 minmaxtest_1
-                                 ->  Seq Scan on minmaxtest2 minmaxtest_2
-                                 ->  Seq Scan on minmaxtest3 minmaxtest_3
+                                 ->  Seq Scan on minmaxtest minmaxtest_1
+                                 ->  Seq Scan on minmaxtest1 minmaxtest_2
+                                 ->  Seq Scan on minmaxtest2 minmaxtest_3
+                                 ->  Seq Scan on minmaxtest3 minmaxtest_4
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -1260,27 +1211,16 @@ explain (costs off) select * from t3 group by a,b,c;
 create temp table t1c () inherits (t1);
 -- Ensure we don't remove any columns when t1 has a child table
 explain (costs off) select * from t1 group by a,b,c,d;
-<<<<<<< HEAD
                 QUERY PLAN                 
 -------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
          Group Key: t1.a, t1.b, t1.c, t1.d
          ->  Append
-               ->  Seq Scan on t1
-               ->  Seq Scan on t1c t1_1
+               ->  Seq Scan on t1 t1_1
+               ->  Seq Scan on t1c t1_2
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-             QUERY PLAN              
--------------------------------------
- HashAggregate
-   Group Key: t1.a, t1.b, t1.c, t1.d
-   ->  Append
-         ->  Seq Scan on t1 t1_1
-         ->  Seq Scan on t1c t1_2
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Okay to remove columns if we're only querying the parent.
 explain (costs off) select * from only t1 group by a,b,c,d;
@@ -1304,27 +1244,16 @@ create temp table p_t1_1 partition of p_t1 for values in(1);
 create temp table p_t1_2 partition of p_t1 for values in(2);
 -- Ensure we can remove non-PK columns for partitioned tables.
 explain (costs off) select * from p_t1 group by a,b,c,d;
-<<<<<<< HEAD
-                 QUERY PLAN                  
----------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  HashAggregate
          Group Key: p_t1.a, p_t1.b
          ->  Append
-               ->  Seq Scan on p_t1_1 p_t1
-               ->  Seq Scan on p_t1_2 p_t1_1
+               ->  Seq Scan on p_t1_1
+               ->  Seq Scan on p_t1_2
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-           QUERY PLAN           
---------------------------------
- HashAggregate
-   Group Key: p_t1.a, p_t1.b
-   ->  Append
-         ->  Seq Scan on p_t1_1
-         ->  Seq Scan on p_t1_2
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table t1 cascade;
 NOTICE:  drop cascades to table t1c

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1063,26 +1063,26 @@ DETAIL:  Feature not supported: Inherited tables
                  Merge Key: minmaxtest.f1
                  ->  Merge Append
                        Sort Key: minmaxtest.f1
-                       ->  Index Only Scan using minmaxtesti on minmaxtest
+                       ->  Index Only Scan using minmaxtesti on minmaxtest minmaxtest_1
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan using minmaxtest1i on minmaxtest1 minmaxtest_1
+                       ->  Index Only Scan using minmaxtest1i on minmaxtest1 minmaxtest_2
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2 minmaxtest_2
+                       ->  Index Only Scan Backward using minmaxtest2i on minmaxtest2 minmaxtest_3
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan using minmaxtest3i on minmaxtest3 minmaxtest_3
+                       ->  Index Only Scan using minmaxtest3i on minmaxtest3 minmaxtest_4
    InitPlan 2 (returns $1)  (slice3)
      ->  Limit
            ->  Gather Motion 3:1  (slice4; segments: 3)
-                 Merge Key: minmaxtest_4.f1
+                 Merge Key: minmaxtest_5.f1
                  ->  Merge Append
-                       Sort Key: minmaxtest_4.f1 DESC
-                       ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_4
+                       Sort Key: minmaxtest_5.f1 DESC
+                       ->  Index Only Scan Backward using minmaxtesti on minmaxtest minmaxtest_6
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest_5
+                       ->  Index Only Scan Backward using minmaxtest1i on minmaxtest1 minmaxtest_7
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest_6
+                       ->  Index Only Scan using minmaxtest2i on minmaxtest2 minmaxtest_8
                              Index Cond: (f1 IS NOT NULL)
-                       ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest_7
+                       ->  Index Only Scan Backward using minmaxtest3i on minmaxtest3 minmaxtest_9
  Optimizer: Postgres query optimizer
 (28 rows)
 
@@ -1110,10 +1110,10 @@ DETAIL:  Feature not supported: Inherited tables
                ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Partial Aggregate
                            ->  Append
-                                 ->  Seq Scan on minmaxtest
-                                 ->  Seq Scan on minmaxtest1 minmaxtest_1
-                                 ->  Seq Scan on minmaxtest2 minmaxtest_2
-                                 ->  Seq Scan on minmaxtest3 minmaxtest_3
+                                 ->  Seq Scan on minmaxtest minmaxtest_1
+                                 ->  Seq Scan on minmaxtest1 minmaxtest_2
+                                 ->  Seq Scan on minmaxtest2 minmaxtest_3
+                                 ->  Seq Scan on minmaxtest3 minmaxtest_4
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -1222,8 +1222,8 @@ DETAIL:  Feature not supported: Inherited tables
    ->  HashAggregate
          Group Key: t1.a, t1.b, t1.c, t1.d
          ->  Append
-               ->  Seq Scan on t1
-               ->  Seq Scan on t1c t1_1
+               ->  Seq Scan on t1 t1_1
+               ->  Seq Scan on t1c t1_2
  Optimizer: Postgres query optimizer
 (7 rows)
 
@@ -1264,6 +1264,38 @@ NOTICE:  drop cascades to table t1c
 drop table t2;
 drop table t3;
 drop table p_t1;
+--
+-- Test GROUP BY matching of join columns that are type-coerced due to USING
+--
+create temp table t1(f1 int, f2 bigint);
+create temp table t2(f1 bigint, f22 bigint);
+select f1 from t1 left join t2 using (f1) group by f1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  CTranslatorQueryToDXL.cpp:4060: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
+ f1 
+----
+(0 rows)
+
+select f1 from t1 left join t2 using (f1) group by t1.f1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  CTranslatorQueryToDXL.cpp:4060: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
+ f1 
+----
+(0 rows)
+
+select t1.f1 from t1 left join t2 using (f1) group by t1.f1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  CTranslatorQueryToDXL.cpp:4060: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
+ f1 
+----
+(0 rows)
+
+-- only this one should fail:
+select t1.f1 from t1 left join t2 using (f1) group by f1;
+ERROR:  column "t1.f1" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: select t1.f1 from t1 left join t2 using (f1) group by f1;
+               ^
+drop table t1, t2;
 --
 -- Test combinations of DISTINCT and/or ORDER BY
 --

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -551,16 +551,15 @@ create table nv_child_2011 () inherits (nv_parent);
 alter table nv_child_2010 add check (d between '2010-01-01'::date and '2010-12-31'::date) not valid;
 alter table nv_child_2011 add check (d between '2011-01-01'::date and '2011-12-31'::date) not valid;
 explain (costs off) select * from nv_parent where d between '2011-08-01' and '2011-08-31';
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on nv_parent
+         ->  Seq Scan on nv_parent nv_parent_1
                Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-         ->  Seq Scan on nv_child_2010 nv_parent_1
+         ->  Seq Scan on nv_child_2010 nv_parent_2
                Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-         ->  Seq Scan on nv_child_2011 nv_parent_2
+         ->  Seq Scan on nv_child_2011 nv_parent_3
                Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -571,11 +570,11 @@ explain (costs off) select * from nv_parent where d between '2011-08-01'::date a
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on nv_parent
+         ->  Seq Scan on nv_parent nv_parent_1
                Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-         ->  Seq Scan on nv_child_2010 nv_parent_1
+         ->  Seq Scan on nv_child_2010 nv_parent_2
                Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-         ->  Seq Scan on nv_child_2011 nv_parent_2
+         ->  Seq Scan on nv_child_2011 nv_parent_3
                Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -585,84 +584,32 @@ explain (costs off) select * from nv_parent where d between '2009-08-01'::date a
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on nv_parent
+         ->  Seq Scan on nv_parent nv_parent_1
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-         ->  Seq Scan on nv_child_2010 nv_parent_1
+         ->  Seq Scan on nv_child_2010 nv_parent_2
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-         ->  Seq Scan on nv_child_2011 nv_parent_2
+         ->  Seq Scan on nv_child_2011 nv_parent_3
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-         ->  Seq Scan on nv_child_2009 nv_parent_3
+         ->  Seq Scan on nv_child_2009 nv_parent_4
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
  Optimizer: Postgres query optimizer
 (11 rows)
-=======
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Append
-   ->  Seq Scan on nv_parent nv_parent_1
-         Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-   ->  Seq Scan on nv_child_2010 nv_parent_2
-         Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-   ->  Seq Scan on nv_child_2011 nv_parent_3
-         Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-(7 rows)
-
-create table nv_child_2009 (check (d between '2009-01-01'::date and '2009-12-31'::date)) inherits (nv_parent);
-explain (costs off) select * from nv_parent where d between '2011-08-01'::date and '2011-08-31'::date;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Append
-   ->  Seq Scan on nv_parent nv_parent_1
-         Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-   ->  Seq Scan on nv_child_2010 nv_parent_2
-         Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-   ->  Seq Scan on nv_child_2011 nv_parent_3
-         Filter: ((d >= '08-01-2011'::date) AND (d <= '08-31-2011'::date))
-(7 rows)
-
-explain (costs off) select * from nv_parent where d between '2009-08-01'::date and '2009-08-31'::date;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Append
-   ->  Seq Scan on nv_parent nv_parent_1
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-   ->  Seq Scan on nv_child_2010 nv_parent_2
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-   ->  Seq Scan on nv_child_2011 nv_parent_3
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-   ->  Seq Scan on nv_child_2009 nv_parent_4
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- after validation, the constraint should be used
 alter table nv_child_2011 VALIDATE CONSTRAINT nv_child_2011_d_check;
 explain (costs off) select * from nv_parent where d between '2009-08-01'::date and '2009-08-31'::date;
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on nv_parent
+         ->  Seq Scan on nv_parent nv_parent_1
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-         ->  Seq Scan on nv_child_2010 nv_parent_1
+         ->  Seq Scan on nv_child_2010 nv_parent_2
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-         ->  Seq Scan on nv_child_2009 nv_parent_2
+         ->  Seq Scan on nv_child_2009 nv_parent_3
                Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Append
-   ->  Seq Scan on nv_parent nv_parent_1
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-   ->  Seq Scan on nv_child_2010 nv_parent_2
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-   ->  Seq Scan on nv_child_2009 nv_parent_3
-         Filter: ((d >= '08-01-2009'::date) AND (d <= '08-31-2009'::date))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- add an inherited NOT VALID constraint
 alter table nv_parent add check (d between '2001-01-01'::date and '2099-12-31'::date) not valid;
@@ -2096,27 +2043,16 @@ select * from another;
 (3 rows)
 
 alter table another
-<<<<<<< HEAD
-  alter f1 type text using f2 || ' more',
-  alter f2 type bigint using f1 * 10;
-ERROR:  cannot alter type of a column used in a distribution policy
-select * from another;
- f1 |  f2   
-----+-------
-  1 | one
-  2 | two
-  3 | three
-=======
   alter f1 type text using f2 || ' and ' || f3 || ' more',
   alter f2 type bigint using f1 * 10,
   drop column f3;
+ERROR:  cannot alter type of a column used in a distribution policy
 select * from another;
-         f1         | f2 
---------------------+----
- one and uno more   | 10
- two and due more   | 20
- three and tre more | 30
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+ f1 |  f2   | f3  
+----+-------+-----
+  1 | one   | uno
+  2 | two   | due
+  3 | three | tre
 (3 rows)
 
 drop table another;

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -3654,69 +3654,48 @@ ALTER TABLE test_add_column
 	ADD COLUMN IF NOT EXISTS c2 integer, -- skipping because c2 already exists
 	ADD COLUMN c3 integer primary key;
 NOTICE:  column "c2" of relation "test_add_column" already exists, skipping
+ERROR:  cannot add column with primary key constraint
 \d test_add_column
           Table "public.test_add_column"
  Column |  Type   | Collation | Nullable | Default 
 --------+---------+-----------+----------+---------
  c1     | integer |           |          | 
  c2     | integer |           |          | 
- c3     | integer |           | not null | 
-Indexes:
-    "test_add_column_pkey" PRIMARY KEY, btree (c3)
 
 ALTER TABLE test_add_column
 	ADD COLUMN IF NOT EXISTS c2 integer, -- skipping because c2 already exists
 	ADD COLUMN IF NOT EXISTS c3 integer primary key; -- skipping because c3 already exists
 NOTICE:  column "c2" of relation "test_add_column" already exists, skipping
-NOTICE:  column "c3" of relation "test_add_column" already exists, skipping
+ERROR:  cannot add column with primary key constraint
 \d test_add_column
           Table "public.test_add_column"
  Column |  Type   | Collation | Nullable | Default 
 --------+---------+-----------+----------+---------
  c1     | integer |           |          | 
  c2     | integer |           |          | 
- c3     | integer |           | not null | 
-Indexes:
-    "test_add_column_pkey" PRIMARY KEY, btree (c3)
 
 ALTER TABLE test_add_column
 	ADD COLUMN IF NOT EXISTS c2 integer, -- skipping because c2 already exists
 	ADD COLUMN IF NOT EXISTS c3 integer, -- skipping because c3 already exists
 	ADD COLUMN c4 integer REFERENCES test_add_column;
 NOTICE:  column "c2" of relation "test_add_column" already exists, skipping
-NOTICE:  column "c3" of relation "test_add_column" already exists, skipping
+ERROR:  there is no primary key for referenced table "test_add_column"
 \d test_add_column
           Table "public.test_add_column"
  Column |  Type   | Collation | Nullable | Default 
 --------+---------+-----------+----------+---------
  c1     | integer |           |          | 
  c2     | integer |           |          | 
- c3     | integer |           | not null | 
- c4     | integer |           |          | 
-Indexes:
-    "test_add_column_pkey" PRIMARY KEY, btree (c3)
-Foreign-key constraints:
-    "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
-Referenced by:
-    TABLE "test_add_column" CONSTRAINT "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
 
 ALTER TABLE test_add_column
 	ADD COLUMN IF NOT EXISTS c4 integer REFERENCES test_add_column;
-NOTICE:  column "c4" of relation "test_add_column" already exists, skipping
+ERROR:  there is no primary key for referenced table "test_add_column"
 \d test_add_column
           Table "public.test_add_column"
  Column |  Type   | Collation | Nullable | Default 
 --------+---------+-----------+----------+---------
  c1     | integer |           |          | 
  c2     | integer |           |          | 
- c3     | integer |           | not null | 
- c4     | integer |           |          | 
-Indexes:
-    "test_add_column_pkey" PRIMARY KEY, btree (c3)
-Foreign-key constraints:
-    "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
-Referenced by:
-    TABLE "test_add_column" CONSTRAINT "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
 
 ALTER TABLE test_add_column
 	ADD COLUMN IF NOT EXISTS c5 SERIAL CHECK (c5 > 8);
@@ -3726,17 +3705,9 @@ ALTER TABLE test_add_column
 --------+---------+-----------+----------+---------------------------------------------
  c1     | integer |           |          | 
  c2     | integer |           |          | 
- c3     | integer |           | not null | 
- c4     | integer |           |          | 
  c5     | integer |           | not null | nextval('test_add_column_c5_seq'::regclass)
-Indexes:
-    "test_add_column_pkey" PRIMARY KEY, btree (c3)
 Check constraints:
     "test_add_column_c5_check" CHECK (c5 > 8)
-Foreign-key constraints:
-    "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
-Referenced by:
-    TABLE "test_add_column" CONSTRAINT "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
 
 ALTER TABLE test_add_column
 	ADD COLUMN IF NOT EXISTS c5 SERIAL CHECK (c5 > 10);
@@ -3747,29 +3718,15 @@ NOTICE:  column "c5" of relation "test_add_column" already exists, skipping
 --------+---------+-----------+----------+---------------------------------------------
  c1     | integer |           |          | 
  c2     | integer |           |          | 
- c3     | integer |           | not null | 
- c4     | integer |           |          | 
  c5     | integer |           | not null | nextval('test_add_column_c5_seq'::regclass)
-Indexes:
-    "test_add_column_pkey" PRIMARY KEY, btree (c3)
 Check constraints:
     "test_add_column_c5_check" CHECK (c5 > 8)
-Foreign-key constraints:
-    "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
-Referenced by:
-    TABLE "test_add_column" CONSTRAINT "test_add_column_c4_fkey" FOREIGN KEY (c4) REFERENCES test_add_column(c3)
 
                Sequence "public.test_add_column_c5_seq"
   Type   | Start | Minimum |  Maximum   | Increment | Cycles? | Cache 
 ---------+-------+---------+------------+-----------+---------+-------
  integer |     1 |       1 | 2147483647 |         1 | no      |     1
 Owned by: public.test_add_column.c5
-
- Index "public.test_add_column_pkey"
- Column |  Type   | Key? | Definition 
---------+---------+------+------------
- c3     | integer | yes  | c3
-primary key, btree, for table "public.test_add_column"
 
 DROP TABLE test_add_column;
 \d test_add_column*
@@ -3789,7 +3746,7 @@ Indexes:
     "ataddindexi0" PRIMARY KEY, btree (f1)
 
 DROP TABLE ataddindex;
-CREATE TABLE ataddindex(f1 VARCHAR(10));
+CREATE TABLE ataddindex(f1 VARCHAR(10)) DISTRIBUTED REPLICATED;
 INSERT INTO ataddindex(f1) VALUES ('foo'), ('a');
 ALTER TABLE ataddindex
   ALTER f1 SET DATA TYPE TEXT,
@@ -3801,6 +3758,7 @@ ALTER TABLE ataddindex
  f1     | text |           |          | 
 Indexes:
     "ataddindex_expr_excl" EXCLUDE USING btree ((f1 ~~ 'a'::text) WITH =)
+Distributed Replicated
 
 DROP TABLE ataddindex;
 -- unsupported constraint types for partitioned tables

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1379,7 +1379,6 @@ analyze patest2;
 set enable_seqscan=off;
 set enable_bitmapscan=off;
 explain (costs off)
-<<<<<<< HEAD
 select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -1387,9 +1386,9 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
    ->  Hash Join
          Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
-               ->  Index Scan using patest0i on patest0
-               ->  Index Scan using patest1i on patest1 patest0_1
-               ->  Index Scan using patest2i on patest2 patest0_2
+               ->  Index Scan using patest0i on patest0 patest0_1
+               ->  Index Scan using patest1i on patest1 patest0_2
+               ->  Index Scan using patest2i on patest2 patest0_3
          ->  Hash
                ->  Redistribute Motion 1:3  (slice2; segments: 1)
                      Hash Key: int4_tbl.f1
@@ -1400,22 +1399,6 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
                                              Filter: ((f1 < 10) AND (f1 > '-10'::integer))
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
-                         QUERY PLAN                         
-------------------------------------------------------------
- Nested Loop
-   ->  Limit
-         ->  Seq Scan on int4_tbl
-   ->  Append
-         ->  Index Scan using patest0i on patest0 patest0_1
-               Index Cond: (id = int4_tbl.f1)
-         ->  Index Scan using patest1i on patest1 patest0_2
-               Index Cond: (id = int4_tbl.f1)
-         ->  Index Scan using patest2i on patest2 patest0_3
-               Index Cond: (id = int4_tbl.f1)
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
  id | x | f1 
@@ -1427,7 +1410,6 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
 
 drop index patest2i;
 explain (costs off)
-<<<<<<< HEAD
 select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -1435,9 +1417,9 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
    ->  Hash Join
          Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
-               ->  Index Scan using patest0i on patest0
-               ->  Index Scan using patest1i on patest1 patest0_1
-               ->  Seq Scan on patest2 patest0_2
+               ->  Index Scan using patest0i on patest0 patest0_1
+               ->  Index Scan using patest1i on patest1 patest0_2
+               ->  Seq Scan on patest2 patest0_3
          ->  Hash
                ->  Redistribute Motion 1:3  (slice2; segments: 1)
                      Hash Key: int4_tbl.f1
@@ -1448,22 +1430,6 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
                                              Filter: ((f1 < 10) AND (f1 > '-10'::integer))
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
-                         QUERY PLAN                         
-------------------------------------------------------------
- Nested Loop
-   ->  Limit
-         ->  Seq Scan on int4_tbl
-   ->  Append
-         ->  Index Scan using patest0i on patest0 patest0_1
-               Index Cond: (id = int4_tbl.f1)
-         ->  Index Scan using patest1i on patest1 patest0_2
-               Index Cond: (id = int4_tbl.f1)
-         ->  Seq Scan on patest2 patest0_3
-               Filter: (int4_tbl.f1 = id)
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
  id | x | f1 
@@ -1505,7 +1471,6 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: matest0.id, matest0.name, ((1 - matest0.id))
-<<<<<<< HEAD
    Merge Key: ((1 - matest0.id))
    ->  Sort
          Output: matest0.id, matest0.name, ((1 - matest0.id))
@@ -1513,32 +1478,17 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
          ->  Result
                Output: matest0.id, matest0.name, (1 - matest0.id)
                ->  Append
-                     ->  Seq Scan on public.matest0
-                           Output: matest0.id, matest0.name
-                     ->  Seq Scan on public.matest1 matest0_1
+                     ->  Seq Scan on public.matest0 matest0_1
                            Output: matest0_1.id, matest0_1.name
-                     ->  Seq Scan on public.matest2 matest0_2
+                     ->  Seq Scan on public.matest1 matest0_2
                            Output: matest0_2.id, matest0_2.name
-                     ->  Seq Scan on public.matest3 matest0_3
+                     ->  Seq Scan on public.matest2 matest0_3
                            Output: matest0_3.id, matest0_3.name
+                     ->  Seq Scan on public.matest3 matest0_4
+                           Output: matest0_4.id, matest0_4.name
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan = 'off', optimizer = 'off'
 (19 rows)
-=======
-   Sort Key: ((1 - matest0.id))
-   ->  Result
-         Output: matest0.id, matest0.name, (1 - matest0.id)
-         ->  Append
-               ->  Seq Scan on public.matest0 matest0_1
-                     Output: matest0_1.id, matest0_1.name
-               ->  Seq Scan on public.matest1 matest0_2
-                     Output: matest0_2.id, matest0_2.name
-               ->  Seq Scan on public.matest2 matest0_3
-                     Output: matest0_3.id, matest0_3.name
-               ->  Seq Scan on public.matest3 matest0_4
-                     Output: matest0_4.id, matest0_4.name
-(14 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select * from matest0 order by 1-id;
  id |  name  
@@ -1556,35 +1506,22 @@ explain (verbose, costs off) select min(1-id) from matest0;
 --------------------------------------------------------------
  Finalize Aggregate
    Output: min((1 - matest0.id))
-<<<<<<< HEAD
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: (PARTIAL min((1 - matest0.id)))
          ->  Partial Aggregate
                Output: PARTIAL min((1 - matest0.id))
                ->  Append
-                     ->  Seq Scan on public.matest0
-                           Output: matest0.id
-                     ->  Seq Scan on public.matest1 matest0_1
+                     ->  Seq Scan on public.matest0 matest0_1
                            Output: matest0_1.id
-                     ->  Seq Scan on public.matest2 matest0_2
+                     ->  Seq Scan on public.matest1 matest0_2
                            Output: matest0_2.id
-                     ->  Seq Scan on public.matest3 matest0_3
+                     ->  Seq Scan on public.matest2 matest0_3
                            Output: matest0_3.id
+                     ->  Seq Scan on public.matest3 matest0_4
+                           Output: matest0_4.id
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan = 'off', optimizer = 'off'
 (17 rows)
-=======
-   ->  Append
-         ->  Seq Scan on public.matest0 matest0_1
-               Output: matest0_1.id
-         ->  Seq Scan on public.matest1 matest0_2
-               Output: matest0_2.id
-         ->  Seq Scan on public.matest2 matest0_3
-               Output: matest0_3.id
-         ->  Seq Scan on public.matest3 matest0_4
-               Output: matest0_4.id
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select min(1-id) from matest0;
  min 
@@ -1600,7 +1537,6 @@ set enable_parallel_append = off; -- Don't let parallel-append interfere
 -- of append with bitmapscan + sort
 set enable_bitmapscan = off; 
 explain (verbose, costs off) select * from matest0 order by 1-id;
-<<<<<<< HEAD
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1608,38 +1544,20 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
    Merge Key: ((1 - matest0.id))
    ->  Merge Append
          Sort Key: ((1 - matest0.id))
-         ->  Index Scan using matest0i on public.matest0
-               Output: matest0.id, matest0.name, (1 - matest0.id)
-         ->  Index Scan using matest1i on public.matest1 matest0_1
+         ->  Index Scan using matest0i on public.matest0 matest0_1
                Output: matest0_1.id, matest0_1.name, (1 - matest0_1.id)
+         ->  Index Scan using matest1i on public.matest1 matest0_2
+               Output: matest0_2.id, matest0_2.name, (1 - matest0_2.id)
          ->  Sort
-               Output: matest0_2.id, matest0_2.name, ((1 - matest0_2.id))
-               Sort Key: ((1 - matest0_2.id))
-               ->  Seq Scan on public.matest2 matest0_2
-                     Output: matest0_2.id, matest0_2.name, (1 - matest0_2.id)
-         ->  Index Scan using matest3i on public.matest3 matest0_3
-               Output: matest0_3.id, matest0_3.name, (1 - matest0_3.id)
+               Output: matest0_3.id, matest0_3.name, ((1 - matest0_3.id))
+               Sort Key: ((1 - matest0_3.id))
+               ->  Seq Scan on public.matest2 matest0_3
+                     Output: matest0_3.id, matest0_3.name, (1 - matest0_3.id)
+         ->  Index Scan using matest3i on public.matest3 matest0_4
+               Output: matest0_4.id, matest0_4.name, (1 - matest0_4.id)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan = 'off', enable_parallel_append = 'off', enable_seqscan = 'off', optimizer = 'off'
 (18 rows)
-=======
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Merge Append
-   Sort Key: ((1 - matest0.id))
-   ->  Index Scan using matest0i on public.matest0 matest0_1
-         Output: matest0_1.id, matest0_1.name, (1 - matest0_1.id)
-   ->  Index Scan using matest1i on public.matest1 matest0_2
-         Output: matest0_2.id, matest0_2.name, (1 - matest0_2.id)
-   ->  Sort
-         Output: matest0_3.id, matest0_3.name, ((1 - matest0_3.id))
-         Sort Key: ((1 - matest0_3.id))
-         ->  Seq Scan on public.matest2 matest0_3
-               Output: matest0_3.id, matest0_3.name, (1 - matest0_3.id)
-   ->  Index Scan using matest3i on public.matest3 matest0_4
-         Output: matest0_4.id, matest0_4.name, (1 - matest0_4.id)
-(13 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select * from matest0 order by 1-id;
  id |  name  
@@ -1662,51 +1580,29 @@ explain (verbose, costs off) select min(1-id) from matest0;
            Output: ((1 - matest0.id))
            ->  Gather Motion 3:1  (slice2; segments: 3)
                  Output: ((1 - matest0.id))
-<<<<<<< HEAD
                  Merge Key: ((1 - matest0.id))
                  ->  Result
                        Output: ((1 - matest0.id))
                        ->  Merge Append
                              Sort Key: ((1 - matest0.id))
-                             ->  Index Scan using matest0i on public.matest0
-                                   Output: matest0.id, (1 - matest0.id)
-                                   Index Cond: ((1 - matest0.id) IS NOT NULL)
-                             ->  Index Scan using matest1i on public.matest1 matest0_1
+                             ->  Index Scan using matest0i on public.matest0 matest0_1
                                    Output: matest0_1.id, (1 - matest0_1.id)
                                    Index Cond: ((1 - matest0_1.id) IS NOT NULL)
+                             ->  Index Scan using matest1i on public.matest1 matest0_2
+                                   Output: matest0_2.id, (1 - matest0_2.id)
+                                   Index Cond: ((1 - matest0_2.id) IS NOT NULL)
                              ->  Sort
-                                   Output: matest0_2.id, ((1 - matest0_2.id))
-                                   Sort Key: ((1 - matest0_2.id))
-                                   ->  Index Only Scan using matest2_pkey on public.matest2 matest0_2
-                                         Output: matest0_2.id, (1 - matest0_2.id)
-                                         Filter: ((1 - matest0_2.id) IS NOT NULL)
-                             ->  Index Scan using matest3i on public.matest3 matest0_3
-                                   Output: matest0_3.id, (1 - matest0_3.id)
-                                   Index Cond: ((1 - matest0_3.id) IS NOT NULL)
+                                   Output: matest0_3.id, ((1 - matest0_3.id))
+                                   Sort Key: ((1 - matest0_3.id))
+                                   ->  Index Only Scan using matest2_pkey on public.matest2 matest0_3
+                                         Output: matest0_3.id, (1 - matest0_3.id)
+                                         Filter: ((1 - matest0_3.id) IS NOT NULL)
+                             ->  Index Scan using matest3i on public.matest3 matest0_4
+                                   Output: matest0_4.id, (1 - matest0_4.id)
+                                   Index Cond: ((1 - matest0_4.id) IS NOT NULL)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan = 'off', enable_parallel_append = 'off', enable_seqscan = 'off', optimizer = 'off'
 (29 rows)
-=======
-                 ->  Merge Append
-                       Sort Key: ((1 - matest0.id))
-                       ->  Index Scan using matest0i on public.matest0 matest0_1
-                             Output: matest0_1.id, (1 - matest0_1.id)
-                             Index Cond: ((1 - matest0_1.id) IS NOT NULL)
-                       ->  Index Scan using matest1i on public.matest1 matest0_2
-                             Output: matest0_2.id, (1 - matest0_2.id)
-                             Index Cond: ((1 - matest0_2.id) IS NOT NULL)
-                       ->  Sort
-                             Output: matest0_3.id, ((1 - matest0_3.id))
-                             Sort Key: ((1 - matest0_3.id))
-                             ->  Bitmap Heap Scan on public.matest2 matest0_3
-                                   Output: matest0_3.id, (1 - matest0_3.id)
-                                   Filter: ((1 - matest0_3.id) IS NOT NULL)
-                                   ->  Bitmap Index Scan on matest2_pkey
-                       ->  Index Scan using matest3i on public.matest3 matest0_4
-                             Output: matest0_4.id, (1 - matest0_4.id)
-                             Index Cond: ((1 - matest0_4.id) IS NOT NULL)
-(25 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select min(1-id) from matest0;
  min 
@@ -1741,38 +1637,23 @@ order by t1.b limit 10;
  Limit
    ->  Merge Join
          Merge Cond: (t1.b = t2.b)
-<<<<<<< HEAD
          ->  Gather Motion 3:1  (slice1; segments: 3)
                Merge Key: t1.b
                ->  Merge Append
                      Sort Key: t1.b
-                     ->  Index Scan using matest0i on matest0 t1
-                     ->  Index Scan using matest1i on matest1 t1_1
+                     ->  Index Scan using matest0i on matest0 t1_1
+                     ->  Index Scan using matest1i on matest1 t1_2
          ->  Materialize
                ->  Gather Motion 3:1  (slice2; segments: 3)
                      Merge Key: t2.b
                      ->  Merge Append
                            Sort Key: t2.b
-                           ->  Index Scan using matest0i on matest0 t2
+                           ->  Index Scan using matest0i on matest0 t2_1
                                  Filter: (c = d)
-                           ->  Index Scan using matest1i on matest1 t2_1
+                           ->  Index Scan using matest1i on matest1 t2_2
                                  Filter: (c = d)
  Optimizer: Postgres query optimizer
 (19 rows)
-=======
-         ->  Merge Append
-               Sort Key: t1.b
-               ->  Index Scan using matest0i on matest0 t1_1
-               ->  Index Scan using matest1i on matest1 t1_2
-         ->  Materialize
-               ->  Merge Append
-                     Sort Key: t2.b
-                     ->  Index Scan using matest0i on matest0 t2_1
-                           Filter: (c = d)
-                     ->  Index Scan using matest1i on matest1 t2_2
-                           Filter: (c = d)
-(14 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 reset enable_nestloop;
 drop table matest0 cascade;
@@ -2020,25 +1901,15 @@ create table part_ab_cd partition of list_parted for values in ('ab', 'cd');
 create table part_ef_gh partition of list_parted for values in ('ef', 'gh');
 create table part_null_xy partition of list_parted for values in (null, 'xy');
 explain (costs off) select * from list_parted;
-<<<<<<< HEAD
                      QUERY PLAN                     
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_ab_cd list_parted
-         ->  Seq Scan on part_ef_gh list_parted_1
-         ->  Seq Scan on part_null_xy list_parted_2
+         ->  Seq Scan on part_ab_cd list_parted_1
+         ->  Seq Scan on part_ef_gh list_parted_2
+         ->  Seq Scan on part_null_xy list_parted_3
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on part_ab_cd list_parted_1
-   ->  Seq Scan on part_ef_gh list_parted_2
-   ->  Seq Scan on part_null_xy list_parted_3
-(4 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from list_parted where a is null;
                  QUERY PLAN                 
@@ -2050,16 +1921,15 @@ explain (costs off) select * from list_parted where a is null;
 (4 rows)
 
 explain (costs off) select * from list_parted where a is not null;
-<<<<<<< HEAD
                      QUERY PLAN                     
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_ab_cd list_parted
+         ->  Seq Scan on part_ab_cd list_parted_1
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on part_ef_gh list_parted_1
+         ->  Seq Scan on part_ef_gh list_parted_2
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on part_null_xy list_parted_2
+         ->  Seq Scan on part_null_xy list_parted_3
                Filter: (a IS NOT NULL)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2069,34 +1939,12 @@ explain (costs off) select * from list_parted where a in ('ab', 'cd', 'ef');
 ----------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on part_ab_cd list_parted
+         ->  Seq Scan on part_ab_cd list_parted_1
                Filter: ((a)::text = ANY ('{ab,cd,ef}'::text[]))
-         ->  Seq Scan on part_ef_gh list_parted_1
+         ->  Seq Scan on part_ef_gh list_parted_2
                Filter: ((a)::text = ANY ('{ab,cd,ef}'::text[]))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on part_ab_cd list_parted_1
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on part_ef_gh list_parted_2
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on part_null_xy list_parted_3
-         Filter: (a IS NOT NULL)
-(7 rows)
-
-explain (costs off) select * from list_parted where a in ('ab', 'cd', 'ef');
-                        QUERY PLAN                        
-----------------------------------------------------------
- Append
-   ->  Seq Scan on part_ab_cd list_parted_1
-         Filter: ((a)::text = ANY ('{ab,cd,ef}'::text[]))
-   ->  Seq Scan on part_ef_gh list_parted_2
-         Filter: ((a)::text = ANY ('{ab,cd,ef}'::text[]))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from list_parted where a = 'ab' or a in (null, 'cd');
                                       QUERY PLAN                                       
@@ -2134,20 +1982,19 @@ create table part_40_inf_ab partition of part_40_inf for values in ('ab');
 create table part_40_inf_cd partition of part_40_inf for values in ('cd');
 create table part_40_inf_null partition of part_40_inf for values in (null);
 explain (costs off) select * from range_list_parted;
-<<<<<<< HEAD
                           QUERY PLAN                          
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
-         ->  Seq Scan on part_1_10_cd range_list_parted_1
-         ->  Seq Scan on part_10_20_ab range_list_parted_2
-         ->  Seq Scan on part_10_20_cd range_list_parted_3
-         ->  Seq Scan on part_21_30_ab range_list_parted_4
-         ->  Seq Scan on part_21_30_cd range_list_parted_5
-         ->  Seq Scan on part_40_inf_ab range_list_parted_6
-         ->  Seq Scan on part_40_inf_cd range_list_parted_7
-         ->  Seq Scan on part_40_inf_null range_list_parted_8
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
+         ->  Seq Scan on part_1_10_cd range_list_parted_2
+         ->  Seq Scan on part_10_20_ab range_list_parted_3
+         ->  Seq Scan on part_10_20_cd range_list_parted_4
+         ->  Seq Scan on part_21_30_ab range_list_parted_5
+         ->  Seq Scan on part_21_30_cd range_list_parted_6
+         ->  Seq Scan on part_40_inf_ab range_list_parted_7
+         ->  Seq Scan on part_40_inf_cd range_list_parted_8
+         ->  Seq Scan on part_40_inf_null range_list_parted_9
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -2156,9 +2003,9 @@ explain (costs off) select * from range_list_parted where a = 5;
 ----------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: (a = 5)
-         ->  Seq Scan on part_1_10_cd range_list_parted_1
+         ->  Seq Scan on part_1_10_cd range_list_parted_2
                Filter: (a = 5)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -2168,13 +2015,13 @@ explain (costs off) select * from range_list_parted where b = 'ab';
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: (b = 'ab'::bpchar)
-         ->  Seq Scan on part_10_20_ab range_list_parted_1
+         ->  Seq Scan on part_10_20_ab range_list_parted_2
                Filter: (b = 'ab'::bpchar)
-         ->  Seq Scan on part_21_30_ab range_list_parted_2
+         ->  Seq Scan on part_21_30_ab range_list_parted_3
                Filter: (b = 'ab'::bpchar)
-         ->  Seq Scan on part_40_inf_ab range_list_parted_3
+         ->  Seq Scan on part_40_inf_ab range_list_parted_4
                Filter: (b = 'ab'::bpchar)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -2184,65 +2031,14 @@ explain (costs off) select * from range_list_parted where a between 3 and 23 and
 -----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-         ->  Seq Scan on part_10_20_ab range_list_parted_1
+         ->  Seq Scan on part_10_20_ab range_list_parted_2
                Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-         ->  Seq Scan on part_21_30_ab range_list_parted_2
+         ->  Seq Scan on part_21_30_ab range_list_parted_3
                Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                       QUERY PLAN                       
---------------------------------------------------------
- Append
-   ->  Seq Scan on part_1_10_ab range_list_parted_1
-   ->  Seq Scan on part_1_10_cd range_list_parted_2
-   ->  Seq Scan on part_10_20_ab range_list_parted_3
-   ->  Seq Scan on part_10_20_cd range_list_parted_4
-   ->  Seq Scan on part_21_30_ab range_list_parted_5
-   ->  Seq Scan on part_21_30_cd range_list_parted_6
-   ->  Seq Scan on part_40_inf_ab range_list_parted_7
-   ->  Seq Scan on part_40_inf_cd range_list_parted_8
-   ->  Seq Scan on part_40_inf_null range_list_parted_9
-(10 rows)
-
-explain (costs off) select * from range_list_parted where a = 5;
-                     QUERY PLAN                     
-----------------------------------------------------
- Append
-   ->  Seq Scan on part_1_10_ab range_list_parted_1
-         Filter: (a = 5)
-   ->  Seq Scan on part_1_10_cd range_list_parted_2
-         Filter: (a = 5)
-(5 rows)
-
-explain (costs off) select * from range_list_parted where b = 'ab';
-                      QUERY PLAN                      
-------------------------------------------------------
- Append
-   ->  Seq Scan on part_1_10_ab range_list_parted_1
-         Filter: (b = 'ab'::bpchar)
-   ->  Seq Scan on part_10_20_ab range_list_parted_2
-         Filter: (b = 'ab'::bpchar)
-   ->  Seq Scan on part_21_30_ab range_list_parted_3
-         Filter: (b = 'ab'::bpchar)
-   ->  Seq Scan on part_40_inf_ab range_list_parted_4
-         Filter: (b = 'ab'::bpchar)
-(9 rows)
-
-explain (costs off) select * from range_list_parted where a between 3 and 23 and b in ('ab');
-                           QUERY PLAN                            
------------------------------------------------------------------
- Append
-   ->  Seq Scan on part_1_10_ab range_list_parted_1
-         Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-   ->  Seq Scan on part_10_20_ab range_list_parted_2
-         Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-   ->  Seq Scan on part_21_30_ab range_list_parted_3
-         Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 /* Should select no rows because range partition key cannot be null */
 explain (costs off) select * from range_list_parted where a is null;
@@ -2264,28 +2060,27 @@ explain (costs off) select * from range_list_parted where b is null;
 (4 rows)
 
 explain (costs off) select * from range_list_parted where a is not null and a < 67;
-<<<<<<< HEAD
                           QUERY PLAN                          
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_1_10_cd range_list_parted_1
+         ->  Seq Scan on part_1_10_cd range_list_parted_2
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_10_20_ab range_list_parted_2
+         ->  Seq Scan on part_10_20_ab range_list_parted_3
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_10_20_cd range_list_parted_3
+         ->  Seq Scan on part_10_20_cd range_list_parted_4
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_21_30_ab range_list_parted_4
+         ->  Seq Scan on part_21_30_ab range_list_parted_5
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_21_30_cd range_list_parted_5
+         ->  Seq Scan on part_21_30_cd range_list_parted_6
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_40_inf_ab range_list_parted_6
+         ->  Seq Scan on part_40_inf_ab range_list_parted_7
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_40_inf_cd range_list_parted_7
+         ->  Seq Scan on part_40_inf_cd range_list_parted_8
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_40_inf_null range_list_parted_8
+         ->  Seq Scan on part_40_inf_null range_list_parted_9
                Filter: ((a IS NOT NULL) AND (a < 67))
  Optimizer: Postgres query optimizer
 (21 rows)
@@ -2295,50 +2090,14 @@ explain (costs off) select * from range_list_parted where a >= 30;
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_40_inf_ab range_list_parted
+         ->  Seq Scan on part_40_inf_ab range_list_parted_1
                Filter: (a >= 30)
-         ->  Seq Scan on part_40_inf_cd range_list_parted_1
+         ->  Seq Scan on part_40_inf_cd range_list_parted_2
                Filter: (a >= 30)
-         ->  Seq Scan on part_40_inf_null range_list_parted_2
+         ->  Seq Scan on part_40_inf_null range_list_parted_3
                Filter: (a >= 30)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                       QUERY PLAN                       
---------------------------------------------------------
- Append
-   ->  Seq Scan on part_1_10_ab range_list_parted_1
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_1_10_cd range_list_parted_2
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_10_20_ab range_list_parted_3
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_10_20_cd range_list_parted_4
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_21_30_ab range_list_parted_5
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_21_30_cd range_list_parted_6
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_40_inf_ab range_list_parted_7
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_40_inf_cd range_list_parted_8
-         Filter: ((a IS NOT NULL) AND (a < 67))
-   ->  Seq Scan on part_40_inf_null range_list_parted_9
-         Filter: ((a IS NOT NULL) AND (a < 67))
-(19 rows)
-
-explain (costs off) select * from range_list_parted where a >= 30;
-                       QUERY PLAN                       
---------------------------------------------------------
- Append
-   ->  Seq Scan on part_40_inf_ab range_list_parted_1
-         Filter: (a >= 30)
-   ->  Seq Scan on part_40_inf_cd range_list_parted_2
-         Filter: (a >= 30)
-   ->  Seq Scan on part_40_inf_null range_list_parted_3
-         Filter: (a >= 30)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table list_parted;
 drop table range_list_parted;
@@ -2353,94 +2112,61 @@ create table mcrparted3 partition of mcrparted for values from (11, 1, 1) to (20
 create table mcrparted4 partition of mcrparted for values from (20, 10, 10) to (20, 20, 20);
 create table mcrparted5 partition of mcrparted for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
 explain (costs off) select * from mcrparted where a = 0;	-- scans mcrparted0, mcrparted_def
-<<<<<<< HEAD
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mcrparted0 mcrparted
+         ->  Seq Scan on mcrparted0 mcrparted_1
                Filter: (a = 0)
-         ->  Seq Scan on mcrparted_def mcrparted_1
-               Filter: (a = 0)
- Optimizer: Postgres query optimizer
-=======
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on mcrparted0 mcrparted_1
-         Filter: (a = 0)
-   ->  Seq Scan on mcrparted_def mcrparted_2
-         Filter: (a = 0)
-(5 rows)
-
-explain (costs off) select * from mcrparted where a = 10 and abs(b) < 5;	-- scans mcrparted1, mcrparted_def
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on mcrparted1 mcrparted_1
-         Filter: ((a = 10) AND (abs(b) < 5))
-   ->  Seq Scan on mcrparted_def mcrparted_2
-         Filter: ((a = 10) AND (abs(b) < 5))
-(5 rows)
-
-explain (costs off) select * from mcrparted where a = 10 and abs(b) = 5;	-- scans mcrparted1, mcrparted2, mcrparted_def
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on mcrparted1 mcrparted_1
-         Filter: ((a = 10) AND (abs(b) = 5))
-   ->  Seq Scan on mcrparted2 mcrparted_2
-         Filter: ((a = 10) AND (abs(b) = 5))
-   ->  Seq Scan on mcrparted_def mcrparted_3
-         Filter: ((a = 10) AND (abs(b) = 5))
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
-(7 rows)
-
-explain (costs off) select * from mcrparted where a = 10 and abs(b) < 5;	-- scans mcrparted1, mcrparted_def
-                    QUERY PLAN                     
----------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Append
-         ->  Seq Scan on mcrparted1 mcrparted
-               Filter: ((a = 10) AND (abs(b) < 5))
-         ->  Seq Scan on mcrparted_def mcrparted_1
-               Filter: ((a = 10) AND (abs(b) < 5))
- Optimizer: Postgres query optimizer
-(7 rows)
-
-explain (costs off) select * from mcrparted where a = 10 and abs(b) = 5;	-- scans mcrparted1, mcrparted2, mcrparted_def
-                    QUERY PLAN                     
----------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Append
-         ->  Seq Scan on mcrparted1 mcrparted
-               Filter: ((a = 10) AND (abs(b) = 5))
-         ->  Seq Scan on mcrparted2 mcrparted_1
-               Filter: ((a = 10) AND (abs(b) = 5))
          ->  Seq Scan on mcrparted_def mcrparted_2
+               Filter: (a = 0)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain (costs off) select * from mcrparted where a = 10 and abs(b) < 5;	-- scans mcrparted1, mcrparted_def
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on mcrparted1 mcrparted_1
+               Filter: ((a = 10) AND (abs(b) < 5))
+         ->  Seq Scan on mcrparted_def mcrparted_2
+               Filter: ((a = 10) AND (abs(b) < 5))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain (costs off) select * from mcrparted where a = 10 and abs(b) = 5;	-- scans mcrparted1, mcrparted2, mcrparted_def
+                    QUERY PLAN                     
+---------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Append
+         ->  Seq Scan on mcrparted1 mcrparted_1
+               Filter: ((a = 10) AND (abs(b) = 5))
+         ->  Seq Scan on mcrparted2 mcrparted_2
+               Filter: ((a = 10) AND (abs(b) = 5))
+         ->  Seq Scan on mcrparted_def mcrparted_3
                Filter: ((a = 10) AND (abs(b) = 5))
  Optimizer: Postgres query optimizer
 (9 rows)
 
 explain (costs off) select * from mcrparted where abs(b) = 5;	-- scans all partitions
-<<<<<<< HEAD
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mcrparted0 mcrparted
+         ->  Seq Scan on mcrparted0 mcrparted_1
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted1 mcrparted_1
+         ->  Seq Scan on mcrparted1 mcrparted_2
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted2 mcrparted_2
+         ->  Seq Scan on mcrparted2 mcrparted_3
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted3 mcrparted_3
+         ->  Seq Scan on mcrparted3 mcrparted_4
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted4 mcrparted_4
+         ->  Seq Scan on mcrparted4 mcrparted_5
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted5 mcrparted_5
+         ->  Seq Scan on mcrparted5 mcrparted_6
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted_def mcrparted_6
+         ->  Seq Scan on mcrparted_def mcrparted_7
                Filter: (abs(b) = 5)
  Optimizer: Postgres query optimizer
 (17 rows)
@@ -2450,62 +2176,22 @@ explain (costs off) select * from mcrparted where a > -1;	-- scans all partition
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mcrparted0 mcrparted
+         ->  Seq Scan on mcrparted0 mcrparted_1
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted1 mcrparted_1
+         ->  Seq Scan on mcrparted1 mcrparted_2
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted2 mcrparted_2
+         ->  Seq Scan on mcrparted2 mcrparted_3
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted3 mcrparted_3
+         ->  Seq Scan on mcrparted3 mcrparted_4
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted4 mcrparted_4
+         ->  Seq Scan on mcrparted4 mcrparted_5
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted5 mcrparted_5
+         ->  Seq Scan on mcrparted5 mcrparted_6
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted_def mcrparted_6
+         ->  Seq Scan on mcrparted_def mcrparted_7
                Filter: (a > '-1'::integer)
  Optimizer: Postgres query optimizer
 (17 rows)
-=======
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on mcrparted0 mcrparted_1
-         Filter: (abs(b) = 5)
-   ->  Seq Scan on mcrparted1 mcrparted_2
-         Filter: (abs(b) = 5)
-   ->  Seq Scan on mcrparted2 mcrparted_3
-         Filter: (abs(b) = 5)
-   ->  Seq Scan on mcrparted3 mcrparted_4
-         Filter: (abs(b) = 5)
-   ->  Seq Scan on mcrparted4 mcrparted_5
-         Filter: (abs(b) = 5)
-   ->  Seq Scan on mcrparted5 mcrparted_6
-         Filter: (abs(b) = 5)
-   ->  Seq Scan on mcrparted_def mcrparted_7
-         Filter: (abs(b) = 5)
-(15 rows)
-
-explain (costs off) select * from mcrparted where a > -1;	-- scans all partitions
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on mcrparted0 mcrparted_1
-         Filter: (a > '-1'::integer)
-   ->  Seq Scan on mcrparted1 mcrparted_2
-         Filter: (a > '-1'::integer)
-   ->  Seq Scan on mcrparted2 mcrparted_3
-         Filter: (a > '-1'::integer)
-   ->  Seq Scan on mcrparted3 mcrparted_4
-         Filter: (a > '-1'::integer)
-   ->  Seq Scan on mcrparted4 mcrparted_5
-         Filter: (a > '-1'::integer)
-   ->  Seq Scan on mcrparted5 mcrparted_6
-         Filter: (a > '-1'::integer)
-   ->  Seq Scan on mcrparted_def mcrparted_7
-         Filter: (a > '-1'::integer)
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from mcrparted where a = 20 and abs(b) = 10 and c > 10;	-- scans mcrparted4
                         QUERY PLAN                         
@@ -2517,35 +2203,20 @@ explain (costs off) select * from mcrparted where a = 20 and abs(b) = 10 and c >
 (4 rows)
 
 explain (costs off) select * from mcrparted where a = 20 and c > 20; -- scans mcrparted3, mcrparte4, mcrparte5, mcrparted_def
-<<<<<<< HEAD
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mcrparted3 mcrparted
+         ->  Seq Scan on mcrparted3 mcrparted_1
                Filter: ((c > 20) AND (a = 20))
-         ->  Seq Scan on mcrparted4 mcrparted_1
+         ->  Seq Scan on mcrparted4 mcrparted_2
                Filter: ((c > 20) AND (a = 20))
-         ->  Seq Scan on mcrparted5 mcrparted_2
+         ->  Seq Scan on mcrparted5 mcrparted_3
                Filter: ((c > 20) AND (a = 20))
-         ->  Seq Scan on mcrparted_def mcrparted_3
+         ->  Seq Scan on mcrparted_def mcrparted_4
                Filter: ((c > 20) AND (a = 20))
  Optimizer: Postgres query optimizer
 (11 rows)
-=======
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on mcrparted3 mcrparted_1
-         Filter: ((c > 20) AND (a = 20))
-   ->  Seq Scan on mcrparted4 mcrparted_2
-         Filter: ((c > 20) AND (a = 20))
-   ->  Seq Scan on mcrparted5 mcrparted_3
-         Filter: ((c > 20) AND (a = 20))
-   ->  Seq Scan on mcrparted_def mcrparted_4
-         Filter: ((c > 20) AND (a = 20))
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- check that partitioned table Appends cope with being referenced in
 -- subplans
@@ -2584,53 +2255,37 @@ drop table parted_minmax;
 create index mcrparted_a_abs_c_idx on mcrparted (a, abs(b), c);
 -- MergeAppend must be used when a default partition exists
 explain (costs off) select * from mcrparted order by a, abs(b), c;
-<<<<<<< HEAD
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Merge Append
          Sort Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_5
-         ->  Index Scan using mcrparted_def_a_abs_c_idx on mcrparted_def mcrparted_6
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
+         ->  Index Scan using mcrparted_def_a_abs_c_idx on mcrparted_def mcrparted_7
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Merge Append
-   Sort Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
-   ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
-   ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-   ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-   ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-   ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
-   ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
-   ->  Index Scan using mcrparted_def_a_abs_c_idx on mcrparted_def mcrparted_7
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table mcrparted_def;
 -- Append is used for a RANGE partitioned table with no default
 -- and no subpartitions
 explain (costs off) select * from mcrparted order by a, abs(b), c;
-<<<<<<< HEAD
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_5
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -2639,41 +2294,16 @@ explain (costs off) select * from mcrparted order by a desc, abs(b) desc, c desc
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: mcrparted_5.a, (abs(mcrparted_5.b)), mcrparted_5.c
+   Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan Backward using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_5
-         ->  Index Scan Backward using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan Backward using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan Backward using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan Backward using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan Backward using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
+         ->  Index Scan Backward using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
+         ->  Index Scan Backward using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan Backward using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan Backward using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan Backward using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan Backward using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
  Optimizer: Postgres query optimizer
 (10 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Append
-   ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
-   ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-   ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-   ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-   ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
-   ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
-(7 rows)
-
--- Append is used with subpaths in reverse order with backwards index scans
-explain (costs off) select * from mcrparted order by a desc, abs(b) desc, c desc;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Append
-   ->  Index Scan Backward using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
-   ->  Index Scan Backward using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
-   ->  Index Scan Backward using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-   ->  Index Scan Backward using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-   ->  Index Scan Backward using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-   ->  Index Scan Backward using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- check that Append plan is used containing a MergeAppend for sub-partitions
 -- that are unordered.
@@ -2682,104 +2312,60 @@ create table mcrparted5 partition of mcrparted for values from (20, 20, 20) to (
 create table mcrparted5a partition of mcrparted5 for values in(20);
 create table mcrparted5_def partition of mcrparted5 default;
 explain (costs off) select * from mcrparted order by a, abs(b), c;
-<<<<<<< HEAD
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
          ->  Merge Append
-               Sort Key: mcrparted_5.a, (abs(mcrparted_5.b)), mcrparted_5.c
-               ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_5
-               ->  Index Scan using mcrparted5_def_a_abs_c_idx on mcrparted5_def mcrparted_6
+               Sort Key: mcrparted_7.a, (abs(mcrparted_7.b)), mcrparted_7.c
+               ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_7
+               ->  Index Scan using mcrparted5_def_a_abs_c_idx on mcrparted5_def mcrparted_8
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Append
-   ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
-   ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-   ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-   ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-   ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
-   ->  Merge Append
-         Sort Key: mcrparted_7.a, (abs(mcrparted_7.b)), mcrparted_7.c
-         ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_7
-         ->  Index Scan using mcrparted5_def_a_abs_c_idx on mcrparted5_def mcrparted_8
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table mcrparted5_def;
 -- check that an Append plan is used and the sub-partitions are flattened
 -- into the main Append when the sub-partition is unordered but contains
 -- just a single sub-partition.
 explain (costs off) select a, abs(b) from mcrparted order by a, abs(b), c;
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_5
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_6
  Optimizer: Postgres query optimizer
 (10 rows)
-=======
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Append
-   ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
-   ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-   ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-   ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-   ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
-   ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_6
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- check that Append is used when the sub-partitioned tables are pruned
 -- during planning.
 explain (costs off) select * from mcrparted where a < 20 order by a, abs(b), c;
-<<<<<<< HEAD
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
                Index Cond: (a < 20)
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
                Index Cond: (a < 20)
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
                Index Cond: (a < 20)
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
                Index Cond: (a < 20)
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Append
-   ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
-         Index Cond: (a < 20)
-   ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-         Index Cond: (a < 20)
-   ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-         Index Cond: (a < 20)
-   ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-         Index Cond: (a < 20)
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 create table mclparted (a int) partition by list(a);
 create table mclparted1 partition of mclparted for values in(1);
@@ -2787,54 +2373,33 @@ create table mclparted2 partition of mclparted for values in(2);
 create index on mclparted (a);
 -- Ensure an Append is used for a list partition with an order by.
 explain (costs off) select * from mclparted order by a;
-<<<<<<< HEAD
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mclparted.a
    ->  Append
-         ->  Index Only Scan using mclparted1_a_idx on mclparted1 mclparted
-         ->  Index Only Scan using mclparted2_a_idx on mclparted2 mclparted_1
+         ->  Index Only Scan using mclparted1_a_idx on mclparted1 mclparted_1
+         ->  Index Only Scan using mclparted2_a_idx on mclparted2 mclparted_2
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using mclparted1_a_idx on mclparted1 mclparted_1
-   ->  Index Only Scan using mclparted2_a_idx on mclparted2 mclparted_2
-(3 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Ensure a MergeAppend is used when a partition exists with interleaved
 -- datums in the partition bound.
 create table mclparted3_5 partition of mclparted for values in(3,5);
 create table mclparted4 partition of mclparted for values in(4);
 explain (costs off) select * from mclparted order by a;
-<<<<<<< HEAD
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mclparted.a
    ->  Merge Append
          Sort Key: mclparted.a
-         ->  Index Only Scan using mclparted1_a_idx on mclparted1 mclparted
-         ->  Index Only Scan using mclparted2_a_idx on mclparted2 mclparted_1
-         ->  Index Only Scan using mclparted3_5_a_idx on mclparted3_5 mclparted_2
-         ->  Index Only Scan using mclparted4_a_idx on mclparted4 mclparted_3
+         ->  Index Only Scan using mclparted1_a_idx on mclparted1 mclparted_1
+         ->  Index Only Scan using mclparted2_a_idx on mclparted2 mclparted_2
+         ->  Index Only Scan using mclparted3_5_a_idx on mclparted3_5 mclparted_3
+         ->  Index Only Scan using mclparted4_a_idx on mclparted4 mclparted_4
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Merge Append
-   Sort Key: mclparted.a
-   ->  Index Only Scan using mclparted1_a_idx on mclparted1 mclparted_1
-   ->  Index Only Scan using mclparted2_a_idx on mclparted2 mclparted_2
-   ->  Index Only Scan using mclparted3_5_a_idx on mclparted3_5 mclparted_3
-   ->  Index Only Scan using mclparted4_a_idx on mclparted4 mclparted_4
-(6 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table mclparted;
 -- Ensure subplans which don't have a path with the correct pathkeys get
@@ -2848,64 +2413,38 @@ explain (costs off) select * from mcrparted where a < 20 order by a, abs(b), c l
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Limit
-<<<<<<< HEAD
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
          ->  Limit
                ->  Append
                      ->  Sort
-                           Sort Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
-                           ->  Seq Scan on mcrparted0 mcrparted
+                           Sort Key: mcrparted_1.a, (abs(mcrparted_1.b)), mcrparted_1.c
+                           ->  Seq Scan on mcrparted0 mcrparted_1
                                  Filter: (a < 20)
-                     ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
+                     ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
                            Index Cond: (a < 20)
-                     ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
+                     ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
                            Index Cond: (a < 20)
-                     ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
+                     ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
                            Index Cond: (a < 20)
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-   ->  Append
-         ->  Sort
-               Sort Key: mcrparted_1.a, (abs(mcrparted_1.b)), mcrparted_1.c
-               ->  Seq Scan on mcrparted0 mcrparted_1
-                     Filter: (a < 20)
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
-               Index Cond: (a < 20)
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
-               Index Cond: (a < 20)
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
-               Index Cond: (a < 20)
-(12 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 set enable_bitmapscan = 0;
 -- Ensure Append node can be used when the partition is ordered by some
 -- pathkeys which were deemed redundant.
 explain (costs off) select * from mcrparted where a = 10 order by a, abs(b), c;
-<<<<<<< HEAD
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    Merge Key: (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
                Index Cond: (a = 10)
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_1
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
                Index Cond: (a = 10)
  Optimizer: Postgres query optimizer
 (8 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Append
-   ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         Index Cond: (a = 10)
-   ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         Index Cond: (a = 10)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 reset enable_bitmapscan;
 drop table mcrparted;
@@ -2915,24 +2454,15 @@ create table bool_lp_true partition of bool_lp for values in(true);
 create table bool_lp_false partition of bool_lp for values in(false);
 create index on bool_lp (b);
 explain (costs off) select * from bool_lp order by b;
-<<<<<<< HEAD
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: bool_lp.b
    ->  Append
-         ->  Index Only Scan using bool_lp_false_b_idx on bool_lp_false bool_lp
-         ->  Index Only Scan using bool_lp_true_b_idx on bool_lp_true bool_lp_1
+         ->  Index Only Scan using bool_lp_false_b_idx on bool_lp_false bool_lp_1
+         ->  Index Only Scan using bool_lp_true_b_idx on bool_lp_true bool_lp_2
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using bool_lp_false_b_idx on bool_lp_false bool_lp_1
-   ->  Index Only Scan using bool_lp_true_b_idx on bool_lp_true bool_lp_2
-(3 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table bool_lp;
 -- Ensure const bool quals can be properly detected as redundant
@@ -2943,15 +2473,14 @@ create table bool_rp_false_2k partition of bool_rp for values from (false,1000) 
 create table bool_rp_true_2k partition of bool_rp for values from (true,1000) to (true,2000);
 create index on bool_rp (b,a);
 explain (costs off) select * from bool_rp where b = true order by b,a;
-<<<<<<< HEAD
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    Merge Key: bool_rp.b, bool_rp.a
    ->  Append
-         ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp
+         ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp_1
                Index Cond: (b = true)
-         ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_1
+         ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_2
                Index Cond: (b = true)
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -2962,38 +2491,17 @@ explain (costs off) select * from bool_rp where b = false order by b,a;
  Gather Motion 1:1  (slice1; segments: 1)
    Merge Key: bool_rp.b, bool_rp.a
    ->  Append
-         ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp
+         ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp_1
                Index Cond: (b = false)
-         ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_1
+         ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_2
                Index Cond: (b = false)
  Optimizer: Postgres query optimizer
 (8 rows)
-=======
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp_1
-         Index Cond: (b = true)
-   ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_2
-         Index Cond: (b = true)
-(5 rows)
-
-explain (costs off) select * from bool_rp where b = false order by b,a;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp_1
-         Index Cond: (b = false)
-   ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_2
-         Index Cond: (b = false)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- GPDB: force the planner to choose same plan as in upstream
 set enable_seqscan=off;
 set enable_bitmapscan=off;
 explain (costs off) select * from bool_rp where b = true order by a;
-<<<<<<< HEAD
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
@@ -3001,9 +2509,9 @@ explain (costs off) select * from bool_rp where b = true order by a;
    ->  Sort
          Sort Key: bool_rp.a
          ->  Append
-               ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp
+               ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp_1
                      Index Cond: (b = true)
-               ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_1
+               ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_2
                      Index Cond: (b = true)
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -3016,32 +2524,12 @@ explain (costs off) select * from bool_rp where b = false order by a;
    ->  Sort
          Sort Key: bool_rp.a
          ->  Append
-               ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp
+               ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp_1
                      Index Cond: (b = false)
-               ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_1
+               ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_2
                      Index Cond: (b = false)
  Optimizer: Postgres query optimizer
 (10 rows)
-=======
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp_1
-         Index Cond: (b = true)
-   ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_2
-         Index Cond: (b = true)
-(5 rows)
-
-explain (costs off) select * from bool_rp where b = false order by a;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp_1
-         Index Cond: (b = false)
-   ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_2
-         Index Cond: (b = false)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 reset enable_seqscan;
 reset enable_bitmapscan;
@@ -3053,14 +2541,13 @@ create table range_parted1 partition of range_parted for values from (0,0) to (1
 create table range_parted2 partition of range_parted for values from (10,10) to (20,20);
 create index on range_parted (a,b,c);
 explain (costs off) select * from range_parted order by a,b,c;
-<<<<<<< HEAD
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: range_parted.a, range_parted.b, range_parted.c
    ->  Append
-         ->  Index Only Scan using range_parted1_a_b_c_idx on range_parted1 range_parted
-         ->  Index Only Scan using range_parted2_a_b_c_idx on range_parted2 range_parted_1
+         ->  Index Only Scan using range_parted1_a_b_c_idx on range_parted1 range_parted_1
+         ->  Index Only Scan using range_parted2_a_b_c_idx on range_parted2 range_parted_2
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -3068,28 +2555,12 @@ explain (costs off) select * from range_parted order by a desc,b desc,c desc;
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: range_parted_1.a, range_parted_1.b, range_parted_1.c
+   Merge Key: range_parted.a, range_parted.b, range_parted.c
    ->  Append
-         ->  Index Only Scan Backward using range_parted2_a_b_c_idx on range_parted2 range_parted_1
-         ->  Index Only Scan Backward using range_parted1_a_b_c_idx on range_parted1 range_parted
+         ->  Index Only Scan Backward using range_parted2_a_b_c_idx on range_parted2 range_parted_2
+         ->  Index Only Scan Backward using range_parted1_a_b_c_idx on range_parted1 range_parted_1
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Append
-   ->  Index Only Scan using range_parted1_a_b_c_idx on range_parted1 range_parted_1
-   ->  Index Only Scan using range_parted2_a_b_c_idx on range_parted2 range_parted_2
-(3 rows)
-
-explain (costs off) select * from range_parted order by a desc,b desc,c desc;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Append
-   ->  Index Only Scan Backward using range_parted2_a_b_c_idx on range_parted2 range_parted_2
-   ->  Index Only Scan Backward using range_parted1_a_b_c_idx on range_parted1 range_parted_1
-(3 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table range_parted;
 -- Check that we allow access to a child table's statistics when the user

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1390,9 +1390,9 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
    ->  Hash Join
          Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
-               ->  Index Scan using patest0i on patest0
-               ->  Index Scan using patest1i on patest1 patest0_1
-               ->  Index Scan using patest2i on patest2 patest0_2
+               ->  Index Scan using patest0i on patest0 patest0_1
+               ->  Index Scan using patest1i on patest1 patest0_2
+               ->  Index Scan using patest2i on patest2 patest0_3
          ->  Hash
                ->  Redistribute Motion 1:3  (slice2; segments: 1)
                      Hash Key: int4_tbl.f1
@@ -1421,9 +1421,9 @@ select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 l
    ->  Hash Join
          Hash Cond: (patest0.id = int4_tbl.f1)
          ->  Append
-               ->  Index Scan using patest0i on patest0
-               ->  Index Scan using patest1i on patest1 patest0_1
-               ->  Seq Scan on patest2 patest0_2
+               ->  Index Scan using patest0i on patest0 patest0_1
+               ->  Index Scan using patest1i on patest1 patest0_2
+               ->  Seq Scan on patest2 patest0_3
          ->  Hash
                ->  Redistribute Motion 1:3  (slice2; segments: 1)
                      Hash Key: int4_tbl.f1
@@ -1482,14 +1482,14 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
          ->  Result
                Output: matest0.id, matest0.name, (1 - matest0.id)
                ->  Append
-                     ->  Seq Scan on public.matest0
-                           Output: matest0.id, matest0.name
-                     ->  Seq Scan on public.matest1 matest0_1
+                     ->  Seq Scan on public.matest0 matest0_1
                            Output: matest0_1.id, matest0_1.name
-                     ->  Seq Scan on public.matest2 matest0_2
+                     ->  Seq Scan on public.matest1 matest0_2
                            Output: matest0_2.id, matest0_2.name
-                     ->  Seq Scan on public.matest3 matest0_3
+                     ->  Seq Scan on public.matest2 matest0_3
                            Output: matest0_3.id, matest0_3.name
+                     ->  Seq Scan on public.matest3 matest0_4
+                           Output: matest0_4.id, matest0_4.name
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan = 'off'
 (19 rows)
@@ -1515,14 +1515,14 @@ explain (verbose, costs off) select min(1-id) from matest0;
          ->  Partial Aggregate
                Output: PARTIAL min((1 - matest0.id))
                ->  Append
-                     ->  Seq Scan on public.matest0
-                           Output: matest0.id
-                     ->  Seq Scan on public.matest1 matest0_1
+                     ->  Seq Scan on public.matest0 matest0_1
                            Output: matest0_1.id
-                     ->  Seq Scan on public.matest2 matest0_2
+                     ->  Seq Scan on public.matest1 matest0_2
                            Output: matest0_2.id
-                     ->  Seq Scan on public.matest3 matest0_3
+                     ->  Seq Scan on public.matest2 matest0_3
                            Output: matest0_3.id
+                     ->  Seq Scan on public.matest3 matest0_4
+                           Output: matest0_4.id
  Optimizer: Postgres query optimizer
  Settings: enable_indexscan = 'off'
 (17 rows)
@@ -1548,17 +1548,17 @@ explain (verbose, costs off) select * from matest0 order by 1-id;
    Merge Key: ((1 - matest0.id))
    ->  Merge Append
          Sort Key: ((1 - matest0.id))
-         ->  Index Scan using matest0i on public.matest0
-               Output: matest0.id, matest0.name, (1 - matest0.id)
-         ->  Index Scan using matest1i on public.matest1 matest0_1
+         ->  Index Scan using matest0i on public.matest0 matest0_1
                Output: matest0_1.id, matest0_1.name, (1 - matest0_1.id)
+         ->  Index Scan using matest1i on public.matest1 matest0_2
+               Output: matest0_2.id, matest0_2.name, (1 - matest0_2.id)
          ->  Sort
-               Output: matest0_2.id, matest0_2.name, ((1 - matest0_2.id))
-               Sort Key: ((1 - matest0_2.id))
-               ->  Seq Scan on public.matest2 matest0_2
-                     Output: matest0_2.id, matest0_2.name, (1 - matest0_2.id)
-         ->  Index Scan using matest3i on public.matest3 matest0_3
-               Output: matest0_3.id, matest0_3.name, (1 - matest0_3.id)
+               Output: matest0_3.id, matest0_3.name, ((1 - matest0_3.id))
+               Sort Key: ((1 - matest0_3.id))
+               ->  Seq Scan on public.matest2 matest0_3
+                     Output: matest0_3.id, matest0_3.name, (1 - matest0_3.id)
+         ->  Index Scan using matest3i on public.matest3 matest0_4
+               Output: matest0_4.id, matest0_4.name, (1 - matest0_4.id)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan = 'off', enable_parallel_append = 'off', enable_seqscan = 'off'
 (18 rows)
@@ -1589,21 +1589,21 @@ explain (verbose, costs off) select min(1-id) from matest0;
                        Output: ((1 - matest0.id))
                        ->  Merge Append
                              Sort Key: ((1 - matest0.id))
-                             ->  Index Scan using matest0i on public.matest0
-                                   Output: matest0.id, (1 - matest0.id)
-                                   Index Cond: ((1 - matest0.id) IS NOT NULL)
-                             ->  Index Scan using matest1i on public.matest1 matest0_1
+                             ->  Index Scan using matest0i on public.matest0 matest0_1
                                    Output: matest0_1.id, (1 - matest0_1.id)
                                    Index Cond: ((1 - matest0_1.id) IS NOT NULL)
+                             ->  Index Scan using matest1i on public.matest1 matest0_2
+                                   Output: matest0_2.id, (1 - matest0_2.id)
+                                   Index Cond: ((1 - matest0_2.id) IS NOT NULL)
                              ->  Sort
-                                   Output: matest0_2.id, ((1 - matest0_2.id))
-                                   Sort Key: ((1 - matest0_2.id))
-                                   ->  Index Only Scan using matest2_pkey on public.matest2 matest0_2
-                                         Output: matest0_2.id, (1 - matest0_2.id)
-                                         Filter: ((1 - matest0_2.id) IS NOT NULL)
-                             ->  Index Scan using matest3i on public.matest3 matest0_3
-                                   Output: matest0_3.id, (1 - matest0_3.id)
-                                   Index Cond: ((1 - matest0_3.id) IS NOT NULL)
+                                   Output: matest0_3.id, ((1 - matest0_3.id))
+                                   Sort Key: ((1 - matest0_3.id))
+                                   ->  Index Only Scan using matest2_pkey on public.matest2 matest0_3
+                                         Output: matest0_3.id, (1 - matest0_3.id)
+                                         Filter: ((1 - matest0_3.id) IS NOT NULL)
+                             ->  Index Scan using matest3i on public.matest3 matest0_4
+                                   Output: matest0_4.id, (1 - matest0_4.id)
+                                   Index Cond: ((1 - matest0_4.id) IS NOT NULL)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan = 'off', enable_parallel_append = 'off', enable_seqscan = 'off'
 (29 rows)
@@ -1645,16 +1645,16 @@ order by t1.b limit 10;
                Merge Key: t1.b
                ->  Merge Append
                      Sort Key: t1.b
-                     ->  Index Scan using matest0i on matest0 t1
-                     ->  Index Scan using matest1i on matest1 t1_1
+                     ->  Index Scan using matest0i on matest0 t1_1
+                     ->  Index Scan using matest1i on matest1 t1_2
          ->  Materialize
                ->  Gather Motion 3:1  (slice2; segments: 3)
                      Merge Key: t2.b
                      ->  Merge Append
                            Sort Key: t2.b
-                           ->  Index Scan using matest0i on matest0 t2
+                           ->  Index Scan using matest0i on matest0 t2_1
                                  Filter: (c = d)
-                           ->  Index Scan using matest1i on matest1 t2_1
+                           ->  Index Scan using matest1i on matest1 t2_2
                                  Filter: (c = d)
  Optimizer: Postgres query optimizer
 (19 rows)
@@ -1971,15 +1971,15 @@ explain (costs off) select * from range_list_parted;
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
-         ->  Seq Scan on part_1_10_cd range_list_parted_1
-         ->  Seq Scan on part_10_20_ab range_list_parted_2
-         ->  Seq Scan on part_10_20_cd range_list_parted_3
-         ->  Seq Scan on part_21_30_ab range_list_parted_4
-         ->  Seq Scan on part_21_30_cd range_list_parted_5
-         ->  Seq Scan on part_40_inf_ab range_list_parted_6
-         ->  Seq Scan on part_40_inf_cd range_list_parted_7
-         ->  Seq Scan on part_40_inf_null range_list_parted_8
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
+         ->  Seq Scan on part_1_10_cd range_list_parted_2
+         ->  Seq Scan on part_10_20_ab range_list_parted_3
+         ->  Seq Scan on part_10_20_cd range_list_parted_4
+         ->  Seq Scan on part_21_30_ab range_list_parted_5
+         ->  Seq Scan on part_21_30_cd range_list_parted_6
+         ->  Seq Scan on part_40_inf_ab range_list_parted_7
+         ->  Seq Scan on part_40_inf_cd range_list_parted_8
+         ->  Seq Scan on part_40_inf_null range_list_parted_9
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -1988,9 +1988,9 @@ explain (costs off) select * from range_list_parted where a = 5;
 ----------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: (a = 5)
-         ->  Seq Scan on part_1_10_cd range_list_parted_1
+         ->  Seq Scan on part_1_10_cd range_list_parted_2
                Filter: (a = 5)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -2000,13 +2000,13 @@ explain (costs off) select * from range_list_parted where b = 'ab';
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: (b = 'ab'::bpchar)
-         ->  Seq Scan on part_10_20_ab range_list_parted_1
+         ->  Seq Scan on part_10_20_ab range_list_parted_2
                Filter: (b = 'ab'::bpchar)
-         ->  Seq Scan on part_21_30_ab range_list_parted_2
+         ->  Seq Scan on part_21_30_ab range_list_parted_3
                Filter: (b = 'ab'::bpchar)
-         ->  Seq Scan on part_40_inf_ab range_list_parted_3
+         ->  Seq Scan on part_40_inf_ab range_list_parted_4
                Filter: (b = 'ab'::bpchar)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -2016,11 +2016,11 @@ explain (costs off) select * from range_list_parted where a between 3 and 23 and
 -----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-         ->  Seq Scan on part_10_20_ab range_list_parted_1
+         ->  Seq Scan on part_10_20_ab range_list_parted_2
                Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
-         ->  Seq Scan on part_21_30_ab range_list_parted_2
+         ->  Seq Scan on part_21_30_ab range_list_parted_3
                Filter: ((a >= 3) AND (a <= 23) AND (b = 'ab'::bpchar))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2049,23 +2049,23 @@ explain (costs off) select * from range_list_parted where a is not null and a < 
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_1_10_ab range_list_parted
+         ->  Seq Scan on part_1_10_ab range_list_parted_1
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_1_10_cd range_list_parted_1
+         ->  Seq Scan on part_1_10_cd range_list_parted_2
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_10_20_ab range_list_parted_2
+         ->  Seq Scan on part_10_20_ab range_list_parted_3
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_10_20_cd range_list_parted_3
+         ->  Seq Scan on part_10_20_cd range_list_parted_4
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_21_30_ab range_list_parted_4
+         ->  Seq Scan on part_21_30_ab range_list_parted_5
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_21_30_cd range_list_parted_5
+         ->  Seq Scan on part_21_30_cd range_list_parted_6
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_40_inf_ab range_list_parted_6
+         ->  Seq Scan on part_40_inf_ab range_list_parted_7
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_40_inf_cd range_list_parted_7
+         ->  Seq Scan on part_40_inf_cd range_list_parted_8
                Filter: ((a IS NOT NULL) AND (a < 67))
-         ->  Seq Scan on part_40_inf_null range_list_parted_8
+         ->  Seq Scan on part_40_inf_null range_list_parted_9
                Filter: ((a IS NOT NULL) AND (a < 67))
  Optimizer: Postgres query optimizer
 (21 rows)
@@ -2075,11 +2075,11 @@ explain (costs off) select * from range_list_parted where a >= 30;
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_40_inf_ab range_list_parted
+         ->  Seq Scan on part_40_inf_ab range_list_parted_1
                Filter: (a >= 30)
-         ->  Seq Scan on part_40_inf_cd range_list_parted_1
+         ->  Seq Scan on part_40_inf_cd range_list_parted_2
                Filter: (a >= 30)
-         ->  Seq Scan on part_40_inf_null range_list_parted_2
+         ->  Seq Scan on part_40_inf_null range_list_parted_3
                Filter: (a >= 30)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2101,9 +2101,9 @@ explain (costs off) select * from mcrparted where a = 0;	-- scans mcrparted0, mc
 ---------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mcrparted0 mcrparted
+         ->  Seq Scan on mcrparted0 mcrparted_1
                Filter: (a = 0)
-         ->  Seq Scan on mcrparted_def mcrparted_1
+         ->  Seq Scan on mcrparted_def mcrparted_2
                Filter: (a = 0)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -2113,9 +2113,9 @@ explain (costs off) select * from mcrparted where a = 10 and abs(b) < 5;	-- scan
 ---------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mcrparted1 mcrparted
+         ->  Seq Scan on mcrparted1 mcrparted_1
                Filter: ((a = 10) AND (abs(b) < 5))
-         ->  Seq Scan on mcrparted_def mcrparted_1
+         ->  Seq Scan on mcrparted_def mcrparted_2
                Filter: ((a = 10) AND (abs(b) < 5))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -2125,11 +2125,11 @@ explain (costs off) select * from mcrparted where a = 10 and abs(b) = 5;	-- scan
 ---------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mcrparted1 mcrparted
+         ->  Seq Scan on mcrparted1 mcrparted_1
                Filter: ((a = 10) AND (abs(b) = 5))
-         ->  Seq Scan on mcrparted2 mcrparted_1
+         ->  Seq Scan on mcrparted2 mcrparted_2
                Filter: ((a = 10) AND (abs(b) = 5))
-         ->  Seq Scan on mcrparted_def mcrparted_2
+         ->  Seq Scan on mcrparted_def mcrparted_3
                Filter: ((a = 10) AND (abs(b) = 5))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2139,19 +2139,19 @@ explain (costs off) select * from mcrparted where abs(b) = 5;	-- scans all parti
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mcrparted0 mcrparted
+         ->  Seq Scan on mcrparted0 mcrparted_1
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted1 mcrparted_1
+         ->  Seq Scan on mcrparted1 mcrparted_2
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted2 mcrparted_2
+         ->  Seq Scan on mcrparted2 mcrparted_3
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted3 mcrparted_3
+         ->  Seq Scan on mcrparted3 mcrparted_4
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted4 mcrparted_4
+         ->  Seq Scan on mcrparted4 mcrparted_5
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted5 mcrparted_5
+         ->  Seq Scan on mcrparted5 mcrparted_6
                Filter: (abs(b) = 5)
-         ->  Seq Scan on mcrparted_def mcrparted_6
+         ->  Seq Scan on mcrparted_def mcrparted_7
                Filter: (abs(b) = 5)
  Optimizer: Postgres query optimizer
 (17 rows)
@@ -2161,19 +2161,19 @@ explain (costs off) select * from mcrparted where a > -1;	-- scans all partition
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mcrparted0 mcrparted
+         ->  Seq Scan on mcrparted0 mcrparted_1
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted1 mcrparted_1
+         ->  Seq Scan on mcrparted1 mcrparted_2
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted2 mcrparted_2
+         ->  Seq Scan on mcrparted2 mcrparted_3
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted3 mcrparted_3
+         ->  Seq Scan on mcrparted3 mcrparted_4
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted4 mcrparted_4
+         ->  Seq Scan on mcrparted4 mcrparted_5
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted5 mcrparted_5
+         ->  Seq Scan on mcrparted5 mcrparted_6
                Filter: (a > '-1'::integer)
-         ->  Seq Scan on mcrparted_def mcrparted_6
+         ->  Seq Scan on mcrparted_def mcrparted_7
                Filter: (a > '-1'::integer)
  Optimizer: Postgres query optimizer
 (17 rows)
@@ -2192,13 +2192,13 @@ explain (costs off) select * from mcrparted where a = 20 and c > 20; -- scans mc
 ---------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mcrparted3 mcrparted
+         ->  Seq Scan on mcrparted3 mcrparted_1
                Filter: ((c > 20) AND (a = 20))
-         ->  Seq Scan on mcrparted4 mcrparted_1
+         ->  Seq Scan on mcrparted4 mcrparted_2
                Filter: ((c > 20) AND (a = 20))
-         ->  Seq Scan on mcrparted5 mcrparted_2
+         ->  Seq Scan on mcrparted5 mcrparted_3
                Filter: ((c > 20) AND (a = 20))
-         ->  Seq Scan on mcrparted_def mcrparted_3
+         ->  Seq Scan on mcrparted_def mcrparted_4
                Filter: ((c > 20) AND (a = 20))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -2239,13 +2239,13 @@ explain (costs off) select * from mcrparted order by a, abs(b), c;
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Merge Append
          Sort Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_5
-         ->  Index Scan using mcrparted_def_a_abs_c_idx on mcrparted_def mcrparted_6
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
+         ->  Index Scan using mcrparted_def_a_abs_c_idx on mcrparted_def mcrparted_7
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -2258,12 +2258,12 @@ explain (costs off) select * from mcrparted order by a, abs(b), c;
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_5
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -2272,14 +2272,14 @@ explain (costs off) select * from mcrparted order by a desc, abs(b) desc, c desc
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: mcrparted_5.a, (abs(mcrparted_5.b)), mcrparted_5.c
+   Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan Backward using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_5
-         ->  Index Scan Backward using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan Backward using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan Backward using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan Backward using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan Backward using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
+         ->  Index Scan Backward using mcrparted5_a_abs_c_idx on mcrparted5 mcrparted_6
+         ->  Index Scan Backward using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan Backward using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan Backward using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan Backward using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan Backward using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -2295,15 +2295,15 @@ explain (costs off) select * from mcrparted order by a, abs(b), c;
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
          ->  Merge Append
-               Sort Key: mcrparted_5.a, (abs(mcrparted_5.b)), mcrparted_5.c
-               ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_5
-               ->  Index Scan using mcrparted5_def_a_abs_c_idx on mcrparted5_def mcrparted_6
+               Sort Key: mcrparted_7.a, (abs(mcrparted_7.b)), mcrparted_7.c
+               ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_7
+               ->  Index Scan using mcrparted5_def_a_abs_c_idx on mcrparted5_def mcrparted_8
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -2317,12 +2317,12 @@ explain (costs off) select a, abs(b) from mcrparted order by a, abs(b), c;
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
-         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_4
-         ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_5
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
+         ->  Index Scan using mcrparted4_a_abs_c_idx on mcrparted4 mcrparted_5
+         ->  Index Scan using mcrparted5a_a_abs_c_idx on mcrparted5a mcrparted_6
  Optimizer: Postgres query optimizer
 (10 rows)
 
@@ -2334,13 +2334,13 @@ explain (costs off) select * from mcrparted where a < 20 order by a, abs(b), c;
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted
+         ->  Index Scan using mcrparted0_a_abs_c_idx on mcrparted0 mcrparted_1
                Index Cond: (a < 20)
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
                Index Cond: (a < 20)
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
                Index Cond: (a < 20)
-         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
+         ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
                Index Cond: (a < 20)
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2395,14 +2395,14 @@ explain (costs off) select * from mcrparted where a < 20 order by a, abs(b), c l
          ->  Limit
                ->  Append
                      ->  Sort
-                           Sort Key: mcrparted.a, (abs(mcrparted.b)), mcrparted.c
-                           ->  Seq Scan on mcrparted0 mcrparted
+                           Sort Key: mcrparted_1.a, (abs(mcrparted_1.b)), mcrparted_1.c
+                           ->  Seq Scan on mcrparted0 mcrparted_1
                                  Filter: (a < 20)
-                     ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
+                     ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_2
                            Index Cond: (a < 20)
-                     ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
+                     ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_3
                            Index Cond: (a < 20)
-                     ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_3
+                     ->  Index Scan using mcrparted3_a_abs_c_idx on mcrparted3 mcrparted_4
                            Index Cond: (a < 20)
  Optimizer: Postgres query optimizer
 (16 rows)
@@ -2416,9 +2416,9 @@ explain (costs off) select * from mcrparted where a = 10 order by a, abs(b), c;
  Gather Motion 1:1  (slice1; segments: 1)
    Merge Key: (abs(mcrparted.b)), mcrparted.c
    ->  Append
-         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted
+         ->  Index Scan using mcrparted1_a_abs_c_idx on mcrparted1 mcrparted_1
                Index Cond: (a = 10)
-         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_1
+         ->  Index Scan using mcrparted2_a_abs_c_idx on mcrparted2 mcrparted_2
                Index Cond: (a = 10)
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -2456,9 +2456,9 @@ explain (costs off) select * from bool_rp where b = true order by b,a;
  Gather Motion 1:1  (slice1; segments: 1)
    Merge Key: bool_rp.b, bool_rp.a
    ->  Append
-         ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp
+         ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp_1
                Index Cond: (b = true)
-         ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_1
+         ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_2
                Index Cond: (b = true)
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -2469,9 +2469,9 @@ explain (costs off) select * from bool_rp where b = false order by b,a;
  Gather Motion 1:1  (slice1; segments: 1)
    Merge Key: bool_rp.b, bool_rp.a
    ->  Append
-         ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp
+         ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp_1
                Index Cond: (b = false)
-         ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_1
+         ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_2
                Index Cond: (b = false)
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -2487,9 +2487,9 @@ explain (costs off) select * from bool_rp where b = true order by a;
    ->  Sort
          Sort Key: bool_rp.a
          ->  Append
-               ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp
+               ->  Index Only Scan using bool_rp_true_1k_b_a_idx on bool_rp_true_1k bool_rp_1
                      Index Cond: (b = true)
-               ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_1
+               ->  Index Only Scan using bool_rp_true_2k_b_a_idx on bool_rp_true_2k bool_rp_2
                      Index Cond: (b = true)
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -2502,9 +2502,9 @@ explain (costs off) select * from bool_rp where b = false order by a;
    ->  Sort
          Sort Key: bool_rp.a
          ->  Append
-               ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp
+               ->  Index Only Scan using bool_rp_false_1k_b_a_idx on bool_rp_false_1k bool_rp_1
                      Index Cond: (b = false)
-               ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_1
+               ->  Index Only Scan using bool_rp_false_2k_b_a_idx on bool_rp_false_2k bool_rp_2
                      Index Cond: (b = false)
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -2524,8 +2524,8 @@ explain (costs off) select * from range_parted order by a,b,c;
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: range_parted.a, range_parted.b, range_parted.c
    ->  Append
-         ->  Index Only Scan using range_parted1_a_b_c_idx on range_parted1 range_parted
-         ->  Index Only Scan using range_parted2_a_b_c_idx on range_parted2 range_parted_1
+         ->  Index Only Scan using range_parted1_a_b_c_idx on range_parted1 range_parted_1
+         ->  Index Only Scan using range_parted2_a_b_c_idx on range_parted2 range_parted_2
  Optimizer: Postgres query optimizer
 (6 rows)
 
@@ -2533,10 +2533,10 @@ explain (costs off) select * from range_parted order by a desc,b desc,c desc;
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: range_parted_1.a, range_parted_1.b, range_parted_1.c
+   Merge Key: range_parted.a, range_parted.b, range_parted.c
    ->  Append
-         ->  Index Only Scan Backward using range_parted2_a_b_c_idx on range_parted2 range_parted_1
-         ->  Index Only Scan Backward using range_parted1_a_b_c_idx on range_parted1 range_parted
+         ->  Index Only Scan Backward using range_parted2_a_b_c_idx on range_parted2 range_parted_2
+         ->  Index Only Scan Backward using range_parted1_a_b_c_idx on range_parted1 range_parted_1
  Optimizer: Postgres query optimizer
 (6 rows)
 

--- a/src/test/regress/expected/partition_aggregate.out
+++ b/src/test/regress/expected/partition_aggregate.out
@@ -395,7 +395,6 @@ RESET enable_hashagg;
 -- ROLLUP, partitionwise aggregation does not apply
 EXPLAIN (COSTS OFF)
 SELECT c, sum(a) FROM pagg_tab GROUP BY rollup(c) ORDER BY 1, 2;
-<<<<<<< HEAD
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -410,25 +409,11 @@ SELECT c, sum(a) FROM pagg_tab GROUP BY rollup(c) ORDER BY 1, 2;
                            Hash Key: pagg_tab.c
                            Group Key: ()
                            ->  Append
-                                 ->  Seq Scan on pagg_tab_p1 pagg_tab
-                                 ->  Seq Scan on pagg_tab_p2 pagg_tab_1
-                                 ->  Seq Scan on pagg_tab_p3 pagg_tab_2
+                                 ->  Seq Scan on pagg_tab_p1 pagg_tab_1
+                                 ->  Seq Scan on pagg_tab_p2 pagg_tab_2
+                                 ->  Seq Scan on pagg_tab_p3 pagg_tab_3
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-                      QUERY PLAN                      
-------------------------------------------------------
- Sort
-   Sort Key: pagg_tab.c, (sum(pagg_tab.a))
-   ->  MixedAggregate
-         Hash Key: pagg_tab.c
-         Group Key: ()
-         ->  Append
-               ->  Seq Scan on pagg_tab_p1 pagg_tab_1
-               ->  Seq Scan on pagg_tab_p2 pagg_tab_2
-               ->  Seq Scan on pagg_tab_p3 pagg_tab_3
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- ORDERED SET within the aggregate.
 -- Full aggregation; since all the rows that belong to the same group come
@@ -472,7 +457,6 @@ SELECT c, sum(b order by a) FROM pagg_tab GROUP BY c ORDER BY 1, 2;
 -- partitionwise aggregation plan is not generated.
 EXPLAIN (COSTS OFF)
 SELECT a, sum(b order by a) FROM pagg_tab GROUP BY a ORDER BY 1, 2;
-<<<<<<< HEAD
                              QUERY PLAN                              
 ---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -484,26 +468,11 @@ SELECT a, sum(b order by a) FROM pagg_tab GROUP BY a ORDER BY 1, 2;
                ->  Sort
                      Sort Key: pagg_tab.a
                      ->  Append
-                           ->  Seq Scan on pagg_tab_p1 pagg_tab
-                           ->  Seq Scan on pagg_tab_p2 pagg_tab_1
-                           ->  Seq Scan on pagg_tab_p3 pagg_tab_2
+                           ->  Seq Scan on pagg_tab_p1 pagg_tab_1
+                           ->  Seq Scan on pagg_tab_p2 pagg_tab_2
+                           ->  Seq Scan on pagg_tab_p3 pagg_tab_3
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                          QUERY PLAN                           
----------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab.a, (sum(pagg_tab.b ORDER BY pagg_tab.a))
-   ->  GroupAggregate
-         Group Key: pagg_tab.a
-         ->  Sort
-               Sort Key: pagg_tab.a
-               ->  Append
-                     ->  Seq Scan on pagg_tab_p1 pagg_tab_1
-                     ->  Seq Scan on pagg_tab_p2 pagg_tab_2
-                     ->  Seq Scan on pagg_tab_p3 pagg_tab_3
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- JOIN query
 CREATE TABLE pagg_tab1(x int, y int) PARTITION BY RANGE(x);
@@ -571,7 +540,6 @@ SELECT t1.x, sum(t1.y), count(*) FROM pagg_tab1 t1, pagg_tab2 t2 WHERE t1.x = t2
 -- Check with whole-row reference; partitionwise aggregation does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1.x, sum(t1.y), count(t1) FROM pagg_tab1 t1, pagg_tab2 t2 WHERE t1.x = t2.y GROUP BY t1.x ORDER BY 1, 2, 3;
-<<<<<<< HEAD
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -585,36 +553,16 @@ SELECT t1.x, sum(t1.y), count(t1) FROM pagg_tab1 t1, pagg_tab2 t2 WHERE t1.x = t
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: t2.y
                            ->  Append
-                                 ->  Seq Scan on pagg_tab2_p1 t2
-                                 ->  Seq Scan on pagg_tab2_p2 t2_1
-                                 ->  Seq Scan on pagg_tab2_p3 t2_2
+                                 ->  Seq Scan on pagg_tab2_p1 t2_1
+                                 ->  Seq Scan on pagg_tab2_p2 t2_2
+                                 ->  Seq Scan on pagg_tab2_p3 t2_3
                      ->  Hash
                            ->  Append
-                                 ->  Seq Scan on pagg_tab1_p1 t1
-                                 ->  Seq Scan on pagg_tab1_p2 t1_1
-                                 ->  Seq Scan on pagg_tab1_p3 t1_2
+                                 ->  Seq Scan on pagg_tab1_p1 t1_1
+                                 ->  Seq Scan on pagg_tab1_p2 t1_2
+                                 ->  Seq Scan on pagg_tab1_p3 t1_3
  Optimizer: Postgres query optimizer
 (20 rows)
-=======
-                         QUERY PLAN                          
--------------------------------------------------------------
- Sort
-   Sort Key: t1.x, (sum(t1.y)), (count(((t1.*)::pagg_tab1)))
-   ->  HashAggregate
-         Group Key: t1.x
-         ->  Hash Join
-               Hash Cond: (t1.x = t2.y)
-               ->  Append
-                     ->  Seq Scan on pagg_tab1_p1 t1_1
-                     ->  Seq Scan on pagg_tab1_p2 t1_2
-                     ->  Seq Scan on pagg_tab1_p3 t1_3
-               ->  Hash
-                     ->  Append
-                           ->  Seq Scan on pagg_tab2_p1 t2_1
-                           ->  Seq Scan on pagg_tab2_p2 t2_2
-                           ->  Seq Scan on pagg_tab2_p3 t2_3
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.x, sum(t1.y), count(t1) FROM pagg_tab1 t1, pagg_tab2 t2 WHERE t1.x = t2.y GROUP BY t1.x ORDER BY 1, 2, 3;
  x  | sum  | count 
@@ -919,7 +867,6 @@ SELECT a.x, sum(b.x) FROM pagg_tab1 a FULL OUTER JOIN pagg_tab2 b ON a.x = b.y G
 -- But right now we are unable to do partitionwise join in this case.
 EXPLAIN (COSTS OFF)
 SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a LEFT JOIN (SELECT * FROM pagg_tab2 WHERE y > 10) b ON a.x = b.y WHERE a.x > 5 or b.y < 20  GROUP BY a.x, b.y ORDER BY 1, 2;
-<<<<<<< HEAD
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -932,43 +879,20 @@ SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a LEFT JOI
                      Hash Cond: (pagg_tab1.x = pagg_tab2.y)
                      Filter: ((pagg_tab1.x > 5) OR (pagg_tab2.y < 20))
                      ->  Append
-                           ->  Seq Scan on pagg_tab1_p1 pagg_tab1
+                           ->  Seq Scan on pagg_tab1_p1 pagg_tab1_1
                                  Filter: (x < 20)
-                           ->  Seq Scan on pagg_tab1_p2 pagg_tab1_1
+                           ->  Seq Scan on pagg_tab1_p2 pagg_tab1_2
                                  Filter: (x < 20)
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: pagg_tab2.y
                                  ->  Append
-                                       ->  Seq Scan on pagg_tab2_p2 pagg_tab2
+                                       ->  Seq Scan on pagg_tab2_p2 pagg_tab2_1
                                              Filter: (y > 10)
-                                       ->  Seq Scan on pagg_tab2_p3 pagg_tab2_1
+                                       ->  Seq Scan on pagg_tab2_p3 pagg_tab2_2
                                              Filter: (y > 10)
  Optimizer: Postgres query optimizer
 (23 rows)
-=======
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab1.x, pagg_tab2.y
-   ->  HashAggregate
-         Group Key: pagg_tab1.x, pagg_tab2.y
-         ->  Hash Left Join
-               Hash Cond: (pagg_tab1.x = pagg_tab2.y)
-               Filter: ((pagg_tab1.x > 5) OR (pagg_tab2.y < 20))
-               ->  Append
-                     ->  Seq Scan on pagg_tab1_p1 pagg_tab1_1
-                           Filter: (x < 20)
-                     ->  Seq Scan on pagg_tab1_p2 pagg_tab1_2
-                           Filter: (x < 20)
-               ->  Hash
-                     ->  Append
-                           ->  Seq Scan on pagg_tab2_p2 pagg_tab2_1
-                                 Filter: (y > 10)
-                           ->  Seq Scan on pagg_tab2_p3 pagg_tab2_2
-                                 Filter: (y > 10)
-(18 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a LEFT JOIN (SELECT * FROM pagg_tab2 WHERE y > 10) b ON a.x = b.y WHERE a.x > 5 or b.y < 20  GROUP BY a.x, b.y ORDER BY 1, 2;
  x  | y  | count 
@@ -988,7 +912,6 @@ SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a LEFT JOI
 -- But right now we are unable to do partitionwise join in this case.
 EXPLAIN (COSTS OFF)
 SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a FULL JOIN (SELECT * FROM pagg_tab2 WHERE y > 10) b ON a.x = b.y WHERE a.x > 5 or b.y < 20  GROUP BY a.x, b.y ORDER BY 1, 2;
-<<<<<<< HEAD
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1003,43 +926,20 @@ SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a FULL JOI
                            Hash Cond: (pagg_tab1.x = pagg_tab2.y)
                            Filter: ((pagg_tab1.x > 5) OR (pagg_tab2.y < 20))
                            ->  Append
-                                 ->  Seq Scan on pagg_tab1_p1 pagg_tab1
+                                 ->  Seq Scan on pagg_tab1_p1 pagg_tab1_1
                                        Filter: (x < 20)
-                                 ->  Seq Scan on pagg_tab1_p2 pagg_tab1_1
+                                 ->  Seq Scan on pagg_tab1_p2 pagg_tab1_2
                                        Filter: (x < 20)
                            ->  Hash
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: pagg_tab2.y
                                        ->  Append
-                                             ->  Seq Scan on pagg_tab2_p2 pagg_tab2
+                                             ->  Seq Scan on pagg_tab2_p2 pagg_tab2_1
                                                    Filter: (y > 10)
-                                             ->  Seq Scan on pagg_tab2_p3 pagg_tab2_1
+                                             ->  Seq Scan on pagg_tab2_p3 pagg_tab2_2
                                                    Filter: (y > 10)
  Optimizer: Postgres query optimizer
 (25 rows)
-=======
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab1.x, pagg_tab2.y
-   ->  HashAggregate
-         Group Key: pagg_tab1.x, pagg_tab2.y
-         ->  Hash Full Join
-               Hash Cond: (pagg_tab1.x = pagg_tab2.y)
-               Filter: ((pagg_tab1.x > 5) OR (pagg_tab2.y < 20))
-               ->  Append
-                     ->  Seq Scan on pagg_tab1_p1 pagg_tab1_1
-                           Filter: (x < 20)
-                     ->  Seq Scan on pagg_tab1_p2 pagg_tab1_2
-                           Filter: (x < 20)
-               ->  Hash
-                     ->  Append
-                           ->  Seq Scan on pagg_tab2_p2 pagg_tab2_1
-                                 Filter: (y > 10)
-                           ->  Seq Scan on pagg_tab2_p3 pagg_tab2_2
-                                 Filter: (y > 10)
-(18 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT a.x, b.y, count(*) FROM (SELECT * FROM pagg_tab1 WHERE x < 20) a FULL JOIN (SELECT * FROM pagg_tab2 WHERE y > 10) b ON a.x = b.y WHERE a.x > 5 or b.y < 20 GROUP BY a.x, b.y ORDER BY 1, 2;
  x  | y  | count 
@@ -1213,7 +1113,6 @@ EXPLAIN (COSTS OFF)
 SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
-<<<<<<< HEAD
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: pagg_tab_ml.a, (sum(pagg_tab_ml.b)), (array_agg(DISTINCT pagg_tab_ml.c))
    ->  Sort
@@ -1225,13 +1124,6 @@ SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HA
                      ->  Sort
                            Sort Key: pagg_tab_ml.a
                            ->  Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
-=======
- Sort
-   Sort Key: pagg_tab_ml_2.a, (sum(pagg_tab_ml_2.b)), (array_agg(DISTINCT pagg_tab_ml_2.c))
-   ->  Gather
-         Workers Planned: 2
-         ->  Parallel Append
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
                ->  GroupAggregate
                      Group Key: pagg_tab_ml_2.a
                      Filter: (avg(pagg_tab_ml_2.b) < '3'::numeric)
@@ -1246,22 +1138,10 @@ SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HA
                      ->  Sort
                            Sort Key: pagg_tab_ml_5.a
                            ->  Append
-<<<<<<< HEAD
-                                 ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_3
-                                 ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_4
- Optimizer: Postgres query optimizer
-(28 rows)
-=======
                                  ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_5
                                  ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_6
-               ->  GroupAggregate
-                     Group Key: pagg_tab_ml.a
-                     Filter: (avg(pagg_tab_ml.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml.a
-                           ->  Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
-(27 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+ Optimizer: Postgres query optimizer
+(28 rows)
 
 SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
  a  | sum  |  array_agg  | count 
@@ -1304,20 +1184,9 @@ SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HA
                ->  Sort
                      Sort Key: pagg_tab_ml_5.a
                      ->  Append
-<<<<<<< HEAD
-                           ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_3
-                           ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_4
- Optimizer: Postgres query optimizer
-=======
                            ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_5
                            ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_6
-         ->  GroupAggregate
-               Group Key: pagg_tab_ml.a
-               Filter: (avg(pagg_tab_ml.b) < '3'::numeric)
-               ->  Sort
-                     Sort Key: pagg_tab_ml.a
-                     ->  Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+ Optimizer: Postgres query optimizer
 (25 rows)
 
 -- Full aggregation at level 1 as GROUP BY clause matches with PARTITION KEY
@@ -1325,7 +1194,6 @@ SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HA
 -- PARTITION KEY, thus we will have a partial aggregation for them.
 EXPLAIN (COSTS OFF)
 SELECT a, sum(b), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
-<<<<<<< HEAD
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1338,67 +1206,31 @@ SELECT a, sum(b), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER B
                      Filter: (avg(pagg_tab_ml.b) < '3'::numeric)
                      ->  Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
                ->  Finalize GroupAggregate
-                     Group Key: pagg_tab_ml_1.a
-                     Filter: (avg(pagg_tab_ml_1.b) < '3'::numeric)
+                     Group Key: pagg_tab_ml_2.a
+                     Filter: (avg(pagg_tab_ml_2.b) < '3'::numeric)
                      ->  Sort
-                           Sort Key: pagg_tab_ml_1.a
+                           Sort Key: pagg_tab_ml_2.a
                            ->  Append
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_ml_1.a
-                                       ->  Seq Scan on pagg_tab_ml_p2_s1 pagg_tab_ml_1
                                  ->  Partial HashAggregate
                                        Group Key: pagg_tab_ml_2.a
-                                       ->  Seq Scan on pagg_tab_ml_p2_s2 pagg_tab_ml_2
-               ->  Finalize GroupAggregate
-                     Group Key: pagg_tab_ml_3.a
-                     Filter: (avg(pagg_tab_ml_3.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml_3.a
-                           ->  Append
+                                       ->  Seq Scan on pagg_tab_ml_p2_s1 pagg_tab_ml_2
                                  ->  Partial HashAggregate
                                        Group Key: pagg_tab_ml_3.a
-                                       ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_3
+                                       ->  Seq Scan on pagg_tab_ml_p2_s2 pagg_tab_ml_3
+               ->  Finalize GroupAggregate
+                     Group Key: pagg_tab_ml_5.a
+                     Filter: (avg(pagg_tab_ml_5.b) < '3'::numeric)
+                     ->  Sort
+                           Sort Key: pagg_tab_ml_5.a
+                           ->  Append
                                  ->  Partial HashAggregate
-                                       Group Key: pagg_tab_ml_4.a
-                                       ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_4
+                                       Group Key: pagg_tab_ml_5.a
+                                       ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_5
+                                 ->  Partial HashAggregate
+                                       Group Key: pagg_tab_ml_6.a
+                                       ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_6
  Optimizer: Postgres query optimizer
 (34 rows)
-=======
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab_ml.a, (sum(pagg_tab_ml.b)), (count(*))
-   ->  Append
-         ->  HashAggregate
-               Group Key: pagg_tab_ml.a
-               Filter: (avg(pagg_tab_ml.b) < '3'::numeric)
-               ->  Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
-         ->  Finalize GroupAggregate
-               Group Key: pagg_tab_ml_2.a
-               Filter: (avg(pagg_tab_ml_2.b) < '3'::numeric)
-               ->  Sort
-                     Sort Key: pagg_tab_ml_2.a
-                     ->  Append
-                           ->  Partial HashAggregate
-                                 Group Key: pagg_tab_ml_2.a
-                                 ->  Seq Scan on pagg_tab_ml_p2_s1 pagg_tab_ml_2
-                           ->  Partial HashAggregate
-                                 Group Key: pagg_tab_ml_3.a
-                                 ->  Seq Scan on pagg_tab_ml_p2_s2 pagg_tab_ml_3
-         ->  Finalize GroupAggregate
-               Group Key: pagg_tab_ml_5.a
-               Filter: (avg(pagg_tab_ml_5.b) < '3'::numeric)
-               ->  Sort
-                     Sort Key: pagg_tab_ml_5.a
-                     ->  Append
-                           ->  Partial HashAggregate
-                                 Group Key: pagg_tab_ml_5.a
-                                 ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_5
-                           ->  Partial HashAggregate
-                                 Group Key: pagg_tab_ml_6.a
-                                 ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_6
-(31 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT a, sum(b), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
  a  | sum  | count 
@@ -1517,7 +1349,6 @@ SET parallel_setup_cost TO 0;
 -- PARTITION KEY, thus we will have a partial aggregation for them.
 EXPLAIN (COSTS OFF)
 SELECT a, sum(b), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
-<<<<<<< HEAD
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1530,77 +1361,31 @@ SELECT a, sum(b), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER B
                      Filter: (avg(pagg_tab_ml.b) < '3'::numeric)
                      ->  Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
                ->  Finalize GroupAggregate
-                     Group Key: pagg_tab_ml_1.a
-                     Filter: (avg(pagg_tab_ml_1.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml_1.a
-                           ->  Append
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_ml_1.a
-                                       ->  Seq Scan on pagg_tab_ml_p2_s1 pagg_tab_ml_1
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_ml_2.a
-                                       ->  Seq Scan on pagg_tab_ml_p2_s2 pagg_tab_ml_2
-               ->  Finalize GroupAggregate
-                     Group Key: pagg_tab_ml_3.a
-                     Filter: (avg(pagg_tab_ml_3.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml_3.a
-                           ->  Append
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_ml_3.a
-                                       ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_3
-                                 ->  Partial HashAggregate
-                                       Group Key: pagg_tab_ml_4.a
-                                       ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_4
- Optimizer: Postgres query optimizer
-(34 rows)
-=======
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab_ml.a, (sum(pagg_tab_ml.b)), (count(*))
-   ->  Append
-         ->  Finalize GroupAggregate
-               Group Key: pagg_tab_ml.a
-               Filter: (avg(pagg_tab_ml.b) < '3'::numeric)
-               ->  Gather Merge
-                     Workers Planned: 2
-                     ->  Sort
-                           Sort Key: pagg_tab_ml.a
-                           ->  Partial HashAggregate
-                                 Group Key: pagg_tab_ml.a
-                                 ->  Parallel Seq Scan on pagg_tab_ml_p1 pagg_tab_ml
-         ->  Finalize GroupAggregate
-               Group Key: pagg_tab_ml_2.a
-               Filter: (avg(pagg_tab_ml_2.b) < '3'::numeric)
-               ->  Gather Merge
-                     Workers Planned: 2
+                     Group Key: pagg_tab_ml_2.a
+                     Filter: (avg(pagg_tab_ml_2.b) < '3'::numeric)
                      ->  Sort
                            Sort Key: pagg_tab_ml_2.a
-                           ->  Parallel Append
+                           ->  Append
                                  ->  Partial HashAggregate
                                        Group Key: pagg_tab_ml_2.a
-                                       ->  Parallel Seq Scan on pagg_tab_ml_p2_s1 pagg_tab_ml_2
+                                       ->  Seq Scan on pagg_tab_ml_p2_s1 pagg_tab_ml_2
                                  ->  Partial HashAggregate
                                        Group Key: pagg_tab_ml_3.a
-                                       ->  Parallel Seq Scan on pagg_tab_ml_p2_s2 pagg_tab_ml_3
-         ->  Finalize GroupAggregate
-               Group Key: pagg_tab_ml_5.a
-               Filter: (avg(pagg_tab_ml_5.b) < '3'::numeric)
-               ->  Gather Merge
-                     Workers Planned: 2
+                                       ->  Seq Scan on pagg_tab_ml_p2_s2 pagg_tab_ml_3
+               ->  Finalize GroupAggregate
+                     Group Key: pagg_tab_ml_5.a
+                     Filter: (avg(pagg_tab_ml_5.b) < '3'::numeric)
                      ->  Sort
                            Sort Key: pagg_tab_ml_5.a
-                           ->  Parallel Append
+                           ->  Append
                                  ->  Partial HashAggregate
                                        Group Key: pagg_tab_ml_5.a
-                                       ->  Parallel Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_5
+                                       ->  Seq Scan on pagg_tab_ml_p3_s1 pagg_tab_ml_5
                                  ->  Partial HashAggregate
                                        Group Key: pagg_tab_ml_6.a
-                                       ->  Parallel Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_6
-(41 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                                       ->  Seq Scan on pagg_tab_ml_p3_s2 pagg_tab_ml_6
+ Optimizer: Postgres query optimizer
+(34 rows)
 
 SELECT a, sum(b), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
  a  | sum  | count 
@@ -1806,7 +1591,6 @@ ALTER TABLE pagg_tab_para_p3 SET (parallel_workers = 0);
 ANALYZE pagg_tab_para;
 EXPLAIN (COSTS OFF)
 SELECT x, sum(y), avg(y), count(*) FROM pagg_tab_para GROUP BY x HAVING avg(y) < 7 ORDER BY 1, 2, 3;
-<<<<<<< HEAD
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1828,26 +1612,6 @@ SELECT x, sum(y), avg(y), count(*) FROM pagg_tab_para GROUP BY x HAVING avg(y) <
                      ->  Seq Scan on pagg_tab_para_p3 pagg_tab_para_2
  Optimizer: Postgres query optimizer
 (18 rows)
-=======
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab_para.x, (sum(pagg_tab_para.y)), (avg(pagg_tab_para.y))
-   ->  Finalize GroupAggregate
-         Group Key: pagg_tab_para.x
-         Filter: (avg(pagg_tab_para.y) < '7'::numeric)
-         ->  Gather Merge
-               Workers Planned: 2
-               ->  Sort
-                     Sort Key: pagg_tab_para.x
-                     ->  Partial HashAggregate
-                           Group Key: pagg_tab_para.x
-                           ->  Parallel Append
-                                 ->  Seq Scan on pagg_tab_para_p1 pagg_tab_para_1
-                                 ->  Seq Scan on pagg_tab_para_p3 pagg_tab_para_3
-                                 ->  Parallel Seq Scan on pagg_tab_para_p2 pagg_tab_para_2
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT x, sum(y), avg(y), count(*) FROM pagg_tab_para GROUP BY x HAVING avg(y) < 7 ORDER BY 1, 2, 3;
  x  | sum  |        avg         | count 
@@ -1864,7 +1628,6 @@ ALTER TABLE pagg_tab_para_p2 SET (parallel_workers = 0);
 ANALYZE pagg_tab_para;
 EXPLAIN (COSTS OFF)
 SELECT x, sum(y), avg(y), count(*) FROM pagg_tab_para GROUP BY x HAVING avg(y) < 7 ORDER BY 1, 2, 3;
-<<<<<<< HEAD
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1886,26 +1649,6 @@ SELECT x, sum(y), avg(y), count(*) FROM pagg_tab_para GROUP BY x HAVING avg(y) <
                      ->  Seq Scan on pagg_tab_para_p3 pagg_tab_para_2
  Optimizer: Postgres query optimizer
 (18 rows)
-=======
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Sort
-   Sort Key: pagg_tab_para.x, (sum(pagg_tab_para.y)), (avg(pagg_tab_para.y))
-   ->  Finalize GroupAggregate
-         Group Key: pagg_tab_para.x
-         Filter: (avg(pagg_tab_para.y) < '7'::numeric)
-         ->  Gather Merge
-               Workers Planned: 2
-               ->  Sort
-                     Sort Key: pagg_tab_para.x
-                     ->  Partial HashAggregate
-                           Group Key: pagg_tab_para.x
-                           ->  Parallel Append
-                                 ->  Seq Scan on pagg_tab_para_p1 pagg_tab_para_1
-                                 ->  Seq Scan on pagg_tab_para_p2 pagg_tab_para_2
-                                 ->  Seq Scan on pagg_tab_para_p3 pagg_tab_para_3
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT x, sum(y), avg(y), count(*) FROM pagg_tab_para GROUP BY x HAVING avg(y) < 7 ORDER BY 1, 2, 3;
  x  | sum  |        avg         | count 

--- a/src/test/regress/expected/partition_join.out
+++ b/src/test/regress/expected/partition_join.out
@@ -34,7 +34,6 @@ ANALYZE prt2;
 -- inner join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -43,54 +42,28 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b =
          Sort Key: t1.a
          ->  Append
                ->  Hash Join
-                     Hash Cond: (t2.b = t1.a)
-                     ->  Seq Scan on prt2_p1 t2
+                     Hash Cond: (t2_1.b = t1_1.a)
+                     ->  Seq Scan on prt2_p1 t2_1
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Seq Scan on prt1_p1 t1
-                                       Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: (t2_1.b = t1_1.a)
-                     ->  Seq Scan on prt2_p2 t2_1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on prt1_p2 t1_1
+                                 ->  Seq Scan on prt1_p1 t1_1
                                        Filter: (b = 0)
                ->  Hash Join
                      Hash Cond: (t2_2.b = t1_2.a)
-                     ->  Seq Scan on prt2_p3 t2_2
+                     ->  Seq Scan on prt2_p2 t2_2
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on prt1_p2 t1_2
+                                       Filter: (b = 0)
+               ->  Hash Join
+                     Hash Cond: (t2_3.b = t1_3.a)
+                     ->  Seq Scan on prt2_p3 t2_3
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                 ->  Seq Scan on prt1_p3 t1_2
+                                 ->  Seq Scan on prt1_p3 t1_3
                                        Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (27 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Hash Join
-               Hash Cond: (t2_1.b = t1_1.a)
-               ->  Seq Scan on prt2_p1 t2_1
-               ->  Hash
-                     ->  Seq Scan on prt1_p1 t1_1
-                           Filter: (b = 0)
-         ->  Hash Join
-               Hash Cond: (t2_2.b = t1_2.a)
-               ->  Seq Scan on prt2_p2 t2_2
-               ->  Hash
-                     ->  Seq Scan on prt1_p2 t1_2
-                           Filter: (b = 0)
-         ->  Hash Join
-               Hash Cond: (t2_3.b = t1_3.a)
-               ->  Seq Scan on prt2_p3 t2_3
-               ->  Hash
-                     ->  Seq Scan on prt1_p3 t1_3
-                           Filter: (b = 0)
-(21 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -104,7 +77,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b =
 -- left outer join, with whole-row reference; partitionwise join does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1, t2 FROM prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -116,40 +88,19 @@ SELECT t1, t2 FROM prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: t2.b
                      ->  Append
-                           ->  Seq Scan on prt2_p1 t2
-                           ->  Seq Scan on prt2_p2 t2_1
-                           ->  Seq Scan on prt2_p3 t2_2
+                           ->  Seq Scan on prt2_p1 t2_1
+                           ->  Seq Scan on prt2_p2 t2_2
+                           ->  Seq Scan on prt2_p3 t2_3
                ->  Hash
                      ->  Append
-                           ->  Seq Scan on prt1_p1 t1
+                           ->  Seq Scan on prt1_p1 t1_1
                                  Filter: (b = 0)
-                           ->  Seq Scan on prt1_p2 t1_1
+                           ->  Seq Scan on prt1_p2 t1_2
                                  Filter: (b = 0)
-                           ->  Seq Scan on prt1_p3 t1_2
+                           ->  Seq Scan on prt1_p3 t1_3
                                  Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (21 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b
-   ->  Hash Right Join
-         Hash Cond: (t2.b = t1.a)
-         ->  Append
-               ->  Seq Scan on prt2_p1 t2_1
-               ->  Seq Scan on prt2_p2 t2_2
-               ->  Seq Scan on prt2_p3 t2_3
-         ->  Hash
-               ->  Append
-                     ->  Seq Scan on prt1_p1 t1_1
-                           Filter: (b = 0)
-                     ->  Seq Scan on prt1_p2 t1_2
-                           Filter: (b = 0)
-                     ->  Seq Scan on prt1_p3 t1_3
-                           Filter: (b = 0)
-(16 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1, t2 FROM prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER BY t1.a, t2.b;
       t1      |      t2      
@@ -171,7 +122,6 @@ SELECT t1, t2 FROM prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER
 -- right outer join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1 RIGHT JOIN prt2 t2 ON t1.a = t2.b WHERE t2.a = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -180,56 +130,31 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1 RIGHT JOIN prt2 t2 ON t1.a = t2.b WHE
          Sort Key: t1.a, t2.b
          ->  Append
                ->  Hash Right Join
-                     Hash Cond: (t1.a = t2.b)
-                     ->  Seq Scan on prt1_p1 t1
+                     Hash Cond: (t1_1.a = t2_1.b)
+                     ->  Seq Scan on prt1_p1 t1_1
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                 Hash Key: t2.b
-                                 ->  Seq Scan on prt2_p1 t2
-                                       Filter: (a = 0)
-               ->  Hash Right Join
-                     Hash Cond: (t1_1.a = t2_1.b)
-                     ->  Seq Scan on prt1_p2 t1_1
-                     ->  Hash
-                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
                                  Hash Key: t2_1.b
-                                 ->  Seq Scan on prt2_p2 t2_1
+                                 ->  Seq Scan on prt2_p1 t2_1
                                        Filter: (a = 0)
                ->  Hash Right Join
                      Hash Cond: (t1_2.a = t2_2.b)
-                     ->  Seq Scan on prt1_p3 t1_2
+                     ->  Seq Scan on prt1_p2 t1_2
+                     ->  Hash
+                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                                 Hash Key: t2_2.b
+                                 ->  Seq Scan on prt2_p2 t2_2
+                                       Filter: (a = 0)
+               ->  Hash Right Join
+                     Hash Cond: (t1_3.a = t2_3.b)
+                     ->  Seq Scan on prt1_p3 t1_3
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice4; segments: 1)
-                                 Hash Key: t2_2.b
-                                 ->  Seq Scan on prt2_p3 t2_2
+                                 Hash Key: t2_3.b
+                                 ->  Seq Scan on prt2_p3 t2_3
                                        Filter: (a = 0)
  Optimizer: Postgres query optimizer
 (30 rows)
-=======
-                          QUERY PLAN                           
----------------------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b
-   ->  Append
-         ->  Hash Right Join
-               Hash Cond: (t1_1.a = t2_1.b)
-               ->  Seq Scan on prt1_p1 t1_1
-               ->  Hash
-                     ->  Seq Scan on prt2_p1 t2_1
-                           Filter: (a = 0)
-         ->  Hash Right Join
-               Hash Cond: (t1_2.a = t2_2.b)
-               ->  Seq Scan on prt1_p2 t1_2
-               ->  Hash
-                     ->  Seq Scan on prt2_p2 t2_2
-                           Filter: (a = 0)
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt2_p3 t2_3
-                     Filter: (a = 0)
-               ->  Index Scan using iprt1_p3_a on prt1_p3 t1_3
-                     Index Cond: (a = t2_3.b)
-(20 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1 RIGHT JOIN prt2 t2 ON t1.a = t2.b WHERE t2.a = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -247,7 +172,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1 RIGHT JOIN prt2 t2 ON t1.a = t2.b WHE
 -- full outer join, with placeholder vars
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT 50 phv, * FROM prt1 WHERE prt1.b = 0) t1 FULL JOIN (SELECT 75 phv, * FROM prt2 WHERE prt2.a = 0) t2 ON (t1.a = t2.b) WHERE t1.phv = t1.a OR t2.phv = t2.b ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -256,69 +180,37 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT 50 phv, * FROM prt1 WHERE prt1.b = 0)
          Sort Key: prt1.a, prt2.b
          ->  Append
                ->  Hash Full Join
-                     Hash Cond: (prt1.a = prt2.b)
-                     Filter: (((50) = prt1.a) OR ((75) = prt2.b))
-                     ->  Seq Scan on prt1_p1 prt1
+                     Hash Cond: (prt1_1.a = prt2_1.b)
+                     Filter: (((50) = prt1_1.a) OR ((75) = prt2_1.b))
+                     ->  Seq Scan on prt1_p1 prt1_1
                            Filter: (b = 0)
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                 Hash Key: prt2.b
-                                 ->  Seq Scan on prt2_p1 prt2
-                                       Filter: (a = 0)
-               ->  Hash Full Join
-                     Hash Cond: (prt1_1.a = prt2_1.b)
-                     Filter: (((50) = prt1_1.a) OR ((75) = prt2_1.b))
-                     ->  Seq Scan on prt1_p2 prt1_1
-                           Filter: (b = 0)
-                     ->  Hash
-                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
                                  Hash Key: prt2_1.b
-                                 ->  Seq Scan on prt2_p2 prt2_1
+                                 ->  Seq Scan on prt2_p1 prt2_1
                                        Filter: (a = 0)
                ->  Hash Full Join
                      Hash Cond: (prt1_2.a = prt2_2.b)
                      Filter: (((50) = prt1_2.a) OR ((75) = prt2_2.b))
-                     ->  Seq Scan on prt1_p3 prt1_2
+                     ->  Seq Scan on prt1_p2 prt1_2
+                           Filter: (b = 0)
+                     ->  Hash
+                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                                 Hash Key: prt2_2.b
+                                 ->  Seq Scan on prt2_p2 prt2_2
+                                       Filter: (a = 0)
+               ->  Hash Full Join
+                     Hash Cond: (prt1_3.a = prt2_3.b)
+                     Filter: (((50) = prt1_3.a) OR ((75) = prt2_3.b))
+                     ->  Seq Scan on prt1_p3 prt1_3
                            Filter: (b = 0)
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice4; segments: 1)
-                                 Hash Key: prt2_2.b
-                                 ->  Seq Scan on prt2_p3 prt2_2
+                                 Hash Key: prt2_3.b
+                                 ->  Seq Scan on prt2_p3 prt2_3
                                        Filter: (a = 0)
  Optimizer: Postgres query optimizer
 (36 rows)
-=======
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Sort
-   Sort Key: prt1.a, prt2.b
-   ->  Append
-         ->  Hash Full Join
-               Hash Cond: (prt1_1.a = prt2_1.b)
-               Filter: (((50) = prt1_1.a) OR ((75) = prt2_1.b))
-               ->  Seq Scan on prt1_p1 prt1_1
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_p1 prt2_1
-                           Filter: (a = 0)
-         ->  Hash Full Join
-               Hash Cond: (prt1_2.a = prt2_2.b)
-               Filter: (((50) = prt1_2.a) OR ((75) = prt2_2.b))
-               ->  Seq Scan on prt1_p2 prt1_2
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_p2 prt2_2
-                           Filter: (a = 0)
-         ->  Hash Full Join
-               Hash Cond: (prt1_3.a = prt2_3.b)
-               Filter: (((50) = prt1_3.a) OR ((75) = prt2_3.b))
-               ->  Seq Scan on prt1_p3 prt1_3
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_p3 prt2_3
-                           Filter: (a = 0)
-(27 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT 50 phv, * FROM prt1 WHERE prt1.b = 0) t1 FULL JOIN (SELECT 75 phv, * FROM prt2 WHERE prt2.a = 0) t2 ON (t1.a = t2.b) WHERE t1.phv = t1.a OR t2.phv = t2.b ORDER BY t1.a, t2.b;
  a  |  c   | b  |  c   
@@ -356,7 +248,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.a <
 -- Currently we can't do partitioned join if nullable-side partitions are pruned
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JOIN (SELECT * FROM prt2 WHERE b > 250) t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -368,38 +259,18 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JO
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: prt2.b
                      ->  Append
-                           ->  Seq Scan on prt2_p2 prt2
+                           ->  Seq Scan on prt2_p2 prt2_1
                                  Filter: (b > 250)
-                           ->  Seq Scan on prt2_p3 prt2_1
+                           ->  Seq Scan on prt2_p3 prt2_2
                                  Filter: (b > 250)
                ->  Hash
                      ->  Append
-                           ->  Seq Scan on prt1_p1 prt1
+                           ->  Seq Scan on prt1_p1 prt1_1
                                  Filter: ((a < 450) AND (b = 0))
-                           ->  Seq Scan on prt1_p2 prt1_1
+                           ->  Seq Scan on prt1_p2 prt1_2
                                  Filter: ((a < 450) AND (b = 0))
  Optimizer: Postgres query optimizer
 (20 rows)
-=======
-                        QUERY PLAN                         
------------------------------------------------------------
- Sort
-   Sort Key: prt1.a, prt2.b
-   ->  Hash Right Join
-         Hash Cond: (prt2.b = prt1.a)
-         ->  Append
-               ->  Seq Scan on prt2_p2 prt2_1
-                     Filter: (b > 250)
-               ->  Seq Scan on prt2_p3 prt2_2
-                     Filter: (b > 250)
-         ->  Hash
-               ->  Append
-                     ->  Seq Scan on prt1_p1 prt1_1
-                           Filter: ((a < 450) AND (b = 0))
-                     ->  Seq Scan on prt1_p2 prt1_2
-                           Filter: ((a < 450) AND (b = 0))
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JOIN (SELECT * FROM prt2 WHERE b > 250) t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -418,7 +289,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JO
 -- Currently we can't do partitioned join if nullable-side partitions are pruned
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 FULL JOIN (SELECT * FROM prt2 WHERE b > 250) t2 ON t1.a = t2.b WHERE t1.b = 0 OR t2.a = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -429,41 +299,20 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 FULL JO
                Hash Cond: (prt1.a = prt2.b)
                Filter: ((prt1.b = 0) OR (prt2.a = 0))
                ->  Append
-                     ->  Seq Scan on prt1_p1 prt1
+                     ->  Seq Scan on prt1_p1 prt1_1
                            Filter: (a < 450)
-                     ->  Seq Scan on prt1_p2 prt1_1
+                     ->  Seq Scan on prt1_p2 prt1_2
                            Filter: (a < 450)
                ->  Hash
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: prt2.b
                            ->  Append
-                                 ->  Seq Scan on prt2_p2 prt2
+                                 ->  Seq Scan on prt2_p2 prt2_1
                                        Filter: (b > 250)
-                                 ->  Seq Scan on prt2_p3 prt2_1
+                                 ->  Seq Scan on prt2_p3 prt2_2
                                        Filter: (b > 250)
  Optimizer: Postgres query optimizer
 (21 rows)
-=======
-                     QUERY PLAN                     
-----------------------------------------------------
- Sort
-   Sort Key: prt1.a, prt2.b
-   ->  Hash Full Join
-         Hash Cond: (prt1.a = prt2.b)
-         Filter: ((prt1.b = 0) OR (prt2.a = 0))
-         ->  Append
-               ->  Seq Scan on prt1_p1 prt1_1
-                     Filter: (a < 450)
-               ->  Seq Scan on prt1_p2 prt1_2
-                     Filter: (a < 450)
-         ->  Hash
-               ->  Append
-                     ->  Seq Scan on prt2_p2 prt2_1
-                           Filter: (b > 250)
-                     ->  Seq Scan on prt2_p3 prt2_2
-                           Filter: (b > 250)
-(16 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 FULL JOIN (SELECT * FROM prt2 WHERE b > 250) t2 ON t1.a = t2.b WHERE t1.b = 0 OR t2.a = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -485,7 +334,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a < 450) t1 FULL JO
 -- Semi-join
 EXPLAIN (COSTS OFF)
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t2.b FROM prt2 t2 WHERE t2.a = 0) AND t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -494,63 +342,34 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t2.b FROM prt2 t2 WHERE t2.a = 0)
          Sort Key: t1.a
          ->  Append
                ->  Hash Semi Join
-                     Hash Cond: (t1.a = t2.b)
-                     ->  Seq Scan on prt1_p1 t1
+                     Hash Cond: (t1_1.a = t2_1.b)
+                     ->  Seq Scan on prt1_p1 t1_1
                            Filter: (b = 0)
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                 Hash Key: t2.b
-                                 ->  Seq Scan on prt2_p1 t2
+                                 Hash Key: t2_1.b
+                                 ->  Seq Scan on prt2_p1 t2_1
                                        Filter: (a = 0)
                ->  Hash Semi Join
-                     Hash Cond: (t1_1.a = t2_1.b)
-                     ->  Seq Scan on prt1_p2 t1_1
+                     Hash Cond: (t1_2.a = t2_2.b)
+                     ->  Seq Scan on prt1_p2 t1_2
                            Filter: (b = 0)
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice3; segments: 1)
-                                 Hash Key: t2_1.b
-                                 ->  Seq Scan on prt2_p2 t2_1
+                                 Hash Key: t2_2.b
+                                 ->  Seq Scan on prt2_p2 t2_2
                                        Filter: (a = 0)
                ->  Nested Loop Semi Join
-                     Join Filter: (t1_2.a = t2_2.b)
-                     ->  Seq Scan on prt1_p3 t1_2
+                     Join Filter: (t1_3.a = t2_3.b)
+                     ->  Seq Scan on prt1_p3 t1_3
                            Filter: (b = 0)
                      ->  Materialize
                            ->  Redistribute Motion 1:3  (slice4; segments: 1)
-                                 Hash Key: t2_2.b
-                                 ->  Seq Scan on prt2_p3 t2_2
+                                 Hash Key: t2_3.b
+                                 ->  Seq Scan on prt2_p3 t2_3
                                        Filter: (a = 0)
  Optimizer: Postgres query optimizer
 (33 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Hash Semi Join
-               Hash Cond: (t1_1.a = t2_1.b)
-               ->  Seq Scan on prt1_p1 t1_1
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_p1 t2_1
-                           Filter: (a = 0)
-         ->  Hash Semi Join
-               Hash Cond: (t1_2.a = t2_2.b)
-               ->  Seq Scan on prt1_p2 t1_2
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_p2 t2_2
-                           Filter: (a = 0)
-         ->  Nested Loop Semi Join
-               Join Filter: (t1_3.a = t2_3.b)
-               ->  Seq Scan on prt1_p3 t1_3
-                     Filter: (b = 0)
-               ->  Materialize
-                     ->  Seq Scan on prt2_p3 t2_3
-                           Filter: (a = 0)
-(24 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t2.b FROM prt2 t2 WHERE t2.a = 0) AND t1.b = 0 ORDER BY t1.a;
   a  | b |  c   
@@ -564,7 +383,6 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t2.b FROM prt2 t2 WHERE t2.a = 0)
 -- Anti-join with aggregates
 EXPLAIN (COSTS OFF)
 SELECT sum(t1.a), avg(t1.a), sum(t1.b), avg(t1.b) FROM prt1 t1 WHERE NOT EXISTS (SELECT 1 FROM prt2 t2 WHERE t1.a = t2.b);
-<<<<<<< HEAD
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -572,50 +390,28 @@ SELECT sum(t1.a), avg(t1.a), sum(t1.b), avg(t1.b) FROM prt1 t1 WHERE NOT EXISTS 
          ->  Partial Aggregate
                ->  Append
                      ->  Hash Anti Join
-                           Hash Cond: (t1.a = t2.b)
-                           ->  Seq Scan on prt1_p1 t1
+                           Hash Cond: (t1_1.a = t2_1.b)
+                           ->  Seq Scan on prt1_p1 t1_1
                            ->  Hash
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: t2.b
-                                       ->  Seq Scan on prt2_p1 t2
-                     ->  Hash Anti Join
-                           Hash Cond: (t1_1.a = t2_1.b)
-                           ->  Seq Scan on prt1_p2 t1_1
-                           ->  Hash
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: t2_1.b
-                                       ->  Seq Scan on prt2_p2 t2_1
+                                       ->  Seq Scan on prt2_p1 t2_1
                      ->  Hash Anti Join
                            Hash Cond: (t1_2.a = t2_2.b)
-                           ->  Seq Scan on prt1_p3 t1_2
+                           ->  Seq Scan on prt1_p2 t1_2
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: t2_2.b
+                                       ->  Seq Scan on prt2_p2 t2_2
+                     ->  Hash Anti Join
+                           Hash Cond: (t1_3.a = t2_3.b)
+                           ->  Seq Scan on prt1_p3 t1_3
                            ->  Hash
                                  ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                       Hash Key: t2_2.b
-                                       ->  Seq Scan on prt2_p3 t2_2
+                                       Hash Key: t2_3.b
+                                       ->  Seq Scan on prt2_p3 t2_3
  Optimizer: Postgres query optimizer
 (26 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Aggregate
-   ->  Append
-         ->  Hash Anti Join
-               Hash Cond: (t1_1.a = t2_1.b)
-               ->  Seq Scan on prt1_p1 t1_1
-               ->  Hash
-                     ->  Seq Scan on prt2_p1 t2_1
-         ->  Hash Anti Join
-               Hash Cond: (t1_2.a = t2_2.b)
-               ->  Seq Scan on prt1_p2 t1_2
-               ->  Hash
-                     ->  Seq Scan on prt2_p2 t2_2
-         ->  Hash Anti Join
-               Hash Cond: (t1_3.a = t2_3.b)
-               ->  Seq Scan on prt1_p3 t1_3
-               ->  Hash
-                     ->  Seq Scan on prt2_p3 t2_3
-(17 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT sum(t1.a), avg(t1.a), sum(t1.b), avg(t1.b) FROM prt1 t1 WHERE NOT EXISTS (SELECT 1 FROM prt2 t2 WHERE t1.a = t2.b);
   sum  |         avg          | sum  |         avg         
@@ -630,41 +426,7 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t3.a AS t3a, least(t1.a,t2.a,t3.b) FROM prt1 t2 JOIN prt2 t3 ON (t2.a = t3.b)) ss
 			  ON t1.a = ss.t2a WHERE t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
 ERROR:  could not devise a query plan for the given query
-=======
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_p1 t1_1
-                     Filter: (b = 0)
-               ->  Nested Loop
-                     ->  Index Only Scan using iprt1_p1_a on prt1_p1 t2_1
-                           Index Cond: (a = t1_1.a)
-                     ->  Index Scan using iprt2_p1_b on prt2_p1 t3_1
-                           Index Cond: (b = t2_1.a)
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_p2 t1_2
-                     Filter: (b = 0)
-               ->  Nested Loop
-                     ->  Index Only Scan using iprt1_p2_a on prt1_p2 t2_2
-                           Index Cond: (a = t1_2.a)
-                     ->  Index Scan using iprt2_p2_b on prt2_p2 t3_2
-                           Index Cond: (b = t2_2.a)
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_p3 t1_3
-                     Filter: (b = 0)
-               ->  Nested Loop
-                     ->  Index Only Scan using iprt1_p3_a on prt1_p3 t2_3
-                           Index Cond: (a = t1_3.a)
-                     ->  Index Scan using iprt2_p3_b on prt2_p3 t3_3
-                           Index Cond: (b = t2_3.a)
-(27 rows)
-
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 SELECT * FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t3.a AS t3a, least(t1.a,t2.a,t3.b) FROM prt1 t2 JOIN prt2 t3 ON (t2.a = t3.b)) ss
 			  ON t1.a = ss.t2a WHERE t1.b = 0 ORDER BY t1.a;
@@ -673,7 +435,6 @@ EXPLAIN (COSTS OFF)
 SELECT t1.a, ss.t2a, ss.t2c FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t3.a AS t3a, t2.b t2b, t2.c t2c, least(t1.a,t2.a,t3.b) FROM prt1 t2 JOIN prt2 t3 ON (t2.a = t3.b)) ss
 			  ON t1.c = ss.t2c WHERE (t1.b + coalesce(ss.t2b, 0)) = 0 ORDER BY t1.a;
-<<<<<<< HEAD
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -686,67 +447,36 @@ SELECT t1.a, ss.t2a, ss.t2c FROM prt1 t1 LEFT JOIN LATERAL
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: t1.c
                      ->  Append
-                           ->  Seq Scan on prt1_p1 t1
-                           ->  Seq Scan on prt1_p2 t1_1
-                           ->  Seq Scan on prt1_p3 t1_2
+                           ->  Seq Scan on prt1_p1 t1_1
+                           ->  Seq Scan on prt1_p2 t1_2
+                           ->  Seq Scan on prt1_p3 t1_3
                ->  Hash
                      ->  Redistribute Motion 3:3  (slice3; segments: 3)
                            Hash Key: t2.c
                            ->  Append
                                  ->  Hash Join
-                                       Hash Cond: (t2.a = t3.b)
-                                       ->  Seq Scan on prt1_p1 t2
+                                       Hash Cond: (t2_1.a = t3_1.b)
+                                       ->  Seq Scan on prt1_p1 t2_1
                                        ->  Hash
                                              ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: t3.b
-                                                   ->  Seq Scan on prt2_p1 t3
-                                 ->  Hash Join
-                                       Hash Cond: (t2_1.a = t3_1.b)
-                                       ->  Seq Scan on prt1_p2 t2_1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)
                                                    Hash Key: t3_1.b
-                                                   ->  Seq Scan on prt2_p2 t3_1
+                                                   ->  Seq Scan on prt2_p1 t3_1
                                  ->  Hash Join
                                        Hash Cond: (t2_2.a = t3_2.b)
-                                       ->  Seq Scan on prt1_p3 t2_2
+                                       ->  Seq Scan on prt1_p2 t2_2
+                                       ->  Hash
+                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                                   Hash Key: t3_2.b
+                                                   ->  Seq Scan on prt2_p2 t3_2
+                                 ->  Hash Join
+                                       Hash Cond: (t2_3.a = t3_3.b)
+                                       ->  Seq Scan on prt1_p3 t2_3
                                        ->  Hash
                                              ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                                   Hash Key: t3_2.b
-                                                   ->  Seq Scan on prt2_p3 t3_2
+                                                   Hash Key: t3_3.b
+                                                   ->  Seq Scan on prt2_p3 t3_3
  Optimizer: Postgres query optimizer
 (39 rows)
-=======
-                          QUERY PLAN                          
---------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Hash Left Join
-         Hash Cond: ((t1.c)::text = (t2.c)::text)
-         Filter: ((t1.b + COALESCE(t2.b, 0)) = 0)
-         ->  Append
-               ->  Seq Scan on prt1_p1 t1_1
-               ->  Seq Scan on prt1_p2 t1_2
-               ->  Seq Scan on prt1_p3 t1_3
-         ->  Hash
-               ->  Append
-                     ->  Hash Join
-                           Hash Cond: (t2_1.a = t3_1.b)
-                           ->  Seq Scan on prt1_p1 t2_1
-                           ->  Hash
-                                 ->  Seq Scan on prt2_p1 t3_1
-                     ->  Hash Join
-                           Hash Cond: (t2_2.a = t3_2.b)
-                           ->  Seq Scan on prt1_p2 t2_2
-                           ->  Hash
-                                 ->  Seq Scan on prt2_p2 t3_2
-                     ->  Hash Join
-                           Hash Cond: (t2_3.a = t3_3.b)
-                           ->  Seq Scan on prt1_p3 t2_3
-                           ->  Hash
-                                 ->  Seq Scan on prt2_p3 t3_3
-(26 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, ss.t2a, ss.t2c FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t3.a AS t3a, t2.b t2b, t2.c t2c, least(t1.a,t2.a,t3.a) FROM prt1 t2 JOIN prt2 t3 ON (t2.a = t3.b)) ss
@@ -786,38 +516,38 @@ SELECT a, b FROM prt1 FULL JOIN prt2 p2(b,a,c) USING(a,b)
                      Hash Key: (COALESCE(prt1.a, p2.a)), (COALESCE(prt1.b, p2.b))
                      ->  Append
                            ->  Merge Full Join
-                                 Merge Cond: ((prt1.a = p2.a) AND (prt1.b = p2.b))
-                                 Filter: ((COALESCE(prt1.a, p2.a) >= 490) AND (COALESCE(prt1.a, p2.a) <= 510))
-                                 ->  Sort
-                                       Sort Key: prt1.a, prt1.b
-                                       ->  Seq Scan on prt1_p1 prt1
-                                 ->  Sort
-                                       Sort Key: p2.a, p2.b
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                             Hash Key: p2.a
-                                             ->  Seq Scan on prt2_p1 p2
-                           ->  Merge Full Join
                                  Merge Cond: ((prt1_1.a = p2_1.a) AND (prt1_1.b = p2_1.b))
                                  Filter: ((COALESCE(prt1_1.a, p2_1.a) >= 490) AND (COALESCE(prt1_1.a, p2_1.a) <= 510))
                                  ->  Sort
                                        Sort Key: prt1_1.a, prt1_1.b
-                                       ->  Seq Scan on prt1_p2 prt1_1
+                                       ->  Seq Scan on prt1_p1 prt1_1
                                  ->  Sort
                                        Sort Key: p2_1.a, p2_1.b
-                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: p2_1.a
-                                             ->  Seq Scan on prt2_p2 p2_1
+                                             ->  Seq Scan on prt2_p1 p2_1
                            ->  Merge Full Join
                                  Merge Cond: ((prt1_2.a = p2_2.a) AND (prt1_2.b = p2_2.b))
                                  Filter: ((COALESCE(prt1_2.a, p2_2.a) >= 490) AND (COALESCE(prt1_2.a, p2_2.a) <= 510))
                                  ->  Sort
                                        Sort Key: prt1_2.a, prt1_2.b
-                                       ->  Seq Scan on prt1_p3 prt1_2
+                                       ->  Seq Scan on prt1_p2 prt1_2
                                  ->  Sort
                                        Sort Key: p2_2.a, p2_2.b
-                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                              Hash Key: p2_2.a
-                                             ->  Seq Scan on prt2_p3 p2_2
+                                             ->  Seq Scan on prt2_p2 p2_2
+                           ->  Merge Full Join
+                                 Merge Cond: ((prt1_3.a = p2_3.a) AND (prt1_3.b = p2_3.b))
+                                 Filter: ((COALESCE(prt1_3.a, p2_3.a) >= 490) AND (COALESCE(prt1_3.a, p2_3.a) <= 510))
+                                 ->  Sort
+                                       Sort Key: prt1_3.a, prt1_3.b
+                                       ->  Seq Scan on prt1_p3 prt1_3
+                                 ->  Sort
+                                       Sort Key: p2_3.a, p2_3.b
+                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                             Hash Key: p2_3.a
+                                             ->  Seq Scan on prt2_p3 p2_3
  Optimizer: Postgres query optimizer
 (43 rows)
 
@@ -864,7 +594,6 @@ INSERT INTO prt2_e SELECT i, i, i % 25 FROM generate_series(0, 599, 3) i;
 ANALYZE prt2_e;
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_e t1, prt2_e t2 WHERE (t1.a + t1.b)/2 = (t2.b + t2.a)/2 AND t1.c = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -873,54 +602,28 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_e t1, prt2_e t2 WHERE (t1.a + t1.b)/2 = 
          Sort Key: t1.a, t2.b
          ->  Append
                ->  Hash Join
-                     Hash Cond: (((t2.b + t2.a) / 2) = ((t1.a + t1.b) / 2))
-                     ->  Seq Scan on prt2_e_p1 t2
+                     Hash Cond: (((t2_1.b + t2_1.a) / 2) = ((t1_1.a + t1_1.b) / 2))
+                     ->  Seq Scan on prt2_e_p1 t2_1
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Seq Scan on prt1_e_p1 t1
-                                       Filter: (c = 0)
-               ->  Hash Join
-                     Hash Cond: (((t2_1.b + t2_1.a) / 2) = ((t1_1.a + t1_1.b) / 2))
-                     ->  Seq Scan on prt2_e_p2 t2_1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on prt1_e_p2 t1_1
+                                 ->  Seq Scan on prt1_e_p1 t1_1
                                        Filter: (c = 0)
                ->  Hash Join
                      Hash Cond: (((t2_2.b + t2_2.a) / 2) = ((t1_2.a + t1_2.b) / 2))
-                     ->  Seq Scan on prt2_e_p3 t2_2
+                     ->  Seq Scan on prt2_e_p2 t2_2
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on prt1_e_p2 t1_2
+                                       Filter: (c = 0)
+               ->  Hash Join
+                     Hash Cond: (((t2_3.b + t2_3.a) / 2) = ((t1_3.a + t1_3.b) / 2))
+                     ->  Seq Scan on prt2_e_p3 t2_3
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                 ->  Seq Scan on prt1_e_p3 t1_2
+                                 ->  Seq Scan on prt1_e_p3 t1_3
                                        Filter: (c = 0)
  Optimizer: Postgres query optimizer
 (27 rows)
-=======
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b
-   ->  Append
-         ->  Hash Join
-               Hash Cond: (((t2_1.b + t2_1.a) / 2) = ((t1_1.a + t1_1.b) / 2))
-               ->  Seq Scan on prt2_e_p1 t2_1
-               ->  Hash
-                     ->  Seq Scan on prt1_e_p1 t1_1
-                           Filter: (c = 0)
-         ->  Hash Join
-               Hash Cond: (((t2_2.b + t2_2.a) / 2) = ((t1_2.a + t1_2.b) / 2))
-               ->  Seq Scan on prt2_e_p2 t2_2
-               ->  Hash
-                     ->  Seq Scan on prt1_e_p2 t1_2
-                           Filter: (c = 0)
-         ->  Hash Join
-               Hash Cond: (((t2_3.b + t2_3.a) / 2) = ((t1_3.a + t1_3.b) / 2))
-               ->  Seq Scan on prt2_e_p3 t2_3
-               ->  Hash
-                     ->  Seq Scan on prt1_e_p3 t1_3
-                           Filter: (c = 0)
-(21 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_e t1, prt2_e t2 WHERE (t1.a + t1.b)/2 = (t2.b + t2.a)/2 AND t1.c = 0 ORDER BY t1.a, t2.b;
   a  | c |  b  | c 
@@ -936,7 +639,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_e t1, prt2_e t2 WHERE (t1.a + t1.b)/2 = 
 --
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM prt1 t1, prt2 t2, prt1_e t3 WHERE t1.a = t2.b AND t1.a = (t3.a + t3.b)/2 AND t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -945,81 +647,43 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM prt1 t1, prt2 t2, prt1_e t
          Sort Key: t1.a
          ->  Append
                ->  Hash Join
-                     Hash Cond: (((t3.a + t3.b) / 2) = t1.a)
-                     ->  Seq Scan on prt1_e_p1 t3
+                     Hash Cond: (((t3_1.a + t3_1.b) / 2) = t1_1.a)
+                     ->  Seq Scan on prt1_e_p1 t3_1
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                  ->  Hash Join
-                                       Hash Cond: (t2.b = t1.a)
-                                       ->  Seq Scan on prt2_p1 t2
+                                       Hash Cond: (t2_1.b = t1_1.a)
+                                       ->  Seq Scan on prt2_p1 t2_1
                                        ->  Hash
                                              ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Seq Scan on prt1_p1 t1
-                                                         Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: (((t3_1.a + t3_1.b) / 2) = t1_1.a)
-                     ->  Seq Scan on prt1_e_p2 t3_1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                 ->  Hash Join
-                                       Hash Cond: (t2_1.b = t1_1.a)
-                                       ->  Seq Scan on prt2_p2 t2_1
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                                   ->  Seq Scan on prt1_p2 t1_1
+                                                   ->  Seq Scan on prt1_p1 t1_1
                                                          Filter: (b = 0)
                ->  Hash Join
                      Hash Cond: (((t3_2.a + t3_2.b) / 2) = t1_2.a)
-                     ->  Seq Scan on prt1_e_p3 t3_2
+                     ->  Seq Scan on prt1_e_p2 t3_2
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                 ->  Hash Join
+                                       Hash Cond: (t2_2.b = t1_2.a)
+                                       ->  Seq Scan on prt2_p2 t2_2
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                   ->  Seq Scan on prt1_p2 t1_2
+                                                         Filter: (b = 0)
+               ->  Hash Join
+                     Hash Cond: (((t3_3.a + t3_3.b) / 2) = t1_3.a)
+                     ->  Seq Scan on prt1_e_p3 t3_3
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                  ->  Hash Join
-                                       Hash Cond: (t2_2.b = t1_2.a)
-                                       ->  Seq Scan on prt2_p3 t2_2
+                                       Hash Cond: (t2_3.b = t1_3.a)
+                                       ->  Seq Scan on prt2_p3 t2_3
                                        ->  Hash
                                              ->  Broadcast Motion 3:3  (slice7; segments: 3)
-                                                   ->  Seq Scan on prt1_p3 t1_2
+                                                   ->  Seq Scan on prt1_p3 t1_3
                                                          Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (42 rows)
-=======
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Nested Loop
-               Join Filter: (t1_1.a = ((t3_1.a + t3_1.b) / 2))
-               ->  Hash Join
-                     Hash Cond: (t2_1.b = t1_1.a)
-                     ->  Seq Scan on prt2_p1 t2_1
-                     ->  Hash
-                           ->  Seq Scan on prt1_p1 t1_1
-                                 Filter: (b = 0)
-               ->  Index Scan using iprt1_e_p1_ab2 on prt1_e_p1 t3_1
-                     Index Cond: (((a + b) / 2) = t2_1.b)
-         ->  Nested Loop
-               Join Filter: (t1_2.a = ((t3_2.a + t3_2.b) / 2))
-               ->  Hash Join
-                     Hash Cond: (t2_2.b = t1_2.a)
-                     ->  Seq Scan on prt2_p2 t2_2
-                     ->  Hash
-                           ->  Seq Scan on prt1_p2 t1_2
-                                 Filter: (b = 0)
-               ->  Index Scan using iprt1_e_p2_ab2 on prt1_e_p2 t3_2
-                     Index Cond: (((a + b) / 2) = t2_2.b)
-         ->  Nested Loop
-               Join Filter: (t1_3.a = ((t3_3.a + t3_3.b) / 2))
-               ->  Hash Join
-                     Hash Cond: (t2_3.b = t1_3.a)
-                     ->  Seq Scan on prt2_p3 t2_3
-                     ->  Hash
-                           ->  Seq Scan on prt1_p3 t1_3
-                                 Filter: (b = 0)
-               ->  Index Scan using iprt1_e_p3_ab2 on prt1_e_p3 t3_3
-                     Index Cond: (((a + b) / 2) = t2_3.b)
-(33 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM prt1 t1, prt2 t2, prt1_e t3 WHERE t1.a = t2.b AND t1.a = (t3.a + t3.b)/2 AND t1.b = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   | ?column? | c 
@@ -1032,7 +696,6 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM prt1 t1, prt2 t2, prt1_e t
 
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b) LEFT JOIN prt1_e t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t1.b = 0 ORDER BY t1.a, t2.b, t3.a + t3.b;
-<<<<<<< HEAD
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1041,87 +704,49 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2
          Sort Key: t1.a, t2.b, ((t3.a + t3.b))
          ->  Append
                ->  Hash Right Join
-                     Hash Cond: (((t3.a + t3.b) / 2) = t1.a)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: ((t3.a + t3.b) / 2)
-                           ->  Seq Scan on prt1_e_p1 t3
-                     ->  Hash
-                           ->  Hash Right Join
-                                 Hash Cond: (t2.b = t1.a)
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: t2.b
-                                       ->  Seq Scan on prt2_p1 t2
-                                 ->  Hash
-                                       ->  Seq Scan on prt1_p1 t1
-                                             Filter: (b = 0)
-               ->  Hash Right Join
                      Hash Cond: (((t3_1.a + t3_1.b) / 2) = t1_1.a)
-                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: ((t3_1.a + t3_1.b) / 2)
-                           ->  Seq Scan on prt1_e_p2 t3_1
+                           ->  Seq Scan on prt1_e_p1 t3_1
                      ->  Hash
                            ->  Hash Right Join
                                  Hash Cond: (t2_1.b = t1_1.a)
-                                 ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                        Hash Key: t2_1.b
-                                       ->  Seq Scan on prt2_p2 t2_1
+                                       ->  Seq Scan on prt2_p1 t2_1
                                  ->  Hash
-                                       ->  Seq Scan on prt1_p2 t1_1
+                                       ->  Seq Scan on prt1_p1 t1_1
                                              Filter: (b = 0)
                ->  Hash Right Join
                      Hash Cond: (((t3_2.a + t3_2.b) / 2) = t1_2.a)
-                     ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
                            Hash Key: ((t3_2.a + t3_2.b) / 2)
-                           ->  Seq Scan on prt1_e_p3 t3_2
+                           ->  Seq Scan on prt1_e_p2 t3_2
                      ->  Hash
                            ->  Hash Right Join
                                  Hash Cond: (t2_2.b = t1_2.a)
-                                 ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                 ->  Redistribute Motion 3:3  (slice5; segments: 3)
                                        Hash Key: t2_2.b
-                                       ->  Seq Scan on prt2_p3 t2_2
+                                       ->  Seq Scan on prt2_p2 t2_2
                                  ->  Hash
-                                       ->  Seq Scan on prt1_p3 t1_2
+                                       ->  Seq Scan on prt1_p2 t1_2
+                                             Filter: (b = 0)
+               ->  Hash Right Join
+                     Hash Cond: (((t3_3.a + t3_3.b) / 2) = t1_3.a)
+                     ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                           Hash Key: ((t3_3.a + t3_3.b) / 2)
+                           ->  Seq Scan on prt1_e_p3 t3_3
+                     ->  Hash
+                           ->  Hash Right Join
+                                 Hash Cond: (t2_3.b = t1_3.a)
+                                 ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                       Hash Key: t2_3.b
+                                       ->  Seq Scan on prt2_p3 t2_3
+                                 ->  Hash
+                                       ->  Seq Scan on prt1_p3 t1_3
                                              Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (48 rows)
-=======
-                          QUERY PLAN                          
---------------------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b, ((t3.a + t3.b))
-   ->  Append
-         ->  Hash Right Join
-               Hash Cond: (((t3_1.a + t3_1.b) / 2) = t1_1.a)
-               ->  Seq Scan on prt1_e_p1 t3_1
-               ->  Hash
-                     ->  Hash Right Join
-                           Hash Cond: (t2_1.b = t1_1.a)
-                           ->  Seq Scan on prt2_p1 t2_1
-                           ->  Hash
-                                 ->  Seq Scan on prt1_p1 t1_1
-                                       Filter: (b = 0)
-         ->  Hash Right Join
-               Hash Cond: (((t3_2.a + t3_2.b) / 2) = t1_2.a)
-               ->  Seq Scan on prt1_e_p2 t3_2
-               ->  Hash
-                     ->  Hash Right Join
-                           Hash Cond: (t2_2.b = t1_2.a)
-                           ->  Seq Scan on prt2_p2 t2_2
-                           ->  Hash
-                                 ->  Seq Scan on prt1_p2 t1_2
-                                       Filter: (b = 0)
-         ->  Hash Right Join
-               Hash Cond: (((t3_3.a + t3_3.b) / 2) = t1_3.a)
-               ->  Seq Scan on prt1_e_p3 t3_3
-               ->  Hash
-                     ->  Hash Right Join
-                           Hash Cond: (t2_3.b = t1_3.a)
-                           ->  Seq Scan on prt2_p3 t2_3
-                           ->  Hash
-                                 ->  Seq Scan on prt1_p3 t1_3
-                                       Filter: (b = 0)
-(33 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b) LEFT JOIN prt1_e t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t1.b = 0 ORDER BY t1.a, t2.b, t3.a + t3.b;
   a  |  c   |  b  |  c   | ?column? | c 
@@ -1150,84 +775,55 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2
          Sort Key: t1.a, t2.b, ((t3.a + t3.b))
          ->  Append
                ->  Hash Right Join
-<<<<<<< HEAD
-                     Hash Cond: (t2.b = t1.a)
+                     Hash Cond: (t2_1.b = t1_1.a)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: t2.b
-                           ->  Seq Scan on prt2_p1 t2
+                           Hash Key: t2_1.b
+                           ->  Seq Scan on prt2_p1 t2_1
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: t1.a
-                                 ->  Hash Right Join
-                                       Hash Cond: (t1.a = ((t3.a + t3.b) / 2))
-                                       ->  Seq Scan on prt1_p1 t1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: ((t3.a + t3.b) / 2)
-                                                   ->  Seq Scan on prt1_e_p1 t3
-                                                         Filter: (c = 0)
-               ->  Hash Right Join
-                     Hash Cond: (t2_1.b = t1_1.a)
-                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                           Hash Key: t2_1.b
-                           ->  Seq Scan on prt2_p2 t2_1
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice6; segments: 3)
                                  Hash Key: t1_1.a
                                  ->  Hash Right Join
                                        Hash Cond: (t1_1.a = ((t3_1.a + t3_1.b) / 2))
-                                       ->  Seq Scan on prt1_p2 t1_1
+                                       ->  Seq Scan on prt1_p1 t1_1
                                        ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                                    Hash Key: ((t3_1.a + t3_1.b) / 2)
-                                                   ->  Seq Scan on prt1_e_p2 t3_1
+                                                   ->  Seq Scan on prt1_e_p1 t3_1
                                                          Filter: (c = 0)
                ->  Hash Right Join
                      Hash Cond: (t2_2.b = t1_2.a)
-                     ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                     ->  Redistribute Motion 3:3  (slice5; segments: 3)
                            Hash Key: t2_2.b
-                           ->  Seq Scan on prt2_p3 t2_2
+                           ->  Seq Scan on prt2_p2 t2_2
                      ->  Hash
-                           ->  Redistribute Motion 3:3  (slice9; segments: 3)
+                           ->  Redistribute Motion 3:3  (slice6; segments: 3)
                                  Hash Key: t1_2.a
                                  ->  Hash Right Join
                                        Hash Cond: (t1_2.a = ((t3_2.a + t3_2.b) / 2))
-                                       ->  Seq Scan on prt1_p3 t1_2
+                                       ->  Seq Scan on prt1_p2 t1_2
+                                       ->  Hash
+                                             ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                                   Hash Key: ((t3_2.a + t3_2.b) / 2)
+                                                   ->  Seq Scan on prt1_e_p2 t3_2
+                                                         Filter: (c = 0)
+               ->  Hash Right Join
+                     Hash Cond: (t2_3.b = t1_3.a)
+                     ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                           Hash Key: t2_3.b
+                           ->  Seq Scan on prt2_p3 t2_3
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice9; segments: 3)
+                                 Hash Key: t1_3.a
+                                 ->  Hash Right Join
+                                       Hash Cond: (t1_3.a = ((t3_3.a + t3_3.b) / 2))
+                                       ->  Seq Scan on prt1_p3 t1_3
                                        ->  Hash
                                              ->  Redistribute Motion 3:3  (slice10; segments: 3)
-                                                   Hash Key: ((t3_2.a + t3_2.b) / 2)
-                                                   ->  Seq Scan on prt1_e_p3 t3_2
+                                                   Hash Key: ((t3_3.a + t3_3.b) / 2)
+                                                   ->  Seq Scan on prt1_e_p3 t3_3
                                                          Filter: (c = 0)
  Optimizer: Postgres query optimizer
 (54 rows)
-=======
-                     Hash Cond: (t1_1.a = ((t3_1.a + t3_1.b) / 2))
-                     ->  Seq Scan on prt1_p1 t1_1
-                     ->  Hash
-                           ->  Seq Scan on prt1_e_p1 t3_1
-                                 Filter: (c = 0)
-               ->  Index Scan using iprt2_p1_b on prt2_p1 t2_1
-                     Index Cond: (b = t1_1.a)
-         ->  Nested Loop Left Join
-               ->  Hash Right Join
-                     Hash Cond: (t1_2.a = ((t3_2.a + t3_2.b) / 2))
-                     ->  Seq Scan on prt1_p2 t1_2
-                     ->  Hash
-                           ->  Seq Scan on prt1_e_p2 t3_2
-                                 Filter: (c = 0)
-               ->  Index Scan using iprt2_p2_b on prt2_p2 t2_2
-                     Index Cond: (b = t1_2.a)
-         ->  Nested Loop Left Join
-               ->  Hash Right Join
-                     Hash Cond: (t1_3.a = ((t3_3.a + t3_3.b) / 2))
-                     ->  Seq Scan on prt1_p3 t1_3
-                     ->  Hash
-                           ->  Seq Scan on prt1_e_p3 t3_3
-                                 Filter: (c = 0)
-               ->  Index Scan using iprt2_p3_b on prt2_p3 t2_3
-                     Index Cond: (b = t1_3.a)
-(30 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b) RIGHT JOIN prt1_e t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t3.c = 0 ORDER BY t1.a, t2.b, t3.a + t3.b;
   a  |  c   |  b  |  c   | ?column? | c 
@@ -1250,7 +846,6 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2
 -- make sure these go to null as expected
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.phv, t2.b, t2.phv, t3.a + t3.b, t3.phv FROM ((SELECT 50 phv, * FROM prt1 WHERE prt1.b = 0) t1 FULL JOIN (SELECT 75 phv, * FROM prt2 WHERE prt2.a = 0) t2 ON (t1.a = t2.b)) FULL JOIN (SELECT 50 phv, * FROM prt1_e WHERE prt1_e.c = 0) t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t1.a = t1.phv OR t2.b = t2.phv OR (t3.a + t3.b)/2 = t3.phv ORDER BY t1.a, t2.b, t3.a + t3.b;
-<<<<<<< HEAD
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1259,105 +854,58 @@ SELECT t1.a, t1.phv, t2.b, t2.phv, t3.a + t3.b, t3.phv FROM ((SELECT 50 phv, * F
          Sort Key: prt1.a, prt2.b, ((prt1_e.a + prt1_e.b))
          ->  Append
                ->  Hash Full Join
-                     Hash Cond: (((prt1_e.a + prt1_e.b) / 2) = prt1.a)
-                     Filter: ((prt1.a = (50)) OR (prt2.b = (75)) OR (((prt1_e.a + prt1_e.b) / 2) = (50)))
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: ((prt1_e.a + prt1_e.b) / 2)
-                           ->  Seq Scan on prt1_e_p1 prt1_e
-                                 Filter: (c = 0)
-                     ->  Hash
-                           ->  Hash Full Join
-                                 Hash Cond: (prt1.a = prt2.b)
-                                 ->  Seq Scan on prt1_p1 prt1
-                                       Filter: (b = 0)
-                                 ->  Hash
-                                       ->  Redistribute Motion 1:3  (slice3; segments: 1)
-                                             Hash Key: prt2.b
-                                             ->  Seq Scan on prt2_p1 prt2
-                                                   Filter: (a = 0)
-               ->  Hash Full Join
                      Hash Cond: (((prt1_e_1.a + prt1_e_1.b) / 2) = prt1_1.a)
                      Filter: ((prt1_1.a = (50)) OR (prt2_1.b = (75)) OR (((prt1_e_1.a + prt1_e_1.b) / 2) = (50)))
-                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: ((prt1_e_1.a + prt1_e_1.b) / 2)
-                           ->  Seq Scan on prt1_e_p2 prt1_e_1
+                           ->  Seq Scan on prt1_e_p1 prt1_e_1
                                  Filter: (c = 0)
                      ->  Hash
                            ->  Hash Full Join
                                  Hash Cond: (prt1_1.a = prt2_1.b)
-                                 ->  Seq Scan on prt1_p2 prt1_1
+                                 ->  Seq Scan on prt1_p1 prt1_1
+                                       Filter: (b = 0)
+                                 ->  Hash
+                                       ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                                             Hash Key: prt2_1.b
+                                             ->  Seq Scan on prt2_p1 prt2_1
+                                                   Filter: (a = 0)
+               ->  Hash Full Join
+                     Hash Cond: (((prt1_e_2.a + prt1_e_2.b) / 2) = prt1_2.a)
+                     Filter: ((prt1_2.a = (50)) OR (prt2_2.b = (75)) OR (((prt1_e_2.a + prt1_e_2.b) / 2) = (50)))
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: ((prt1_e_2.a + prt1_e_2.b) / 2)
+                           ->  Seq Scan on prt1_e_p2 prt1_e_2
+                                 Filter: (c = 0)
+                     ->  Hash
+                           ->  Hash Full Join
+                                 Hash Cond: (prt1_2.a = prt2_2.b)
+                                 ->  Seq Scan on prt1_p2 prt1_2
                                        Filter: (b = 0)
                                  ->  Hash
                                        ->  Redistribute Motion 1:3  (slice5; segments: 1)
-                                             Hash Key: prt2_1.b
-                                             ->  Seq Scan on prt2_p2 prt2_1
+                                             Hash Key: prt2_2.b
+                                             ->  Seq Scan on prt2_p2 prt2_2
                                                    Filter: (a = 0)
                ->  Hash Full Join
-                     Hash Cond: (prt1_2.a = ((prt1_e_2.a + prt1_e_2.b) / 2))
-                     Filter: ((prt1_2.a = (50)) OR (prt2_2.b = (75)) OR (((prt1_e_2.a + prt1_e_2.b) / 2) = (50)))
+                     Hash Cond: (prt1_3.a = ((prt1_e_3.a + prt1_e_3.b) / 2))
+                     Filter: ((prt1_3.a = (50)) OR (prt2_3.b = (75)) OR (((prt1_e_3.a + prt1_e_3.b) / 2) = (50)))
                      ->  Hash Full Join
-                           Hash Cond: (prt1_2.a = prt2_2.b)
-                           ->  Seq Scan on prt1_p3 prt1_2
+                           Hash Cond: (prt1_3.a = prt2_3.b)
+                           ->  Seq Scan on prt1_p3 prt1_3
                                  Filter: (b = 0)
                            ->  Hash
                                  ->  Redistribute Motion 1:3  (slice6; segments: 1)
-                                       Hash Key: prt2_2.b
-                                       ->  Seq Scan on prt2_p3 prt2_2
+                                       Hash Key: prt2_3.b
+                                       ->  Seq Scan on prt2_p3 prt2_3
                                              Filter: (a = 0)
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice7; segments: 3)
-                                 Hash Key: ((prt1_e_2.a + prt1_e_2.b) / 2)
-                                 ->  Seq Scan on prt1_e_p3 prt1_e_2
+                                 Hash Key: ((prt1_e_3.a + prt1_e_3.b) / 2)
+                                 ->  Seq Scan on prt1_e_p3 prt1_e_3
                                        Filter: (c = 0)
  Optimizer: Postgres query optimizer
 (57 rows)
-=======
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: prt1.a, prt2.b, ((prt1_e.a + prt1_e.b))
-   ->  Append
-         ->  Hash Full Join
-               Hash Cond: (prt1_1.a = ((prt1_e_1.a + prt1_e_1.b) / 2))
-               Filter: ((prt1_1.a = (50)) OR (prt2_1.b = (75)) OR (((prt1_e_1.a + prt1_e_1.b) / 2) = (50)))
-               ->  Hash Full Join
-                     Hash Cond: (prt1_1.a = prt2_1.b)
-                     ->  Seq Scan on prt1_p1 prt1_1
-                           Filter: (b = 0)
-                     ->  Hash
-                           ->  Seq Scan on prt2_p1 prt2_1
-                                 Filter: (a = 0)
-               ->  Hash
-                     ->  Seq Scan on prt1_e_p1 prt1_e_1
-                           Filter: (c = 0)
-         ->  Hash Full Join
-               Hash Cond: (prt1_2.a = ((prt1_e_2.a + prt1_e_2.b) / 2))
-               Filter: ((prt1_2.a = (50)) OR (prt2_2.b = (75)) OR (((prt1_e_2.a + prt1_e_2.b) / 2) = (50)))
-               ->  Hash Full Join
-                     Hash Cond: (prt1_2.a = prt2_2.b)
-                     ->  Seq Scan on prt1_p2 prt1_2
-                           Filter: (b = 0)
-                     ->  Hash
-                           ->  Seq Scan on prt2_p2 prt2_2
-                                 Filter: (a = 0)
-               ->  Hash
-                     ->  Seq Scan on prt1_e_p2 prt1_e_2
-                           Filter: (c = 0)
-         ->  Hash Full Join
-               Hash Cond: (prt1_3.a = ((prt1_e_3.a + prt1_e_3.b) / 2))
-               Filter: ((prt1_3.a = (50)) OR (prt2_3.b = (75)) OR (((prt1_e_3.a + prt1_e_3.b) / 2) = (50)))
-               ->  Hash Full Join
-                     Hash Cond: (prt1_3.a = prt2_3.b)
-                     ->  Seq Scan on prt1_p3 prt1_3
-                           Filter: (b = 0)
-                     ->  Hash
-                           ->  Seq Scan on prt2_p3 prt2_3
-                                 Filter: (a = 0)
-               ->  Hash
-                     ->  Seq Scan on prt1_e_p3 prt1_e_3
-                           Filter: (c = 0)
-(42 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.phv, t2.b, t2.phv, t3.a + t3.b, t3.phv FROM ((SELECT 50 phv, * FROM prt1 WHERE prt1.b = 0) t1 FULL JOIN (SELECT 75 phv, * FROM prt2 WHERE prt2.a = 0) t2 ON (t1.a = t2.b)) FULL JOIN (SELECT 50 phv, * FROM prt1_e WHERE prt1_e.c = 0) t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t1.a = t1.phv OR t2.b = t2.phv OR (t3.a + t3.b)/2 = t3.phv ORDER BY t1.a, t2.b, t3.a + t3.b;
  a  | phv | b  | phv | ?column? | phv 
@@ -1369,7 +917,6 @@ SELECT t1.a, t1.phv, t2.b, t2.phv, t3.a + t3.b, t3.phv FROM ((SELECT 50 phv, * F
 -- Semi-join
 EXPLAIN (COSTS OFF)
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1, prt1_e t2 WHERE t1.a = 0 AND t1.b = (t2.a + t2.b)/2) AND t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1382,105 +929,59 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1, prt1_e t2 WHER
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Nested Loop
-                                 Join Filter: (t1.a = t1_3.b)
+                                 Join Filter: (t1_2.a = t1_5.b)
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: t1_3.b
+                                       Hash Key: t1_5.b
                                        ->  Hash Join
-                                             Hash Cond: (((t2.a + t2.b) / 2) = t1_3.b)
-                                             ->  Seq Scan on prt1_e_p1 t2
+                                             Hash Cond: (((t2_1.a + t2_1.b) / 2) = t1_5.b)
+                                             ->  Seq Scan on prt1_e_p1 t2_1
                                              ->  Hash
                                                    ->  Broadcast Motion 1:3  (slice4; segments: 1)
-                                                         ->  Seq Scan on prt2_p1 t1_3
+                                                         ->  Seq Scan on prt2_p1 t1_5
                                                                Filter: (a = 0)
                                  ->  Materialize
-                                       ->  Index Scan using iprt1_p1_a on prt1_p1 t1
-                                             Index Cond: (a = ((t2.a + t2.b) / 2))
+                                       ->  Index Scan using iprt1_p1_a on prt1_p1 t1_2
+                                             Index Cond: (a = ((t2_1.a + t2_1.b) / 2))
                                              Filter: (b = 0)
                ->  HashAggregate
                      Group Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice5; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Nested Loop
-                                 Join Filter: (t1_1.a = t1_4.b)
+                                 Join Filter: (t1_3.a = t1_6.b)
                                  ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                       Hash Key: t1_4.b
+                                       Hash Key: t1_6.b
                                        ->  Hash Join
-                                             Hash Cond: (((t2_1.a + t2_1.b) / 2) = t1_4.b)
-                                             ->  Seq Scan on prt1_e_p2 t2_1
+                                             Hash Cond: (((t2_2.a + t2_2.b) / 2) = t1_6.b)
+                                             ->  Seq Scan on prt1_e_p2 t2_2
                                              ->  Hash
                                                    ->  Broadcast Motion 1:3  (slice7; segments: 1)
-                                                         ->  Seq Scan on prt2_p2 t1_4
+                                                         ->  Seq Scan on prt2_p2 t1_6
                                                                Filter: (a = 0)
                                  ->  Materialize
-                                       ->  Index Scan using iprt1_p2_a on prt1_p2 t1_1
-                                             Index Cond: (a = ((t2_1.a + t2_1.b) / 2))
+                                       ->  Index Scan using iprt1_p2_a on prt1_p2 t1_3
+                                             Index Cond: (a = ((t2_2.a + t2_2.b) / 2))
                                              Filter: (b = 0)
                ->  Nested Loop
-                     Join Filter: (t1_2.a = t1_5.b)
+                     Join Filter: (t1_4.a = t1_7.b)
                      ->  Redistribute Motion 3:3  (slice8; segments: 3)
-                           Hash Key: t1_5.b
+                           Hash Key: t1_7.b
                            ->  HashAggregate
-                                 Group Key: t1_5.b
+                                 Group Key: t1_7.b
                                  ->  Redistribute Motion 3:3  (slice9; segments: 3)
-                                       Hash Key: t1_5.b
+                                       Hash Key: t1_7.b
                                        ->  Hash Join
-                                             Hash Cond: (((t2_2.a + t2_2.b) / 2) = t1_5.b)
-                                             ->  Seq Scan on prt1_e_p3 t2_2
+                                             Hash Cond: (((t2_3.a + t2_3.b) / 2) = t1_7.b)
+                                             ->  Seq Scan on prt1_e_p3 t2_3
                                              ->  Hash
                                                    ->  Broadcast Motion 1:3  (slice10; segments: 1)
-                                                         ->  Seq Scan on prt2_p3 t1_5
+                                                         ->  Seq Scan on prt2_p3 t1_7
                                                                Filter: (a = 0)
-                     ->  Index Scan using iprt1_p3_a on prt1_p3 t1_2
-                           Index Cond: (a = ((t2_2.a + t2_2.b) / 2))
+                     ->  Index Scan using iprt1_p3_a on prt1_p3 t1_4
+                           Index Cond: (a = ((t2_3.a + t2_3.b) / 2))
                            Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (62 rows)
-=======
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Nested Loop
-               Join Filter: (t1_2.a = t1_5.b)
-               ->  HashAggregate
-                     Group Key: t1_5.b
-                     ->  Hash Join
-                           Hash Cond: (((t2_1.a + t2_1.b) / 2) = t1_5.b)
-                           ->  Seq Scan on prt1_e_p1 t2_1
-                           ->  Hash
-                                 ->  Seq Scan on prt2_p1 t1_5
-                                       Filter: (a = 0)
-               ->  Index Scan using iprt1_p1_a on prt1_p1 t1_2
-                     Index Cond: (a = ((t2_1.a + t2_1.b) / 2))
-                     Filter: (b = 0)
-         ->  Nested Loop
-               Join Filter: (t1_3.a = t1_6.b)
-               ->  HashAggregate
-                     Group Key: t1_6.b
-                     ->  Hash Join
-                           Hash Cond: (((t2_2.a + t2_2.b) / 2) = t1_6.b)
-                           ->  Seq Scan on prt1_e_p2 t2_2
-                           ->  Hash
-                                 ->  Seq Scan on prt2_p2 t1_6
-                                       Filter: (a = 0)
-               ->  Index Scan using iprt1_p2_a on prt1_p2 t1_3
-                     Index Cond: (a = ((t2_2.a + t2_2.b) / 2))
-                     Filter: (b = 0)
-         ->  Nested Loop
-               Join Filter: (t1_4.a = t1_7.b)
-               ->  HashAggregate
-                     Group Key: t1_7.b
-                     ->  Nested Loop
-                           ->  Seq Scan on prt2_p3 t1_7
-                                 Filter: (a = 0)
-                           ->  Index Scan using iprt1_e_p3_ab2 on prt1_e_p3 t2_3
-                                 Index Cond: (((a + b) / 2) = t1_7.b)
-               ->  Index Scan using iprt1_p3_a on prt1_p3 t1_4
-                     Index Cond: (a = ((t2_3.a + t2_3.b) / 2))
-                     Filter: (b = 0)
-(41 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1, prt1_e t2 WHERE t1.a = 0 AND t1.b = (t2.a + t2.b)/2) AND t1.b = 0 ORDER BY t1.a;
   a  | b |  c   
@@ -1493,7 +994,6 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1, prt1_e t2 WHER
 
 EXPLAIN (COSTS OFF)
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (SELECT (t1.a + t1.b)/2 FROM prt1_e t1 WHERE t1.c = 0)) AND t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1507,17 +1007,17 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (
                            Hash Key: (RowIdExpr)
                            ->  Nested Loop
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: t1_3.b
+                                       Hash Key: t1_6.b
                                        ->  Hash Semi Join
-                                             Hash Cond: (t1_3.b = ((t1_6.a + t1_6.b) / 2))
-                                             ->  Seq Scan on prt2_p1 t1_3
+                                             Hash Cond: (t1_6.b = ((t1_9.a + t1_9.b) / 2))
+                                             ->  Seq Scan on prt2_p1 t1_6
                                              ->  Hash
                                                    ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                         ->  Seq Scan on prt1_e_p1 t1_6
+                                                         ->  Seq Scan on prt1_e_p1 t1_9
                                                                Filter: (c = 0)
                                  ->  Materialize
-                                       ->  Index Scan using iprt1_p1_a on prt1_p1 t1
-                                             Index Cond: (a = t1_3.b)
+                                       ->  Index Scan using iprt1_p1_a on prt1_p1 t1_3
+                                             Index Cond: (a = t1_6.b)
                                              Filter: (b = 0)
                ->  HashAggregate
                      Group Key: (RowIdExpr)
@@ -1525,17 +1025,17 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (
                            Hash Key: (RowIdExpr)
                            ->  Nested Loop
                                  ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                       Hash Key: t1_4.b
+                                       Hash Key: t1_7.b
                                        ->  Hash Semi Join
-                                             Hash Cond: (t1_4.b = ((t1_7.a + t1_7.b) / 2))
-                                             ->  Seq Scan on prt2_p2 t1_4
+                                             Hash Cond: (t1_7.b = ((t1_10.a + t1_10.b) / 2))
+                                             ->  Seq Scan on prt2_p2 t1_7
                                              ->  Hash
                                                    ->  Broadcast Motion 3:3  (slice7; segments: 3)
-                                                         ->  Seq Scan on prt1_e_p2 t1_7
+                                                         ->  Seq Scan on prt1_e_p2 t1_10
                                                                Filter: (c = 0)
                                  ->  Materialize
-                                       ->  Index Scan using iprt1_p2_a on prt1_p2 t1_1
-                                             Index Cond: (a = t1_4.b)
+                                       ->  Index Scan using iprt1_p2_a on prt1_p2 t1_4
+                                             Index Cond: (a = t1_7.b)
                                              Filter: (b = 0)
                ->  HashAggregate
                      Group Key: (RowIdExpr)
@@ -1543,64 +1043,20 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (
                            Hash Key: (RowIdExpr)
                            ->  Nested Loop
                                  ->  Redistribute Motion 3:3  (slice9; segments: 3)
-                                       Hash Key: t1_5.b
+                                       Hash Key: t1_8.b
                                        ->  Hash Semi Join
-                                             Hash Cond: (t1_5.b = ((t1_8.a + t1_8.b) / 2))
-                                             ->  Seq Scan on prt2_p3 t1_5
+                                             Hash Cond: (t1_8.b = ((t1_11.a + t1_11.b) / 2))
+                                             ->  Seq Scan on prt2_p3 t1_8
                                              ->  Hash
                                                    ->  Broadcast Motion 3:3  (slice10; segments: 3)
-                                                         ->  Seq Scan on prt1_e_p3 t1_8
+                                                         ->  Seq Scan on prt1_e_p3 t1_11
                                                                Filter: (c = 0)
                                  ->  Materialize
-                                       ->  Index Scan using iprt1_p3_a on prt1_p3 t1_2
-                                             Index Cond: (a = t1_5.b)
+                                       ->  Index Scan using iprt1_p3_a on prt1_p3 t1_5
+                                             Index Cond: (a = t1_8.b)
                                              Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (60 rows)
-=======
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Nested Loop
-               ->  HashAggregate
-                     Group Key: t1_6.b
-                     ->  Hash Semi Join
-                           Hash Cond: (t1_6.b = ((t1_9.a + t1_9.b) / 2))
-                           ->  Seq Scan on prt2_p1 t1_6
-                           ->  Hash
-                                 ->  Seq Scan on prt1_e_p1 t1_9
-                                       Filter: (c = 0)
-               ->  Index Scan using iprt1_p1_a on prt1_p1 t1_3
-                     Index Cond: (a = t1_6.b)
-                     Filter: (b = 0)
-         ->  Nested Loop
-               ->  HashAggregate
-                     Group Key: t1_7.b
-                     ->  Hash Semi Join
-                           Hash Cond: (t1_7.b = ((t1_10.a + t1_10.b) / 2))
-                           ->  Seq Scan on prt2_p2 t1_7
-                           ->  Hash
-                                 ->  Seq Scan on prt1_e_p2 t1_10
-                                       Filter: (c = 0)
-               ->  Index Scan using iprt1_p2_a on prt1_p2 t1_4
-                     Index Cond: (a = t1_7.b)
-                     Filter: (b = 0)
-         ->  Nested Loop
-               ->  HashAggregate
-                     Group Key: t1_8.b
-                     ->  Hash Semi Join
-                           Hash Cond: (t1_8.b = ((t1_11.a + t1_11.b) / 2))
-                           ->  Seq Scan on prt2_p3 t1_8
-                           ->  Hash
-                                 ->  Seq Scan on prt1_e_p3 t1_11
-                                       Filter: (c = 0)
-               ->  Index Scan using iprt1_p3_a on prt1_p3 t1_5
-                     Index Cond: (a = t1_8.b)
-                     Filter: (b = 0)
-(39 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (SELECT (t1.a + t1.b)/2 FROM prt1_e t1 WHERE t1.c = 0)) AND t1.b = 0 ORDER BY t1.a;
   a  | b |  c   
@@ -1616,7 +1072,6 @@ SET enable_hashjoin TO off;
 SET enable_nestloop TO off;
 EXPLAIN (COSTS OFF)
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (SELECT (t1.a + t1.b)/2 FROM prt1_e t1 WHERE t1.c = 0)) AND t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1629,121 +1084,69 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Merge Join
-                                 Merge Cond: (t1_3.b = t1.a)
+                                 Merge Cond: (t1_6.b = t1_3.a)
                                  ->  Merge Semi Join
-                                       Merge Cond: (t1_3.b = (((t1_6.a + t1_6.b) / 2)))
+                                       Merge Cond: (t1_6.b = (((t1_9.a + t1_9.b) / 2)))
                                        ->  Sort
-                                             Sort Key: t1_3.b
-                                             ->  Seq Scan on prt2_p1 t1_3
+                                             Sort Key: t1_6.b
+                                             ->  Seq Scan on prt2_p1 t1_6
                                        ->  Sort
-                                             Sort Key: (((t1_6.a + t1_6.b) / 2))
+                                             Sort Key: (((t1_9.a + t1_9.b) / 2))
                                              ->  Result
                                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                         ->  Seq Scan on prt1_e_p1 t1_6
+                                                         ->  Seq Scan on prt1_e_p1 t1_9
                                                                Filter: (c = 0)
                                  ->  Sort
-                                       Sort Key: t1.a
+                                       Sort Key: t1_3.a
                                        ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                             ->  Seq Scan on prt1_p1 t1
+                                             ->  Seq Scan on prt1_p1 t1_3
                                                    Filter: (b = 0)
                ->  HashAggregate
                      Group Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice5; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Merge Join
-                                 Merge Cond: (t1_4.b = t1_1.a)
+                                 Merge Cond: (t1_7.b = t1_4.a)
                                  ->  Merge Semi Join
-                                       Merge Cond: (t1_4.b = (((t1_7.a + t1_7.b) / 2)))
+                                       Merge Cond: (t1_7.b = (((t1_10.a + t1_10.b) / 2)))
                                        ->  Sort
-                                             Sort Key: t1_4.b
-                                             ->  Seq Scan on prt2_p2 t1_4
+                                             Sort Key: t1_7.b
+                                             ->  Seq Scan on prt2_p2 t1_7
                                        ->  Sort
-                                             Sort Key: (((t1_7.a + t1_7.b) / 2))
+                                             Sort Key: (((t1_10.a + t1_10.b) / 2))
                                              ->  Result
                                                    ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                                         ->  Seq Scan on prt1_e_p2 t1_7
+                                                         ->  Seq Scan on prt1_e_p2 t1_10
                                                                Filter: (c = 0)
                                  ->  Sort
-                                       Sort Key: t1_1.a
+                                       Sort Key: t1_4.a
                                        ->  Broadcast Motion 3:3  (slice7; segments: 3)
-                                             ->  Seq Scan on prt1_p2 t1_1
+                                             ->  Seq Scan on prt1_p2 t1_4
                                                    Filter: (b = 0)
                ->  HashAggregate
                      Group Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice8; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Merge Join
-                                 Merge Cond: (t1_5.b = t1_2.a)
+                                 Merge Cond: (t1_8.b = t1_5.a)
                                  ->  Merge Semi Join
-                                       Merge Cond: (t1_5.b = (((t1_8.a + t1_8.b) / 2)))
+                                       Merge Cond: (t1_8.b = (((t1_11.a + t1_11.b) / 2)))
                                        ->  Sort
-                                             Sort Key: t1_5.b
-                                             ->  Seq Scan on prt2_p3 t1_5
+                                             Sort Key: t1_8.b
+                                             ->  Seq Scan on prt2_p3 t1_8
                                        ->  Sort
-                                             Sort Key: (((t1_8.a + t1_8.b) / 2))
+                                             Sort Key: (((t1_11.a + t1_11.b) / 2))
                                              ->  Result
                                                    ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                                                         ->  Seq Scan on prt1_e_p3 t1_8
+                                                         ->  Seq Scan on prt1_e_p3 t1_11
                                                                Filter: (c = 0)
                                  ->  Sort
-                                       Sort Key: t1_2.a
+                                       Sort Key: t1_5.a
                                        ->  Broadcast Motion 3:3  (slice10; segments: 3)
-                                             ->  Seq Scan on prt1_p3 t1_2
+                                             ->  Seq Scan on prt1_p3 t1_5
                                                    Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (72 rows)
-=======
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Merge Append
-   Sort Key: t1.a
-   ->  Merge Semi Join
-         Merge Cond: (t1_3.a = t1_6.b)
-         ->  Sort
-               Sort Key: t1_3.a
-               ->  Seq Scan on prt1_p1 t1_3
-                     Filter: (b = 0)
-         ->  Merge Semi Join
-               Merge Cond: (t1_6.b = (((t1_9.a + t1_9.b) / 2)))
-               ->  Sort
-                     Sort Key: t1_6.b
-                     ->  Seq Scan on prt2_p1 t1_6
-               ->  Sort
-                     Sort Key: (((t1_9.a + t1_9.b) / 2))
-                     ->  Seq Scan on prt1_e_p1 t1_9
-                           Filter: (c = 0)
-   ->  Merge Semi Join
-         Merge Cond: (t1_4.a = t1_7.b)
-         ->  Sort
-               Sort Key: t1_4.a
-               ->  Seq Scan on prt1_p2 t1_4
-                     Filter: (b = 0)
-         ->  Merge Semi Join
-               Merge Cond: (t1_7.b = (((t1_10.a + t1_10.b) / 2)))
-               ->  Sort
-                     Sort Key: t1_7.b
-                     ->  Seq Scan on prt2_p2 t1_7
-               ->  Sort
-                     Sort Key: (((t1_10.a + t1_10.b) / 2))
-                     ->  Seq Scan on prt1_e_p2 t1_10
-                           Filter: (c = 0)
-   ->  Merge Semi Join
-         Merge Cond: (t1_5.a = t1_8.b)
-         ->  Sort
-               Sort Key: t1_5.a
-               ->  Seq Scan on prt1_p3 t1_5
-                     Filter: (b = 0)
-         ->  Merge Semi Join
-               Merge Cond: (t1_8.b = (((t1_11.a + t1_11.b) / 2)))
-               ->  Sort
-                     Sort Key: t1_8.b
-                     ->  Seq Scan on prt2_p3 t1_8
-               ->  Sort
-                     Sort Key: (((t1_11.a + t1_11.b) / 2))
-                     ->  Seq Scan on prt1_e_p3 t1_11
-                           Filter: (c = 0)
-(47 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (SELECT (t1.a + t1.b)/2 FROM prt1_e t1 WHERE t1.c = 0)) AND t1.b = 0 ORDER BY t1.a;
   a  | b |  c   
@@ -1756,7 +1159,6 @@ SELECT t1.* FROM prt1 t1 WHERE t1.a IN (SELECT t1.b FROM prt2 t1 WHERE t1.b IN (
 
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b) RIGHT JOIN prt1_e t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t3.c = 0 ORDER BY t1.a, t2.b, t3.a + t3.b;
-<<<<<<< HEAD
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1765,128 +1167,72 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2
          Sort Key: t1.a, t2.b, ((t3.a + t3.b))
          ->  Append
                ->  Merge Left Join
-                     Merge Cond: (t1.a = t2.b)
-                     ->  Sort
-                           Sort Key: t1.a
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: t1.a
-                                 ->  Merge Left Join
-                                       Merge Cond: ((((t3.a + t3.b) / 2)) = t1.a)
-                                       ->  Sort
-                                             Sort Key: (((t3.a + t3.b) / 2))
-                                             ->  Result
-                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                                         Hash Key: ((t3.a + t3.b) / 2)
-                                                         ->  Seq Scan on prt1_e_p1 t3
-                                                               Filter: (c = 0)
-                                       ->  Sort
-                                             Sort Key: t1.a
-                                             ->  Seq Scan on prt1_p1 t1
-                     ->  Sort
-                           Sort Key: t2.b
-                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: t2.b
-                                 ->  Seq Scan on prt2_p1 t2
-               ->  Merge Left Join
                      Merge Cond: (t1_1.a = t2_1.b)
                      ->  Sort
                            Sort Key: t1_1.a
-                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: t1_1.a
                                  ->  Merge Left Join
                                        Merge Cond: ((((t3_1.a + t3_1.b) / 2)) = t1_1.a)
                                        ->  Sort
                                              Sort Key: (((t3_1.a + t3_1.b) / 2))
                                              ->  Result
-                                                   ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                                          Hash Key: ((t3_1.a + t3_1.b) / 2)
-                                                         ->  Seq Scan on prt1_e_p2 t3_1
+                                                         ->  Seq Scan on prt1_e_p1 t3_1
                                                                Filter: (c = 0)
                                        ->  Sort
                                              Sort Key: t1_1.a
-                                             ->  Seq Scan on prt1_p2 t1_1
+                                             ->  Seq Scan on prt1_p1 t1_1
                      ->  Sort
                            Sort Key: t2_1.b
-                           ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
                                  Hash Key: t2_1.b
-                                 ->  Seq Scan on prt2_p2 t2_1
-               ->  Merge Right Join
-                     Merge Cond: (t1_2.a = (((t3_2.a + t3_2.b) / 2)))
-                     ->  Merge Left Join
-                           Merge Cond: (t1_2.a = t2_2.b)
-                           ->  Sort
-                                 Sort Key: t1_2.a
-                                 ->  Seq Scan on prt1_p3 t1_2
-                           ->  Sort
-                                 Sort Key: t2_2.b
-                                 ->  Redistribute Motion 3:3  (slice8; segments: 3)
-                                       Hash Key: t2_2.b
-                                       ->  Seq Scan on prt2_p3 t2_2
+                                 ->  Seq Scan on prt2_p1 t2_1
+               ->  Merge Left Join
+                     Merge Cond: (t1_2.a = t2_2.b)
                      ->  Sort
-                           Sort Key: (((t3_2.a + t3_2.b) / 2))
-                           ->  Result
-                                 ->  Redistribute Motion 3:3  (slice9; segments: 3)
-                                       Hash Key: ((t3_2.a + t3_2.b) / 2)
-                                       ->  Seq Scan on prt1_e_p3 t3_2
-                                             Filter: (c = 0)
- Optimizer: Postgres query optimizer
-(71 rows)
-=======
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b, ((t3.a + t3.b))
-   ->  Append
-         ->  Merge Left Join
-               Merge Cond: (t1_1.a = t2_1.b)
-               ->  Sort
-                     Sort Key: t1_1.a
+                           Sort Key: t1_2.a
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 Hash Key: t1_2.a
+                                 ->  Merge Left Join
+                                       Merge Cond: ((((t3_2.a + t3_2.b) / 2)) = t1_2.a)
+                                       ->  Sort
+                                             Sort Key: (((t3_2.a + t3_2.b) / 2))
+                                             ->  Result
+                                                   ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                                         Hash Key: ((t3_2.a + t3_2.b) / 2)
+                                                         ->  Seq Scan on prt1_e_p2 t3_2
+                                                               Filter: (c = 0)
+                                       ->  Sort
+                                             Sort Key: t1_2.a
+                                             ->  Seq Scan on prt1_p2 t1_2
+                     ->  Sort
+                           Sort Key: t2_2.b
+                           ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                 Hash Key: t2_2.b
+                                 ->  Seq Scan on prt2_p2 t2_2
+               ->  Merge Right Join
+                     Merge Cond: (t1_3.a = (((t3_3.a + t3_3.b) / 2)))
                      ->  Merge Left Join
-                           Merge Cond: ((((t3_1.a + t3_1.b) / 2)) = t1_1.a)
-                           ->  Sort
-                                 Sort Key: (((t3_1.a + t3_1.b) / 2))
-                                 ->  Seq Scan on prt1_e_p1 t3_1
-                                       Filter: (c = 0)
-                           ->  Sort
-                                 Sort Key: t1_1.a
-                                 ->  Seq Scan on prt1_p1 t1_1
-               ->  Sort
-                     Sort Key: t2_1.b
-                     ->  Seq Scan on prt2_p1 t2_1
-         ->  Merge Left Join
-               Merge Cond: (t1_2.a = t2_2.b)
-               ->  Sort
-                     Sort Key: t1_2.a
-                     ->  Merge Left Join
-                           Merge Cond: ((((t3_2.a + t3_2.b) / 2)) = t1_2.a)
-                           ->  Sort
-                                 Sort Key: (((t3_2.a + t3_2.b) / 2))
-                                 ->  Seq Scan on prt1_e_p2 t3_2
-                                       Filter: (c = 0)
-                           ->  Sort
-                                 Sort Key: t1_2.a
-                                 ->  Seq Scan on prt1_p2 t1_2
-               ->  Sort
-                     Sort Key: t2_2.b
-                     ->  Seq Scan on prt2_p2 t2_2
-         ->  Merge Left Join
-               Merge Cond: (t1_3.a = t2_3.b)
-               ->  Sort
-                     Sort Key: t1_3.a
-                     ->  Merge Left Join
-                           Merge Cond: ((((t3_3.a + t3_3.b) / 2)) = t1_3.a)
-                           ->  Sort
-                                 Sort Key: (((t3_3.a + t3_3.b) / 2))
-                                 ->  Seq Scan on prt1_e_p3 t3_3
-                                       Filter: (c = 0)
+                           Merge Cond: (t1_3.a = t2_3.b)
                            ->  Sort
                                  Sort Key: t1_3.a
                                  ->  Seq Scan on prt1_p3 t1_3
-               ->  Sort
-                     Sort Key: t2_3.b
-                     ->  Seq Scan on prt2_p3 t2_3
-(51 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                           ->  Sort
+                                 Sort Key: t2_3.b
+                                 ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                                       Hash Key: t2_3.b
+                                       ->  Seq Scan on prt2_p3 t2_3
+                     ->  Sort
+                           Sort Key: (((t3_3.a + t3_3.b) / 2))
+                           ->  Result
+                                 ->  Redistribute Motion 3:3  (slice9; segments: 3)
+                                       Hash Key: ((t3_3.a + t3_3.b) / 2)
+                                       ->  Seq Scan on prt1_e_p3 t3_3
+                                             Filter: (c = 0)
+ Optimizer: Postgres query optimizer
+(71 rows)
 
 SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2 ON t1.a = t2.b) RIGHT JOIN prt1_e t3 ON (t1.a = (t3.a + t3.b)/2) WHERE t3.c = 0 ORDER BY t1.a, t2.b, t3.a + t3.b;
   a  |  c   |  b  |  c   | ?column? | c 
@@ -1909,7 +1255,6 @@ SELECT t1.a, t1.c, t2.b, t2.c, t3.a + t3.b, t3.c FROM (prt1 t1 LEFT JOIN prt2 t2
 -- This should generate a partitionwise join, but currently fails to
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t2.b FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JOIN (SELECT * FROM prt2 WHERE b > 250) t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1921,44 +1266,21 @@ SELECT t1.a, t2.b FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JOIN (SELECT *
                ->  Sort
                      Sort Key: prt1.a
                      ->  Append
-                           ->  Seq Scan on prt1_p1 prt1
+                           ->  Seq Scan on prt1_p1 prt1_1
                                  Filter: ((a < 450) AND (b = 0))
-                           ->  Seq Scan on prt1_p2 prt1_1
+                           ->  Seq Scan on prt1_p2 prt1_2
                                  Filter: ((a < 450) AND (b = 0))
                ->  Sort
                      Sort Key: prt2.b
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: prt2.b
                            ->  Append
-                                 ->  Seq Scan on prt2_p2 prt2
+                                 ->  Seq Scan on prt2_p2 prt2_1
                                        Filter: (b > 250)
-                                 ->  Seq Scan on prt2_p3 prt2_1
+                                 ->  Seq Scan on prt2_p3 prt2_2
                                        Filter: (b > 250)
  Optimizer: Postgres query optimizer
 (23 rows)
-=======
-                        QUERY PLAN                         
------------------------------------------------------------
- Sort
-   Sort Key: prt1.a, prt2.b
-   ->  Merge Left Join
-         Merge Cond: (prt1.a = prt2.b)
-         ->  Sort
-               Sort Key: prt1.a
-               ->  Append
-                     ->  Seq Scan on prt1_p1 prt1_1
-                           Filter: ((a < 450) AND (b = 0))
-                     ->  Seq Scan on prt1_p2 prt1_2
-                           Filter: ((a < 450) AND (b = 0))
-         ->  Sort
-               Sort Key: prt2.b
-               ->  Append
-                     ->  Seq Scan on prt2_p2 prt2_1
-                           Filter: (b > 250)
-                     ->  Seq Scan on prt2_p3 prt2_2
-                           Filter: (b > 250)
-(18 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t2.b FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JOIN (SELECT * FROM prt2 WHERE b > 250) t2 ON t1.a = t2.b WHERE t1.b = 0 ORDER BY t1.a, t2.b;
   a  |  b  
@@ -1978,7 +1300,6 @@ SELECT t1.a, t2.b FROM (SELECT * FROM prt1 WHERE a < 450) t1 LEFT JOIN (SELECT *
 -- partitionwise join does not apply
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t2.b FROM prt1 t1, prt2 t2 WHERE t1::text = t2::text AND t1.a = t2.b ORDER BY t1.a;
-<<<<<<< HEAD
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1990,9 +1311,9 @@ SELECT t1.a, t2.b FROM prt1 t1, prt2 t2 WHERE t1::text = t2::text AND t1.a = t2.
                ->  Result
                      ->  Append
                            Partition Selectors: $0
-                           ->  Seq Scan on prt1_p1 t1
-                           ->  Seq Scan on prt1_p2 t1_1
-                           ->  Seq Scan on prt1_p3 t1_2
+                           ->  Seq Scan on prt1_p1 t1_1
+                           ->  Seq Scan on prt1_p2 t1_2
+                           ->  Seq Scan on prt1_p3 t1_3
          ->  Sort
                Sort Key: t2.b, ((((t2.*)::prt2))::text)
                ->  Result
@@ -2000,32 +1321,11 @@ SELECT t1.a, t2.b FROM prt1 t1, prt2 t2 WHERE t1::text = t2::text AND t1.a = t2.
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: t2.b
                                  ->  Append
-                                       ->  Seq Scan on prt2_p1 t2
-                                       ->  Seq Scan on prt2_p2 t2_1
-                                       ->  Seq Scan on prt2_p3 t2_2
+                                       ->  Seq Scan on prt2_p1 t2_1
+                                       ->  Seq Scan on prt2_p2 t2_2
+                                       ->  Seq Scan on prt2_p3 t2_3
  Optimizer: Postgres query optimizer
 (23 rows)
-=======
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Merge Join
-   Merge Cond: ((t1.a = t2.b) AND (((((t1.*)::prt1))::text) = ((((t2.*)::prt2))::text)))
-   ->  Sort
-         Sort Key: t1.a, ((((t1.*)::prt1))::text)
-         ->  Result
-               ->  Append
-                     ->  Seq Scan on prt1_p1 t1_1
-                     ->  Seq Scan on prt1_p2 t1_2
-                     ->  Seq Scan on prt1_p3 t1_3
-   ->  Sort
-         Sort Key: t2.b, ((((t2.*)::prt2))::text)
-         ->  Result
-               ->  Append
-                     ->  Seq Scan on prt2_p1 t2_1
-                     ->  Seq Scan on prt2_p2 t2_2
-                     ->  Seq Scan on prt2_p3 t2_3
-(16 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t2.b FROM prt1 t1, prt2 t2 WHERE t1::text = t2::text AND t1.a = t2.b ORDER BY t1.a;
  a  | b  
@@ -2056,7 +1356,6 @@ INSERT INTO prt2_m SELECT i, i, i % 25 FROM generate_series(0, 599, 3) i;
 ANALYZE prt2_m;
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_m WHERE prt1_m.c = 0) t1 FULL JOIN (SELECT * FROM prt2_m WHERE prt2_m.c = 0) t2 ON (t1.a = (t2.b + t2.a)/2 AND t2.b = (t1.a + t1.b)/2) ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2065,58 +1364,31 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_m WHERE prt1_m.c = 0) t1 
          Sort Key: prt1_m.a, prt2_m.b
          ->  Append
                ->  Hash Full Join
-                     Hash Cond: ((prt1_m.a = ((prt2_m.b + prt2_m.a) / 2)) AND (((prt1_m.a + prt1_m.b) / 2) = prt2_m.b))
-                     ->  Seq Scan on prt1_m_p1 prt1_m
+                     Hash Cond: ((prt1_m_1.a = ((prt2_m_1.b + prt2_m_1.a) / 2)) AND (((prt1_m_1.a + prt1_m_1.b) / 2) = prt2_m_1.b))
+                     ->  Seq Scan on prt1_m_p1 prt1_m_1
                            Filter: (c = 0)
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: ((prt2_m.b + prt2_m.a) / 2)
-                                 ->  Seq Scan on prt2_m_p1 prt2_m
-                                       Filter: (c = 0)
-               ->  Hash Full Join
-                     Hash Cond: ((prt1_m_1.a = ((prt2_m_1.b + prt2_m_1.a) / 2)) AND (((prt1_m_1.a + prt1_m_1.b) / 2) = prt2_m_1.b))
-                     ->  Seq Scan on prt1_m_p2 prt1_m_1
-                           Filter: (c = 0)
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                  Hash Key: ((prt2_m_1.b + prt2_m_1.a) / 2)
-                                 ->  Seq Scan on prt2_m_p2 prt2_m_1
+                                 ->  Seq Scan on prt2_m_p1 prt2_m_1
                                        Filter: (c = 0)
                ->  Hash Full Join
                      Hash Cond: ((prt1_m_2.a = ((prt2_m_2.b + prt2_m_2.a) / 2)) AND (((prt1_m_2.a + prt1_m_2.b) / 2) = prt2_m_2.b))
-                     ->  Seq Scan on prt1_m_p3 prt1_m_2
-=======
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: prt1_m.a, prt2_m.b
-   ->  Append
-         ->  Hash Full Join
-               Hash Cond: ((prt1_m_1.a = ((prt2_m_1.b + prt2_m_1.a) / 2)) AND (((prt1_m_1.a + prt1_m_1.b) / 2) = prt2_m_1.b))
-               ->  Seq Scan on prt1_m_p1 prt1_m_1
-                     Filter: (c = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_m_p1 prt2_m_1
+                     ->  Seq Scan on prt1_m_p2 prt1_m_2
                            Filter: (c = 0)
-         ->  Hash Full Join
-               Hash Cond: ((prt1_m_2.a = ((prt2_m_2.b + prt2_m_2.a) / 2)) AND (((prt1_m_2.a + prt1_m_2.b) / 2) = prt2_m_2.b))
-               ->  Seq Scan on prt1_m_p2 prt1_m_2
-                     Filter: (c = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_m_p2 prt2_m_2
-                           Filter: (c = 0)
-         ->  Hash Full Join
-               Hash Cond: ((prt1_m_3.a = ((prt2_m_3.b + prt2_m_3.a) / 2)) AND (((prt1_m_3.a + prt1_m_3.b) / 2) = prt2_m_3.b))
-               ->  Seq Scan on prt1_m_p3 prt1_m_3
-                     Filter: (c = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_m_p3 prt2_m_3
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: ((prt2_m_2.b + prt2_m_2.a) / 2)
+                                 ->  Seq Scan on prt2_m_p2 prt2_m_2
+                                       Filter: (c = 0)
+               ->  Hash Full Join
+                     Hash Cond: ((prt1_m_3.a = ((prt2_m_3.b + prt2_m_3.a) / 2)) AND (((prt1_m_3.a + prt1_m_3.b) / 2) = prt2_m_3.b))
+                     ->  Seq Scan on prt1_m_p3 prt1_m_3
                            Filter: (c = 0)
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: ((prt2_m_2.b + prt2_m_2.a) / 2)
-                                 ->  Seq Scan on prt2_m_p3 prt2_m_2
+                                 Hash Key: ((prt2_m_3.b + prt2_m_3.a) / 2)
+                                 ->  Seq Scan on prt2_m_p3 prt2_m_3
                                        Filter: (c = 0)
  Optimizer: Postgres query optimizer
 (33 rows)
@@ -2169,7 +1441,6 @@ ANALYZE plt1_e;
 -- test partition matching with N-way join
 EXPLAIN (COSTS OFF)
 SELECT avg(t1.a), avg(t2.b), avg(t3.a + t3.b), t1.c, t2.c, t3.c FROM plt1 t1, plt2 t2, plt1_e t3 WHERE t1.b = t2.b AND t1.c = t2.c AND ltrim(t3.c, 'A') = t1.c GROUP BY t1.c, t2.c, t3.c ORDER BY t1.c, t2.c, t3.c;
-<<<<<<< HEAD
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2182,77 +1453,40 @@ SELECT avg(t1.a), avg(t2.b), avg(t3.a + t3.b), t1.c, t2.c, t3.c FROM plt1 t1, pl
                      Hash Key: t1.c, t1.c, t3.c
                      ->  Append
                            ->  Hash Join
-                                 Hash Cond: (ltrim(t3.c, 'A'::text) = t1.c)
-                                 ->  Seq Scan on plt1_e_p1 t3
+                                 Hash Cond: (ltrim(t3_1.c, 'A'::text) = t1_1.c)
+                                 ->  Seq Scan on plt1_e_p1 t3_1
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                              ->  Hash Join
-                                                   Hash Cond: ((t2.b = t1.b) AND (t2.c = t1.c))
+                                                   Hash Cond: ((t2_1.b = t1_1.b) AND (t2_1.c = t1_1.c))
                                                    ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                         ->  Seq Scan on plt2_p1 t2
+                                                         ->  Seq Scan on plt2_p1 t2_1
                                                    ->  Hash
-                                                         ->  Seq Scan on plt1_p1 t1
+                                                         ->  Seq Scan on plt1_p1 t1_1
                            ->  Hash Join
-                                 Hash Cond: (ltrim(t3_1.c, 'A'::text) = t1_1.c)
-                                 ->  Seq Scan on plt1_e_p2 t3_1
+                                 Hash Cond: (ltrim(t3_2.c, 'A'::text) = t1_2.c)
+                                 ->  Seq Scan on plt1_e_p2 t3_2
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice5; segments: 3)
                                              ->  Hash Join
-                                                   Hash Cond: ((t2_1.b = t1_1.b) AND (t2_1.c = t1_1.c))
+                                                   Hash Cond: ((t2_2.b = t1_2.b) AND (t2_2.c = t1_2.c))
                                                    ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                                         ->  Seq Scan on plt2_p2 t2_1
+                                                         ->  Seq Scan on plt2_p2 t2_2
                                                    ->  Hash
-                                                         ->  Seq Scan on plt1_p2 t1_1
+                                                         ->  Seq Scan on plt1_p2 t1_2
                            ->  Hash Join
-                                 Hash Cond: (ltrim(t3_2.c, 'A'::text) = t1_2.c)
-                                 ->  Seq Scan on plt1_e_p3 t3_2
+                                 Hash Cond: (ltrim(t3_3.c, 'A'::text) = t1_3.c)
+                                 ->  Seq Scan on plt1_e_p3 t3_3
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice7; segments: 3)
                                              ->  Hash Join
-                                                   Hash Cond: ((t2_2.b = t1_2.b) AND (t2_2.c = t1_2.c))
+                                                   Hash Cond: ((t2_3.b = t1_3.b) AND (t2_3.c = t1_3.c))
                                                    ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                                                         ->  Seq Scan on plt2_p3 t2_2
+                                                         ->  Seq Scan on plt2_p3 t2_3
                                                    ->  Hash
-                                                         ->  Seq Scan on plt1_p3 t1_2
+                                                         ->  Seq Scan on plt1_p3 t1_3
  Optimizer: Postgres query optimizer
 (43 rows)
-=======
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- GroupAggregate
-   Group Key: t1.c, t2.c, t3.c
-   ->  Sort
-         Sort Key: t1.c, t3.c
-         ->  Append
-               ->  Hash Join
-                     Hash Cond: (t1_1.c = ltrim(t3_1.c, 'A'::text))
-                     ->  Hash Join
-                           Hash Cond: ((t1_1.b = t2_1.b) AND (t1_1.c = t2_1.c))
-                           ->  Seq Scan on plt1_p1 t1_1
-                           ->  Hash
-                                 ->  Seq Scan on plt2_p1 t2_1
-                     ->  Hash
-                           ->  Seq Scan on plt1_e_p1 t3_1
-               ->  Hash Join
-                     Hash Cond: (t1_2.c = ltrim(t3_2.c, 'A'::text))
-                     ->  Hash Join
-                           Hash Cond: ((t1_2.b = t2_2.b) AND (t1_2.c = t2_2.c))
-                           ->  Seq Scan on plt1_p2 t1_2
-                           ->  Hash
-                                 ->  Seq Scan on plt2_p2 t2_2
-                     ->  Hash
-                           ->  Seq Scan on plt1_e_p2 t3_2
-               ->  Hash Join
-                     Hash Cond: (t1_3.c = ltrim(t3_3.c, 'A'::text))
-                     ->  Hash Join
-                           Hash Cond: ((t1_3.b = t2_3.b) AND (t1_3.c = t2_3.c))
-                           ->  Seq Scan on plt1_p3 t1_3
-                           ->  Hash
-                                 ->  Seq Scan on plt2_p3 t2_3
-                     ->  Hash
-                           ->  Seq Scan on plt1_e_p3 t3_3
-(32 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT avg(t1.a), avg(t2.b), avg(t3.a + t3.b), t1.c, t2.c, t3.c FROM plt1 t1, plt2 t2, plt1_e t3 WHERE t1.b = t2.b AND t1.c = t2.c AND ltrim(t3.c, 'A') = t1.c GROUP BY t1.c, t2.c, t3.c ORDER BY t1.c, t2.c, t3.c;
          avg          |         avg          |          avg          |  c   |  c   |   c   
@@ -2290,7 +1524,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a = 1 AND a = 2) t1
 
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a = 1 AND a = 2) t1 RIGHT JOIN prt2 t2 ON t1.a = t2.b, prt1 t3 WHERE t2.b = t3.a;
-<<<<<<< HEAD
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2298,68 +1531,26 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a = 1 AND a = 2) t1
          Hash Cond: (t2.b = a)
          ->  Append
                ->  Hash Join
-                     Hash Cond: (t3.a = t2.b)
-                     ->  Seq Scan on prt1_p1 t3
+                     Hash Cond: (t3_1.a = t2_1.b)
+                     ->  Seq Scan on prt1_p1 t3_1
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: t2.b
-                                 ->  Seq Scan on prt2_p1 t2
-               ->  Hash Join
-                     Hash Cond: (t3_1.a = t2_1.b)
-                     ->  Seq Scan on prt1_p2 t3_1
-                     ->  Hash
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                  Hash Key: t2_1.b
-                                 ->  Seq Scan on prt2_p2 t2_1
+                                 ->  Seq Scan on prt2_p1 t2_1
                ->  Hash Join
                      Hash Cond: (t3_2.a = t2_2.b)
-                     ->  Seq Scan on prt1_p3 t3_2
+                     ->  Seq Scan on prt1_p2 t3_2
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: t2_2.b
+                                 ->  Seq Scan on prt2_p2 t2_2
+               ->  Hash Join
+                     Hash Cond: (t3_3.a = t2_3.b)
+                     ->  Seq Scan on prt1_p3 t3_3
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                 Hash Key: t2_2.b
-                                 ->  Seq Scan on prt2_p3 t2_2
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Hash Left Join
-   Hash Cond: (t2.b = a)
-   ->  Append
-         ->  Hash Join
-               Hash Cond: (t3_1.a = t2_1.b)
-               ->  Seq Scan on prt1_p1 t3_1
-               ->  Hash
-                     ->  Seq Scan on prt2_p1 t2_1
-         ->  Hash Join
-               Hash Cond: (t3_2.a = t2_2.b)
-               ->  Seq Scan on prt1_p2 t3_2
-               ->  Hash
-                     ->  Seq Scan on prt2_p2 t2_2
-         ->  Hash Join
-               Hash Cond: (t3_3.a = t2_3.b)
-               ->  Seq Scan on prt1_p3 t3_3
-               ->  Hash
-                     ->  Seq Scan on prt2_p3 t2_3
-   ->  Hash
-         ->  Result
-               One-Time Filter: false
-(21 rows)
-
-EXPLAIN (COSTS OFF)
-SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a = 1 AND a = 2) t1 FULL JOIN prt2 t2 ON t1.a = t2.b WHERE t2.a = 0 ORDER BY t1.a, t2.b;
-                 QUERY PLAN                 
---------------------------------------------
- Sort
-   Sort Key: a, t2.b
-   ->  Hash Left Join
-         Hash Cond: (t2.b = a)
-         ->  Append
-               ->  Seq Scan on prt2_p1 t2_1
-                     Filter: (a = 0)
-               ->  Seq Scan on prt2_p2 t2_2
-                     Filter: (a = 0)
-               ->  Seq Scan on prt2_p3 t2_3
-                     Filter: (a = 0)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                                 Hash Key: t2_3.b
+                                 ->  Seq Scan on prt2_p3 t2_3
          ->  Hash
                ->  Result
                      One-Time Filter: false
@@ -2377,11 +1568,11 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1 WHERE a = 1 AND a = 2) t1
          ->  Hash Left Join
                Hash Cond: (t2.b = a)
                ->  Append
-                     ->  Seq Scan on prt2_p1 t2
+                     ->  Seq Scan on prt2_p1 t2_1
                            Filter: (a = 0)
-                     ->  Seq Scan on prt2_p2 t2_1
+                     ->  Seq Scan on prt2_p2 t2_2
                            Filter: (a = 0)
-                     ->  Seq Scan on prt2_p3 t2_2
+                     ->  Seq Scan on prt2_p3 t2_3
                            Filter: (a = 0)
                ->  Hash
                      ->  Result
@@ -2416,7 +1607,6 @@ ANALYZE pht1_e;
 -- test partition matching with N-way join
 EXPLAIN (COSTS OFF)
 SELECT avg(t1.a), avg(t2.b), avg(t3.a + t3.b), t1.c, t2.c, t3.c FROM pht1 t1, pht2 t2, pht1_e t3 WHERE t1.b = t2.b AND t1.c = t2.c AND ltrim(t3.c, 'A') = t1.c GROUP BY t1.c, t2.c, t3.c ORDER BY t1.c, t2.c, t3.c;
-<<<<<<< HEAD
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2429,81 +1619,44 @@ SELECT avg(t1.a), avg(t2.b), avg(t3.a + t3.b), t1.c, t2.c, t3.c FROM pht1 t1, ph
                      Hash Key: t1.c, t1.c, t3.c
                      ->  Append
                            ->  Hash Join
-                                 Hash Cond: ((t1.b = t2.b) AND (t1.c = t2.c))
+                                 Hash Cond: ((t1_1.b = t2_1.b) AND (t1_1.c = t2_1.c))
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: t1.c
-                                       ->  Seq Scan on pht1_p1 t1
+                                       Hash Key: t1_1.c
+                                       ->  Seq Scan on pht1_p1 t1_1
                                  ->  Hash
                                        ->  Hash Join
-                                             Hash Cond: (t2.c = ltrim(t3.c, 'A'::text))
+                                             Hash Cond: (t2_1.c = ltrim(t3_1.c, 'A'::text))
                                              ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: t2.c
-                                                   ->  Seq Scan on pht2_p1 t2
+                                                   Hash Key: t2_1.c
+                                                   ->  Seq Scan on pht2_p1 t2_1
                                              ->  Hash
                                                    ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                                         Hash Key: ltrim(t3.c, 'A'::text)
-                                                         ->  Seq Scan on pht1_e_p1 t3
+                                                         Hash Key: ltrim(t3_1.c, 'A'::text)
+                                                         ->  Seq Scan on pht1_e_p1 t3_1
                            ->  Hash Join
-                                 Hash Cond: (t1_1.c = ltrim(t3_1.c, 'A'::text))
+                                 Hash Cond: (t1_2.c = ltrim(t3_2.c, 'A'::text))
                                  ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                        ->  Hash Join
-                                             Hash Cond: ((t2_1.b = t1_1.b) AND (t2_1.c = t1_1.c))
+                                             Hash Cond: ((t2_2.b = t1_2.b) AND (t2_2.c = t1_2.c))
                                              ->  Broadcast Motion 3:3  (slice7; segments: 3)
-                                                   ->  Seq Scan on pht2_p2 t2_1
+                                                   ->  Seq Scan on pht2_p2 t2_2
                                              ->  Hash
-                                                   ->  Seq Scan on pht1_p2 t1_1
+                                                   ->  Seq Scan on pht1_p2 t1_2
                                  ->  Hash
-                                       ->  Seq Scan on pht1_e_p2 t3_1
+                                       ->  Seq Scan on pht1_e_p2 t3_2
                            ->  Hash Join
-                                 Hash Cond: (ltrim(t3_2.c, 'A'::text) = t1_2.c)
-                                 ->  Seq Scan on pht1_e_p3 t3_2
+                                 Hash Cond: (ltrim(t3_3.c, 'A'::text) = t1_3.c)
+                                 ->  Seq Scan on pht1_e_p3 t3_3
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice8; segments: 3)
                                              ->  Hash Join
-                                                   Hash Cond: ((t2_2.b = t1_2.b) AND (t2_2.c = t1_2.c))
+                                                   Hash Cond: ((t2_3.b = t1_3.b) AND (t2_3.c = t1_3.c))
                                                    ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                                                         ->  Seq Scan on pht2_p3 t2_2
+                                                         ->  Seq Scan on pht2_p3 t2_3
                                                    ->  Hash
-                                                         ->  Seq Scan on pht1_p3 t1_2
+                                                         ->  Seq Scan on pht1_p3 t1_3
  Optimizer: Postgres query optimizer
 (47 rows)
-=======
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- GroupAggregate
-   Group Key: t1.c, t2.c, t3.c
-   ->  Sort
-         Sort Key: t1.c, t3.c
-         ->  Append
-               ->  Hash Join
-                     Hash Cond: (t1_1.c = ltrim(t3_1.c, 'A'::text))
-                     ->  Hash Join
-                           Hash Cond: ((t1_1.b = t2_1.b) AND (t1_1.c = t2_1.c))
-                           ->  Seq Scan on pht1_p1 t1_1
-                           ->  Hash
-                                 ->  Seq Scan on pht2_p1 t2_1
-                     ->  Hash
-                           ->  Seq Scan on pht1_e_p1 t3_1
-               ->  Hash Join
-                     Hash Cond: (t1_2.c = ltrim(t3_2.c, 'A'::text))
-                     ->  Hash Join
-                           Hash Cond: ((t1_2.b = t2_2.b) AND (t1_2.c = t2_2.c))
-                           ->  Seq Scan on pht1_p2 t1_2
-                           ->  Hash
-                                 ->  Seq Scan on pht2_p2 t2_2
-                     ->  Hash
-                           ->  Seq Scan on pht1_e_p2 t3_2
-               ->  Hash Join
-                     Hash Cond: (t1_3.c = ltrim(t3_3.c, 'A'::text))
-                     ->  Hash Join
-                           Hash Cond: ((t1_3.b = t2_3.b) AND (t1_3.c = t2_3.c))
-                           ->  Seq Scan on pht1_p3 t1_3
-                           ->  Hash
-                                 ->  Seq Scan on pht2_p3 t2_3
-                     ->  Hash
-                           ->  Seq Scan on pht1_e_p3 t3_3
-(32 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT avg(t1.a), avg(t2.b), avg(t3.a + t3.b), t1.c, t2.c, t3.c FROM pht1 t1, pht2 t2, pht1_e t3 WHERE t1.b = t2.b AND t1.c = t2.c AND ltrim(t3.c, 'A') = t1.c GROUP BY t1.c, t2.c, t3.c ORDER BY t1.c, t2.c, t3.c;
          avg          |         avg          |         avg          |  c   |  c   |   c   
@@ -2525,7 +1678,6 @@ ALTER TABLE prt2 ATTACH PARTITION prt2_p3 DEFAULT;
 ANALYZE prt2;
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2534,54 +1686,28 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b =
          Sort Key: t1.a
          ->  Append
                ->  Hash Join
-                     Hash Cond: (t2.b = t1.a)
-                     ->  Seq Scan on prt2_p1 t2
+                     Hash Cond: (t2_1.b = t1_1.a)
+                     ->  Seq Scan on prt2_p1 t2_1
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Seq Scan on prt1_p1 t1
-                                       Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: (t2_1.b = t1_1.a)
-                     ->  Seq Scan on prt2_p2 t2_1
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on prt1_p2 t1_1
+                                 ->  Seq Scan on prt1_p1 t1_1
                                        Filter: (b = 0)
                ->  Hash Join
                      Hash Cond: (t2_2.b = t1_2.a)
-                     ->  Seq Scan on prt2_p3 t2_2
+                     ->  Seq Scan on prt2_p2 t2_2
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on prt1_p2 t1_2
+                                       Filter: (b = 0)
+               ->  Hash Join
+                     Hash Cond: (t2_3.b = t1_3.a)
+                     ->  Seq Scan on prt2_p3 t2_3
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                 ->  Seq Scan on prt1_p3 t1_2
+                                 ->  Seq Scan on prt1_p3 t1_3
                                        Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (27 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Hash Join
-               Hash Cond: (t2_1.b = t1_1.a)
-               ->  Seq Scan on prt2_p1 t2_1
-               ->  Hash
-                     ->  Seq Scan on prt1_p1 t1_1
-                           Filter: (b = 0)
-         ->  Hash Join
-               Hash Cond: (t2_2.b = t1_2.a)
-               ->  Seq Scan on prt2_p2 t2_2
-               ->  Hash
-                     ->  Seq Scan on prt1_p2 t1_2
-                           Filter: (b = 0)
-         ->  Hash Join
-               Hash Cond: (t2_3.b = t1_3.a)
-               ->  Seq Scan on prt2_p3 t2_3
-               ->  Hash
-                     ->  Seq Scan on prt1_p3 t1_3
-                           Filter: (b = 0)
-(21 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- test default partition behavior for list
 ALTER TABLE plt1 DETACH PARTITION plt1_p3;
@@ -2592,7 +1718,6 @@ ALTER TABLE plt2 ATTACH PARTITION plt2_p3 DEFAULT;
 ANALYZE plt2;
 EXPLAIN (COSTS OFF)
 SELECT avg(t1.a), avg(t2.b), t1.c, t2.c FROM plt1 t1 RIGHT JOIN plt2 t2 ON t1.c = t2.c WHERE t1.a % 25 = 0 GROUP BY t1.c, t2.c ORDER BY t1.c, t2.c;
-<<<<<<< HEAD
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2607,56 +1732,28 @@ SELECT avg(t1.a), avg(t2.b), t1.c, t2.c FROM plt1 t1 RIGHT JOIN plt2 t2 ON t1.c 
                            Group Key: t1.c, t2.c
                            ->  Append
                                  ->  Hash Join
-                                       Hash Cond: (t2.c = t1.c)
-                                       ->  Seq Scan on plt2_p1 t2
+                                       Hash Cond: (t2_1.c = t1_1.c)
+                                       ->  Seq Scan on plt2_p1 t2_1
                                        ->  Hash
                                              ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Seq Scan on plt1_p1 t1
-                                                         Filter: ((a % 25) = 0)
-                                 ->  Hash Join
-                                       Hash Cond: (t2_1.c = t1_1.c)
-                                       ->  Seq Scan on plt2_p2 t2_1
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                   ->  Seq Scan on plt1_p2 t1_1
+                                                   ->  Seq Scan on plt1_p1 t1_1
                                                          Filter: ((a % 25) = 0)
                                  ->  Hash Join
                                        Hash Cond: (t2_2.c = t1_2.c)
-                                       ->  Seq Scan on plt2_p3 t2_2
+                                       ->  Seq Scan on plt2_p2 t2_2
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                   ->  Seq Scan on plt1_p2 t1_2
+                                                         Filter: ((a % 25) = 0)
+                                 ->  Hash Join
+                                       Hash Cond: (t2_3.c = t1_3.c)
+                                       ->  Seq Scan on plt2_p3 t2_3
                                        ->  Hash
                                              ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                                   ->  Seq Scan on plt1_p3 t1_2
+                                                   ->  Seq Scan on plt1_p3 t1_3
                                                          Filter: ((a % 25) = 0)
  Optimizer: Postgres query optimizer
 (33 rows)
-=======
-                       QUERY PLAN                       
---------------------------------------------------------
- Sort
-   Sort Key: t1.c
-   ->  HashAggregate
-         Group Key: t1.c, t2.c
-         ->  Append
-               ->  Hash Join
-                     Hash Cond: (t2_1.c = t1_1.c)
-                     ->  Seq Scan on plt2_p1 t2_1
-                     ->  Hash
-                           ->  Seq Scan on plt1_p1 t1_1
-                                 Filter: ((a % 25) = 0)
-               ->  Hash Join
-                     Hash Cond: (t2_2.c = t1_2.c)
-                     ->  Seq Scan on plt2_p2 t2_2
-                     ->  Hash
-                           ->  Seq Scan on plt1_p2 t1_2
-                                 Filter: ((a % 25) = 0)
-               ->  Hash Join
-                     Hash Cond: (t2_3.c = t1_3.c)
-                     ->  Seq Scan on plt2_p3 t2_3
-                     ->  Hash
-                           ->  Seq Scan on plt1_p3 t1_3
-                                 Filter: ((a % 25) = 0)
-(23 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- multiple levels of partitioning
@@ -2684,7 +1781,6 @@ ANALYZE prt2_l;
 -- inner join, qual covering only top-level partitions
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1, prt2_l t2 WHERE t1.a = t2.b AND t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2693,68 +1789,35 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1, prt2_l t2 WHERE t1.a = t2.b AND t1
          Sort Key: t1.a
          ->  Append
                ->  Hash Join
-                     Hash Cond: (t2.b = t1.a)
-                     ->  Seq Scan on prt2_l_p1 t2
+                     Hash Cond: (t2_1.b = t1_1.a)
+                     ->  Seq Scan on prt2_l_p1 t2_1
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Seq Scan on prt1_l_p1 t1
+                                 ->  Seq Scan on prt1_l_p1 t1_1
                                        Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: (t2_1.b = t1_1.a)
-                     ->  Append
-                           ->  Seq Scan on prt2_l_p2_p1 t2_1
-                           ->  Seq Scan on prt2_l_p2_p2 t2_2
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Append
-                                       ->  Seq Scan on prt1_l_p2_p1 t1_1
-                                             Filter: (b = 0)
-                                       ->  Seq Scan on prt1_l_p2_p2 t1_2
-                                             Filter: (b = 0)
                ->  Hash Join
                      Hash Cond: (t2_3.b = t1_3.a)
                      ->  Append
-                           ->  Seq Scan on prt2_l_p3_p1 t2_3
-                           ->  Seq Scan on prt2_l_p3_p2 t2_4
+                           ->  Seq Scan on prt2_l_p2_p1 t2_3
+                           ->  Seq Scan on prt2_l_p2_p2 t2_4
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Append
+                                       ->  Seq Scan on prt1_l_p2_p1 t1_3
+                                             Filter: (b = 0)
+                                       ->  Seq Scan on prt1_l_p2_p2 t1_4
+                                             Filter: (b = 0)
+               ->  Hash Join
+                     Hash Cond: (t2_6.b = t1_5.a)
+                     ->  Append
+                           ->  Seq Scan on prt2_l_p3_p1 t2_6
+                           ->  Seq Scan on prt2_l_p3_p2 t2_7
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                 ->  Seq Scan on prt1_l_p3_p1 t1_3
+                                 ->  Seq Scan on prt1_l_p3_p1 t1_5
                                        Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (34 rows)
-=======
-                         QUERY PLAN                          
--------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Hash Join
-               Hash Cond: (t2_1.b = t1_1.a)
-               ->  Seq Scan on prt2_l_p1 t2_1
-               ->  Hash
-                     ->  Seq Scan on prt1_l_p1 t1_1
-                           Filter: (b = 0)
-         ->  Hash Join
-               Hash Cond: (t2_3.b = t1_3.a)
-               ->  Append
-                     ->  Seq Scan on prt2_l_p2_p1 t2_3
-                     ->  Seq Scan on prt2_l_p2_p2 t2_4
-               ->  Hash
-                     ->  Append
-                           ->  Seq Scan on prt1_l_p2_p1 t1_3
-                                 Filter: (b = 0)
-                           ->  Seq Scan on prt1_l_p2_p2 t1_4
-                                 Filter: (b = 0)
-         ->  Hash Join
-               Hash Cond: (t2_6.b = t1_5.a)
-               ->  Append
-                     ->  Seq Scan on prt2_l_p3_p1 t2_6
-                     ->  Seq Scan on prt2_l_p3_p2 t2_7
-               ->  Hash
-                     ->  Seq Scan on prt1_l_p3_p1 t1_5
-                           Filter: (b = 0)
-(28 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1, prt2_l t2 WHERE t1.a = t2.b AND t1.b = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -2768,7 +1831,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1, prt2_l t2 WHERE t1.a = t2.b AND t1
 -- left join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 LEFT JOIN prt2_l t2 ON t1.a = t2.b AND t1.c = t2.c WHERE t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2777,77 +1839,43 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 LEFT JOIN prt2_l t2 ON t1.a = t2.b 
          Sort Key: t1.a, t2.b
          ->  Append
                ->  Hash Right Join
-                     Hash Cond: ((t2.b = t1.a) AND ((t2.c)::text = (t1.c)::text))
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: t2.b
-                           ->  Seq Scan on prt2_l_p1 t2
-                     ->  Hash
-                           ->  Seq Scan on prt1_l_p1 t1
-                                 Filter: (b = 0)
-               ->  Hash Right Join
                      Hash Cond: ((t2_1.b = t1_1.a) AND ((t2_1.c)::text = (t1_1.c)::text))
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: t2_1.b
-                           ->  Seq Scan on prt2_l_p2_p1 t2_1
+                           ->  Seq Scan on prt2_l_p1 t2_1
                      ->  Hash
-                           ->  Seq Scan on prt1_l_p2_p1 t1_1
+                           ->  Seq Scan on prt1_l_p1 t1_1
                                  Filter: (b = 0)
                ->  Hash Right Join
                      Hash Cond: ((t2_2.b = t1_2.a) AND ((t2_2.c)::text = (t1_2.c)::text))
-                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
                            Hash Key: t2_2.b
-                           ->  Seq Scan on prt2_l_p2_p2 t2_2
+                           ->  Seq Scan on prt2_l_p2_p1 t2_2
                      ->  Hash
-                           ->  Seq Scan on prt1_l_p2_p2 t1_2
+                           ->  Seq Scan on prt1_l_p2_p1 t1_2
                                  Filter: (b = 0)
                ->  Hash Right Join
                      Hash Cond: ((t2_3.b = t1_3.a) AND ((t2_3.c)::text = (t1_3.c)::text))
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: t2_3.b
+                           ->  Seq Scan on prt2_l_p2_p2 t2_3
+                     ->  Hash
+                           ->  Seq Scan on prt1_l_p2_p2 t1_3
+                                 Filter: (b = 0)
+               ->  Hash Right Join
+                     Hash Cond: ((t2_5.b = t1_4.a) AND ((t2_5.c)::text = (t1_4.c)::text))
                      ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                           Hash Key: t2_3.b, t2_3.c
+                           Hash Key: t2_5.b, t2_5.c
                            ->  Append
-                                 ->  Seq Scan on prt2_l_p3_p1 t2_3
-                                 ->  Seq Scan on prt2_l_p3_p2 t2_4
+                                 ->  Seq Scan on prt2_l_p3_p1 t2_5
+                                 ->  Seq Scan on prt2_l_p3_p2 t2_6
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                 Hash Key: t1_3.a, t1_3.c
-                                 ->  Seq Scan on prt1_l_p3_p1 t1_3
+                                 Hash Key: t1_4.a, t1_4.c
+                                 ->  Seq Scan on prt1_l_p3_p1 t1_4
                                        Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (42 rows)
-=======
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b
-   ->  Append
-         ->  Hash Right Join
-               Hash Cond: ((t2_1.b = t1_1.a) AND ((t2_1.c)::text = (t1_1.c)::text))
-               ->  Seq Scan on prt2_l_p1 t2_1
-               ->  Hash
-                     ->  Seq Scan on prt1_l_p1 t1_1
-                           Filter: (b = 0)
-         ->  Hash Right Join
-               Hash Cond: ((t2_2.b = t1_2.a) AND ((t2_2.c)::text = (t1_2.c)::text))
-               ->  Seq Scan on prt2_l_p2_p1 t2_2
-               ->  Hash
-                     ->  Seq Scan on prt1_l_p2_p1 t1_2
-                           Filter: (b = 0)
-         ->  Hash Right Join
-               Hash Cond: ((t2_3.b = t1_3.a) AND ((t2_3.c)::text = (t1_3.c)::text))
-               ->  Seq Scan on prt2_l_p2_p2 t2_3
-               ->  Hash
-                     ->  Seq Scan on prt1_l_p2_p2 t1_3
-                           Filter: (b = 0)
-         ->  Hash Right Join
-               Hash Cond: ((t2_5.b = t1_4.a) AND ((t2_5.c)::text = (t1_4.c)::text))
-               ->  Append
-                     ->  Seq Scan on prt2_l_p3_p1 t2_5
-                     ->  Seq Scan on prt2_l_p3_p2 t2_6
-               ->  Hash
-                     ->  Seq Scan on prt1_l_p3_p1 t1_4
-                           Filter: (b = 0)
-(29 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 LEFT JOIN prt2_l t2 ON t1.a = t2.b AND t1.c = t2.c WHERE t1.b = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -2869,7 +1897,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 LEFT JOIN prt2_l t2 ON t1.a = t2.b 
 -- right join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 RIGHT JOIN prt2_l t2 ON t1.a = t2.b AND t1.c = t2.c WHERE t2.a = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2878,75 +1905,41 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 RIGHT JOIN prt2_l t2 ON t1.a = t2.b
          Sort Key: t1.a, t2.b
          ->  Append
                ->  Hash Right Join
-                     Hash Cond: ((t1.a = t2.b) AND ((t1.c)::text = (t2.c)::text))
-                     ->  Seq Scan on prt1_l_p1 t1
+                     Hash Cond: ((t1_1.a = t2_1.b) AND ((t1_1.c)::text = (t2_1.c)::text))
+                     ->  Seq Scan on prt1_l_p1 t1_1
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                 Hash Key: t2.b
-                                 ->  Seq Scan on prt2_l_p1 t2
-                                       Filter: (a = 0)
-               ->  Hash Right Join
-                     Hash Cond: ((t1_1.a = t2_1.b) AND ((t1_1.c)::text = (t2_1.c)::text))
-                     ->  Seq Scan on prt1_l_p2_p1 t1_1
-                     ->  Hash
-                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
                                  Hash Key: t2_1.b
-                                 ->  Seq Scan on prt2_l_p2_p1 t2_1
+                                 ->  Seq Scan on prt2_l_p1 t2_1
                                        Filter: (a = 0)
                ->  Hash Right Join
                      Hash Cond: ((t1_2.a = t2_2.b) AND ((t1_2.c)::text = (t2_2.c)::text))
-                     ->  Seq Scan on prt1_l_p2_p2 t1_2
+                     ->  Seq Scan on prt1_l_p2_p1 t1_2
                      ->  Hash
-                           ->  Redistribute Motion 1:3  (slice4; segments: 1)
+                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
                                  Hash Key: t2_2.b
-                                 ->  Seq Scan on prt2_l_p2_p2 t2_2
+                                 ->  Seq Scan on prt2_l_p2_p1 t2_2
                                        Filter: (a = 0)
                ->  Hash Right Join
                      Hash Cond: ((t1_3.a = t2_3.b) AND ((t1_3.c)::text = (t2_3.c)::text))
+                     ->  Seq Scan on prt1_l_p2_p2 t1_3
+                     ->  Hash
+                           ->  Redistribute Motion 1:3  (slice4; segments: 1)
+                                 Hash Key: t2_3.b
+                                 ->  Seq Scan on prt2_l_p2_p2 t2_3
+                                       Filter: (a = 0)
+               ->  Hash Right Join
+                     Hash Cond: ((t1_5.a = t2_4.b) AND ((t1_5.c)::text = (t2_4.c)::text))
                      ->  Redistribute Motion 3:3  (slice5; segments: 3)
                            Hash Key: 0
                            ->  Append
-                                 ->  Seq Scan on prt1_l_p3_p1 t1_3
-                                 ->  Seq Scan on prt1_l_p3_p2 t1_4
+                                 ->  Seq Scan on prt1_l_p3_p1 t1_5
+                                 ->  Seq Scan on prt1_l_p3_p2 t1_6
                      ->  Hash
-                           ->  Seq Scan on prt2_l_p3_p1 t2_3
+                           ->  Seq Scan on prt2_l_p3_p1 t2_4
                                  Filter: (a = 0)
  Optimizer: Postgres query optimizer
 (40 rows)
-=======
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a, t2.b
-   ->  Append
-         ->  Hash Right Join
-               Hash Cond: ((t1_1.a = t2_1.b) AND ((t1_1.c)::text = (t2_1.c)::text))
-               ->  Seq Scan on prt1_l_p1 t1_1
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p1 t2_1
-                           Filter: (a = 0)
-         ->  Hash Right Join
-               Hash Cond: ((t1_2.a = t2_2.b) AND ((t1_2.c)::text = (t2_2.c)::text))
-               ->  Seq Scan on prt1_l_p2_p1 t1_2
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p2_p1 t2_2
-                           Filter: (a = 0)
-         ->  Hash Right Join
-               Hash Cond: ((t1_3.a = t2_3.b) AND ((t1_3.c)::text = (t2_3.c)::text))
-               ->  Seq Scan on prt1_l_p2_p2 t1_3
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p2_p2 t2_3
-                           Filter: (a = 0)
-         ->  Hash Right Join
-               Hash Cond: ((t1_5.a = t2_4.b) AND ((t1_5.c)::text = (t2_4.c)::text))
-               ->  Append
-                     ->  Seq Scan on prt1_l_p3_p1 t1_5
-                     ->  Seq Scan on prt1_l_p3_p2 t1_6
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p3_p1 t2_4
-                           Filter: (a = 0)
-(29 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 RIGHT JOIN prt2_l t2 ON t1.a = t2.b AND t1.c = t2.c WHERE t2.a = 0 ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -2964,7 +1957,6 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_l t1 RIGHT JOIN prt2_l t2 ON t1.a = t2.b
 -- full join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE prt1_l.b = 0) t1 FULL JOIN (SELECT * FROM prt2_l WHERE prt2_l.a = 0) t2 ON (t1.a = t2.b AND t1.c = t2.c) ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2973,79 +1965,43 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE prt1_l.b = 0) t1 
          Sort Key: prt1_l.a, prt2_l.b
          ->  Append
                ->  Hash Full Join
-                     Hash Cond: ((prt1_l.a = prt2_l.b) AND ((prt1_l.c)::text = (prt2_l.c)::text))
-                     ->  Seq Scan on prt1_l_p1 prt1_l
+                     Hash Cond: ((prt1_l_1.a = prt2_l_1.b) AND ((prt1_l_1.c)::text = (prt2_l_1.c)::text))
+                     ->  Seq Scan on prt1_l_p1 prt1_l_1
                            Filter: (b = 0)
                      ->  Hash
                            ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                 Hash Key: prt2_l.b
-                                 ->  Seq Scan on prt2_l_p1 prt2_l
-                                       Filter: (a = 0)
-               ->  Hash Full Join
-                     Hash Cond: ((prt1_l_1.a = prt2_l_1.b) AND ((prt1_l_1.c)::text = (prt2_l_1.c)::text))
-                     ->  Seq Scan on prt1_l_p2_p1 prt1_l_1
-                           Filter: (b = 0)
-                     ->  Hash
-                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
                                  Hash Key: prt2_l_1.b
-                                 ->  Seq Scan on prt2_l_p2_p1 prt2_l_1
+                                 ->  Seq Scan on prt2_l_p1 prt2_l_1
                                        Filter: (a = 0)
                ->  Hash Full Join
                      Hash Cond: ((prt1_l_2.a = prt2_l_2.b) AND ((prt1_l_2.c)::text = (prt2_l_2.c)::text))
-                     ->  Seq Scan on prt1_l_p2_p2 prt1_l_2
+                     ->  Seq Scan on prt1_l_p2_p1 prt1_l_2
                            Filter: (b = 0)
                      ->  Hash
-                           ->  Redistribute Motion 1:3  (slice4; segments: 1)
+                           ->  Redistribute Motion 1:3  (slice3; segments: 1)
                                  Hash Key: prt2_l_2.b
-                                 ->  Seq Scan on prt2_l_p2_p2 prt2_l_2
+                                 ->  Seq Scan on prt2_l_p2_p1 prt2_l_2
                                        Filter: (a = 0)
                ->  Hash Full Join
                      Hash Cond: ((prt1_l_3.a = prt2_l_3.b) AND ((prt1_l_3.c)::text = (prt2_l_3.c)::text))
+                     ->  Seq Scan on prt1_l_p2_p2 prt1_l_3
+                           Filter: (b = 0)
+                     ->  Hash
+                           ->  Redistribute Motion 1:3  (slice4; segments: 1)
+                                 Hash Key: prt2_l_3.b
+                                 ->  Seq Scan on prt2_l_p2_p2 prt2_l_3
+                                       Filter: (a = 0)
+               ->  Hash Full Join
+                     Hash Cond: ((prt1_l_4.a = prt2_l_4.b) AND ((prt1_l_4.c)::text = (prt2_l_4.c)::text))
                      ->  Redistribute Motion 3:3  (slice5; segments: 3)
                            Hash Key: 0
-                           ->  Seq Scan on prt1_l_p3_p1 prt1_l_3
+                           ->  Seq Scan on prt1_l_p3_p1 prt1_l_4
                                  Filter: (b = 0)
                      ->  Hash
-                           ->  Seq Scan on prt2_l_p3_p1 prt2_l_3
+                           ->  Seq Scan on prt2_l_p3_p1 prt2_l_4
                                  Filter: (a = 0)
  Optimizer: Postgres query optimizer
 (42 rows)
-=======
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: prt1_l.a, prt2_l.b
-   ->  Append
-         ->  Hash Full Join
-               Hash Cond: ((prt1_l_1.a = prt2_l_1.b) AND ((prt1_l_1.c)::text = (prt2_l_1.c)::text))
-               ->  Seq Scan on prt1_l_p1 prt1_l_1
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p1 prt2_l_1
-                           Filter: (a = 0)
-         ->  Hash Full Join
-               Hash Cond: ((prt1_l_2.a = prt2_l_2.b) AND ((prt1_l_2.c)::text = (prt2_l_2.c)::text))
-               ->  Seq Scan on prt1_l_p2_p1 prt1_l_2
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p2_p1 prt2_l_2
-                           Filter: (a = 0)
-         ->  Hash Full Join
-               Hash Cond: ((prt1_l_3.a = prt2_l_3.b) AND ((prt1_l_3.c)::text = (prt2_l_3.c)::text))
-               ->  Seq Scan on prt1_l_p2_p2 prt1_l_3
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p2_p2 prt2_l_3
-                           Filter: (a = 0)
-         ->  Hash Full Join
-               Hash Cond: ((prt1_l_4.a = prt2_l_4.b) AND ((prt1_l_4.c)::text = (prt2_l_4.c)::text))
-               ->  Seq Scan on prt1_l_p3_p1 prt1_l_4
-                     Filter: (b = 0)
-               ->  Hash
-                     ->  Seq Scan on prt2_l_p3_p1 prt2_l_4
-                           Filter: (a = 0)
-(31 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE prt1_l.b = 0) t1 FULL JOIN (SELECT * FROM prt2_l WHERE prt2_l.a = 0) t2 ON (t1.a = t2.b AND t1.c = t2.c) ORDER BY t1.a, t2.b;
   a  |  c   |  b  |  c   
@@ -3075,58 +2031,7 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM prt1_l t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t2.c AS t2c, t2.b AS t2b, t3.b AS t3b, least(t1.a,t2.a,t3.b) FROM prt1_l t2 JOIN prt2_l t3 ON (t2.a = t3.b AND t2.c = t3.c)) ss
 			  ON t1.a = ss.t2a AND t1.c = ss.t2c WHERE t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
 ERROR:  could not devise a query plan for the given query
-=======
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Append
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_l_p1 t1_1
-                     Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: ((t3_1.b = t2_1.a) AND ((t3_1.c)::text = (t2_1.c)::text))
-                     ->  Seq Scan on prt2_l_p1 t3_1
-                     ->  Hash
-                           ->  Seq Scan on prt1_l_p1 t2_1
-                                 Filter: ((t1_1.a = a) AND ((t1_1.c)::text = (c)::text))
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_l_p2_p1 t1_2
-                     Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: ((t3_2.b = t2_2.a) AND ((t3_2.c)::text = (t2_2.c)::text))
-                     ->  Seq Scan on prt2_l_p2_p1 t3_2
-                     ->  Hash
-                           ->  Seq Scan on prt1_l_p2_p1 t2_2
-                                 Filter: ((t1_2.a = a) AND ((t1_2.c)::text = (c)::text))
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_l_p2_p2 t1_3
-                     Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: ((t3_3.b = t2_3.a) AND ((t3_3.c)::text = (t2_3.c)::text))
-                     ->  Seq Scan on prt2_l_p2_p2 t3_3
-                     ->  Hash
-                           ->  Seq Scan on prt1_l_p2_p2 t2_3
-                                 Filter: ((t1_3.a = a) AND ((t1_3.c)::text = (c)::text))
-         ->  Nested Loop Left Join
-               ->  Seq Scan on prt1_l_p3_p1 t1_4
-                     Filter: (b = 0)
-               ->  Hash Join
-                     Hash Cond: ((t3_5.b = t2_5.a) AND ((t3_5.c)::text = (t2_5.c)::text))
-                     ->  Append
-                           ->  Seq Scan on prt2_l_p3_p1 t3_5
-                           ->  Seq Scan on prt2_l_p3_p2 t3_6
-                     ->  Hash
-                           ->  Append
-                                 ->  Seq Scan on prt1_l_p3_p1 t2_5
-                                       Filter: ((t1_4.a = a) AND ((t1_4.c)::text = (c)::text))
-                                 ->  Seq Scan on prt1_l_p3_p2 t2_6
-                                       Filter: ((t1_4.a = a) AND ((t1_4.c)::text = (c)::text))
-(44 rows)
-
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 SELECT * FROM prt1_l t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t2.c AS t2c, t2.b AS t2b, t3.b AS t3b, least(t1.a,t2.a,t3.b) FROM prt1_l t2 JOIN prt2_l t3 ON (t2.a = t3.b AND t2.c = t3.c)) ss
 			  ON t1.a = ss.t2a AND t1.c = ss.t2c WHERE t1.b = 0 ORDER BY t1.a;
@@ -3134,39 +2039,22 @@ ERROR:  could not devise a query plan for the given query
 -- join with one side empty
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE a = 1 AND a = 2) t1 RIGHT JOIN prt2_l t2 ON t1.a = t2.b AND t1.b = t2.a AND t1.c = t2.c;
-<<<<<<< HEAD
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
          Hash Cond: ((t2.b = a) AND (t2.a = b) AND ((t2.c)::text = (c)::text))
          ->  Append
-               ->  Seq Scan on prt2_l_p1 t2
-               ->  Seq Scan on prt2_l_p2_p1 t2_1
-               ->  Seq Scan on prt2_l_p2_p2 t2_2
-               ->  Seq Scan on prt2_l_p3_p1 t2_3
-               ->  Seq Scan on prt2_l_p3_p2 t2_4
+               ->  Seq Scan on prt2_l_p1 t2_1
+               ->  Seq Scan on prt2_l_p2_p1 t2_2
+               ->  Seq Scan on prt2_l_p2_p2 t2_3
+               ->  Seq Scan on prt2_l_p3_p1 t2_4
+               ->  Seq Scan on prt2_l_p3_p2 t2_5
          ->  Hash
                ->  Result
                      One-Time Filter: false
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Hash Left Join
-   Hash Cond: ((t2.b = a) AND (t2.a = b) AND ((t2.c)::text = (c)::text))
-   ->  Append
-         ->  Seq Scan on prt2_l_p1 t2_1
-         ->  Seq Scan on prt2_l_p2_p1 t2_2
-         ->  Seq Scan on prt2_l_p2_p2 t2_3
-         ->  Seq Scan on prt2_l_p3_p1 t2_4
-         ->  Seq Scan on prt2_l_p3_p2 t2_5
-   ->  Hash
-         ->  Result
-               One-Time Filter: false
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Test case to verify proper handling of subqueries in a partitioned delete.
 -- The weird-looking lateral join is just there to force creation of a
@@ -3264,7 +2152,6 @@ ANALYZE prt4_n;
 -- partitionwise join can not be applied if the partition ranges differ
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt4_n t2 WHERE t1.a = t2.a;
-<<<<<<< HEAD
                         QUERY PLAN                        
 ----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3272,15 +2159,15 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt4_n t2 WHERE t1.a = t2.a;
          Hash Cond: (t1.a = t2.a)
          ->  Append
                Partition Selectors: $0
-               ->  Seq Scan on prt1_p1 t1
-               ->  Seq Scan on prt1_p2 t1_1
-               ->  Seq Scan on prt1_p3 t1_2
+               ->  Seq Scan on prt1_p1 t1_1
+               ->  Seq Scan on prt1_p2 t1_2
+               ->  Seq Scan on prt1_p3 t1_3
          ->  Hash
                ->  Partition Selector (selector id: $0)
                      ->  Append
-                           ->  Seq Scan on prt4_n_p1 t2
-                           ->  Seq Scan on prt4_n_p2 t2_1
-                           ->  Seq Scan on prt4_n_p3 t2_2
+                           ->  Seq Scan on prt4_n_p1 t2_1
+                           ->  Seq Scan on prt4_n_p2 t2_2
+                           ->  Seq Scan on prt4_n_p3 t2_3
  Optimizer: Postgres query optimizer
 (15 rows)
 
@@ -3293,126 +2180,62 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt4_n t2, prt2 t3 WHERE t1.a = t2.a
          Hash Cond: (t2.a = t1.a)
          ->  Append
                Partition Selectors: $0
-               ->  Seq Scan on prt4_n_p1 t2
-               ->  Seq Scan on prt4_n_p2 t2_1
-               ->  Seq Scan on prt4_n_p3 t2_2
+               ->  Seq Scan on prt4_n_p1 t2_1
+               ->  Seq Scan on prt4_n_p2 t2_2
+               ->  Seq Scan on prt4_n_p3 t2_3
          ->  Hash
                ->  Partition Selector (selector id: $0)
                      ->  Append
                            ->  Hash Join
-                                 Hash Cond: (t1.a = t3.b)
-                                 ->  Seq Scan on prt1_p1 t1
+                                 Hash Cond: (t1_1.a = t3_1.b)
+                                 ->  Seq Scan on prt1_p1 t1_1
                                  ->  Hash
                                        ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                             Hash Key: t3.b
-                                             ->  Seq Scan on prt2_p1 t3
-                           ->  Hash Join
-                                 Hash Cond: (t1_1.a = t3_1.b)
-                                 ->  Seq Scan on prt1_p2 t1_1
-                                 ->  Hash
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: t3_1.b
-                                             ->  Seq Scan on prt2_p2 t3_1
+                                             ->  Seq Scan on prt2_p1 t3_1
                            ->  Hash Join
                                  Hash Cond: (t1_2.a = t3_2.b)
-                                 ->  Seq Scan on prt1_p3 t1_2
+                                 ->  Seq Scan on prt1_p2 t1_2
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Hash Key: t3_2.b
+                                             ->  Seq Scan on prt2_p2 t3_2
+                           ->  Hash Join
+                                 Hash Cond: (t1_3.a = t3_3.b)
+                                 ->  Seq Scan on prt1_p3 t1_3
                                  ->  Hash
                                        ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                             Hash Key: t3_2.b
-                                             ->  Seq Scan on prt2_p3 t3_2
+                                             Hash Key: t3_3.b
+                                             ->  Seq Scan on prt2_p3 t3_3
  Optimizer: Postgres query optimizer
 (33 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Hash Join
-   Hash Cond: (t1.a = t2.a)
-   ->  Append
-         ->  Seq Scan on prt1_p1 t1_1
-         ->  Seq Scan on prt1_p2 t1_2
-         ->  Seq Scan on prt1_p3 t1_3
-   ->  Hash
-         ->  Append
-               ->  Seq Scan on prt4_n_p1 t2_1
-               ->  Seq Scan on prt4_n_p2 t2_2
-               ->  Seq Scan on prt4_n_p3 t2_3
-(11 rows)
-
-EXPLAIN (COSTS OFF)
-SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt4_n t2, prt2 t3 WHERE t1.a = t2.a and t1.a = t3.b;
-                       QUERY PLAN                       
---------------------------------------------------------
- Hash Join
-   Hash Cond: (t2.a = t1.a)
-   ->  Append
-         ->  Seq Scan on prt4_n_p1 t2_1
-         ->  Seq Scan on prt4_n_p2 t2_2
-         ->  Seq Scan on prt4_n_p3 t2_3
-   ->  Hash
-         ->  Append
-               ->  Hash Join
-                     Hash Cond: (t1_1.a = t3_1.b)
-                     ->  Seq Scan on prt1_p1 t1_1
-                     ->  Hash
-                           ->  Seq Scan on prt2_p1 t3_1
-               ->  Hash Join
-                     Hash Cond: (t1_2.a = t3_2.b)
-                     ->  Seq Scan on prt1_p2 t1_2
-                     ->  Hash
-                           ->  Seq Scan on prt2_p2 t3_2
-               ->  Hash Join
-                     Hash Cond: (t1_3.a = t3_3.b)
-                     ->  Seq Scan on prt1_p3 t1_3
-                     ->  Hash
-                           ->  Seq Scan on prt2_p3 t3_3
-(23 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- partitionwise join can not be applied if there are no equi-join conditions
 -- between partition keys
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1 LEFT JOIN prt2 t2 ON (t1.a < t2.b);
-<<<<<<< HEAD
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Left Join
          Join Filter: (t1.a < t2.b)
          ->  Append
-               ->  Seq Scan on prt1_p1 t1
-               ->  Seq Scan on prt1_p2 t1_1
-               ->  Seq Scan on prt1_p3 t1_2
+               ->  Seq Scan on prt1_p1 t1_1
+               ->  Seq Scan on prt1_p2 t1_2
+               ->  Seq Scan on prt1_p3 t1_3
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Append
-                           ->  Seq Scan on prt2_p1 t2
-                           ->  Seq Scan on prt2_p2 t2_1
-                           ->  Seq Scan on prt2_p3 t2_2
+                           ->  Seq Scan on prt2_p1 t2_1
+                           ->  Seq Scan on prt2_p2 t2_2
+                           ->  Seq Scan on prt2_p3 t2_3
  Optimizer: Postgres query optimizer
 (14 rows)
-=======
-                       QUERY PLAN                        
----------------------------------------------------------
- Nested Loop Left Join
-   ->  Append
-         ->  Seq Scan on prt1_p1 t1_1
-         ->  Seq Scan on prt1_p2 t1_2
-         ->  Seq Scan on prt1_p3 t1_3
-   ->  Append
-         ->  Index Scan using iprt2_p1_b on prt2_p1 t2_1
-               Index Cond: (b > t1.a)
-         ->  Index Scan using iprt2_p2_b on prt2_p2 t2_2
-               Index Cond: (b > t1.a)
-         ->  Index Scan using iprt2_p3_b on prt2_p3 t2_3
-               Index Cond: (b > t1.a)
-(12 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- equi-join with join condition on partial keys does not qualify for
 -- partitionwise join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_m t1, prt2_m t2 WHERE t1.a = (t2.b + t2.a)/2;
-<<<<<<< HEAD
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3420,80 +2243,46 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_m t1, prt2_m t2 WHERE t1.a = (t2.b + t2.
          Hash Cond: (t1.a = ((t2.b + t2.a) / 2))
          ->  Append
                Partition Selectors: $0
-               ->  Seq Scan on prt1_m_p1 t1
-               ->  Seq Scan on prt1_m_p2 t1_1
-               ->  Seq Scan on prt1_m_p3 t1_2
+               ->  Seq Scan on prt1_m_p1 t1_1
+               ->  Seq Scan on prt1_m_p2 t1_2
+               ->  Seq Scan on prt1_m_p3 t1_3
          ->  Hash
                ->  Partition Selector (selector id: $0)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: ((t2.b + t2.a) / 2)
                            ->  Append
-                                 ->  Seq Scan on prt2_m_p1 t2
-                                 ->  Seq Scan on prt2_m_p2 t2_1
-                                 ->  Seq Scan on prt2_m_p3 t2_2
+                                 ->  Seq Scan on prt2_m_p1 t2_1
+                                 ->  Seq Scan on prt2_m_p2 t2_2
+                                 ->  Seq Scan on prt2_m_p3 t2_3
  Optimizer: Postgres query optimizer
 (17 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Hash Join
-   Hash Cond: (((t2.b + t2.a) / 2) = t1.a)
-   ->  Append
-         ->  Seq Scan on prt2_m_p1 t2_1
-         ->  Seq Scan on prt2_m_p2 t2_2
-         ->  Seq Scan on prt2_m_p3 t2_3
-   ->  Hash
-         ->  Append
-               ->  Seq Scan on prt1_m_p1 t1_1
-               ->  Seq Scan on prt1_m_p2 t1_2
-               ->  Seq Scan on prt1_m_p3 t1_3
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- equi-join between out-of-order partition key columns does not qualify for
 -- partitionwise join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_m t1 LEFT JOIN prt2_m t2 ON t1.a = t2.b;
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Left Join
          Hash Cond: (t1.a = t2.b)
          ->  Append
-               ->  Seq Scan on prt1_m_p1 t1
-               ->  Seq Scan on prt1_m_p2 t1_1
-               ->  Seq Scan on prt1_m_p3 t1_2
+               ->  Seq Scan on prt1_m_p1 t1_1
+               ->  Seq Scan on prt1_m_p2 t1_2
+               ->  Seq Scan on prt1_m_p3 t1_3
          ->  Hash
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: t2.b
                      ->  Append
-                           ->  Seq Scan on prt2_m_p1 t2
-                           ->  Seq Scan on prt2_m_p2 t2_1
-                           ->  Seq Scan on prt2_m_p3 t2_2
+                           ->  Seq Scan on prt2_m_p1 t2_1
+                           ->  Seq Scan on prt2_m_p2 t2_2
+                           ->  Seq Scan on prt2_m_p3 t2_3
  Optimizer: Postgres query optimizer
 (15 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Hash Left Join
-   Hash Cond: (t1.a = t2.b)
-   ->  Append
-         ->  Seq Scan on prt1_m_p1 t1_1
-         ->  Seq Scan on prt1_m_p2 t1_2
-         ->  Seq Scan on prt1_m_p3 t1_3
-   ->  Hash
-         ->  Append
-               ->  Seq Scan on prt2_m_p1 t2_1
-               ->  Seq Scan on prt2_m_p2 t2_2
-               ->  Seq Scan on prt2_m_p3 t2_3
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- equi-join between non-key columns does not qualify for partitionwise join
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_m t1 LEFT JOIN prt2_m t2 ON t1.c = t2.c;
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3502,40 +2291,23 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_m t1 LEFT JOIN prt2_m t2 ON t1.c = t2.c;
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: t1.c
                ->  Append
-                     ->  Seq Scan on prt1_m_p1 t1
-                     ->  Seq Scan on prt1_m_p2 t1_1
-                     ->  Seq Scan on prt1_m_p3 t1_2
+                     ->  Seq Scan on prt1_m_p1 t1_1
+                     ->  Seq Scan on prt1_m_p2 t1_2
+                     ->  Seq Scan on prt1_m_p3 t1_3
          ->  Hash
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: t2.c
                      ->  Append
-                           ->  Seq Scan on prt2_m_p1 t2
-                           ->  Seq Scan on prt2_m_p2 t2_1
-                           ->  Seq Scan on prt2_m_p3 t2_2
+                           ->  Seq Scan on prt2_m_p1 t2_1
+                           ->  Seq Scan on prt2_m_p2 t2_2
+                           ->  Seq Scan on prt2_m_p3 t2_3
  Optimizer: Postgres query optimizer
 (17 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Hash Left Join
-   Hash Cond: (t1.c = t2.c)
-   ->  Append
-         ->  Seq Scan on prt1_m_p1 t1_1
-         ->  Seq Scan on prt1_m_p2 t1_2
-         ->  Seq Scan on prt1_m_p3 t1_3
-   ->  Hash
-         ->  Append
-               ->  Seq Scan on prt2_m_p1 t2_1
-               ->  Seq Scan on prt2_m_p2 t2_2
-               ->  Seq Scan on prt2_m_p3 t2_3
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- partitionwise join can not be applied for a join between list and range
 -- partitioned tables
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 LEFT JOIN prt2_n t2 ON (t1.c = t2.c);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3544,17 +2316,19 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 LEFT JOIN prt2_n t2 ON (t1.c = t2.c
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: t2.c
                ->  Append
-                     ->  Seq Scan on prt2_n_p1 t2
-                     ->  Seq Scan on prt2_n_p2 t2_1
+                     ->  Seq Scan on prt2_n_p1 t2_1
+                     ->  Seq Scan on prt2_n_p2 t2_2
          ->  Hash
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: t1.c
                      ->  Append
-                           ->  Seq Scan on prt1_n_p1 t1
-                           ->  Seq Scan on prt1_n_p2 t1_1
+                           ->  Seq Scan on prt1_n_p1 t1_1
+                           ->  Seq Scan on prt1_n_p2 t1_2
  Optimizer: Postgres query optimizer
 (15 rows)
 
+-- partitionwise join can not be applied between tables with different
+-- partition lists
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 JOIN prt2_n t2 ON (t1.c = t2.c) JOIN plt1 t3 ON (t1.c = t3.c);
                                QUERY PLAN                               
@@ -3567,67 +2341,28 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 JOIN prt2_n t2 ON (t1.c = t2.c) JOI
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: t3.c
                      ->  Append
-                           ->  Seq Scan on plt1_p1 t3
-                           ->  Seq Scan on plt1_p2 t3_1
-                           ->  Seq Scan on plt1_p3 t3_2
+                           ->  Seq Scan on plt1_p1 t3_1
+                           ->  Seq Scan on plt1_p2 t3_2
+                           ->  Seq Scan on plt1_p3 t3_3
                ->  Hash
                      ->  Redistribute Motion 3:3  (slice3; segments: 3)
                            Hash Key: t1.c
                            ->  Append
-                                 ->  Seq Scan on prt1_n_p1 t1
-                                 ->  Seq Scan on prt1_n_p2 t1_1
+                                 ->  Seq Scan on prt1_n_p1 t1_1
+                                 ->  Seq Scan on prt1_n_p2 t1_2
          ->  Hash
                ->  Redistribute Motion 3:3  (slice4; segments: 3)
                      Hash Key: t2.c
                      ->  Append
-                           ->  Seq Scan on prt2_n_p1 t2
-                           ->  Seq Scan on prt2_n_p2 t2_1
+                           ->  Seq Scan on prt2_n_p1 t2_1
+                           ->  Seq Scan on prt2_n_p2 t2_2
  Optimizer: Postgres query optimizer
 (24 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Hash Right Join
-   Hash Cond: (t2.c = (t1.c)::text)
-   ->  Append
-         ->  Seq Scan on prt2_n_p1 t2_1
-         ->  Seq Scan on prt2_n_p2 t2_2
-   ->  Hash
-         ->  Append
-               ->  Seq Scan on prt1_n_p1 t1_1
-               ->  Seq Scan on prt1_n_p2 t1_2
-(9 rows)
-
--- partitionwise join can not be applied between tables with different
--- partition lists
-EXPLAIN (COSTS OFF)
-SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 JOIN prt2_n t2 ON (t1.c = t2.c) JOIN plt1 t3 ON (t1.c = t3.c);
-                        QUERY PLAN                        
-----------------------------------------------------------
- Hash Join
-   Hash Cond: (t2.c = (t1.c)::text)
-   ->  Append
-         ->  Seq Scan on prt2_n_p1 t2_1
-         ->  Seq Scan on prt2_n_p2 t2_2
-   ->  Hash
-         ->  Hash Join
-               Hash Cond: (t3.c = (t1.c)::text)
-               ->  Append
-                     ->  Seq Scan on plt1_p1 t3_1
-                     ->  Seq Scan on plt1_p2 t3_2
-                     ->  Seq Scan on plt1_p3 t3_3
-               ->  Hash
-                     ->  Append
-                           ->  Seq Scan on prt1_n_p1 t1_1
-                           ->  Seq Scan on prt1_n_p2 t1_2
-(16 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- partitionwise join can not be applied for a join between key column and
 -- non-key column
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 FULL JOIN prt1 t2 ON (t1.c = t2.c);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3636,32 +2371,17 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1_n t1 FULL JOIN prt1 t2 ON (t1.c = t2.c);
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: t2.c
                ->  Append
-                     ->  Seq Scan on prt1_p1 t2
-                     ->  Seq Scan on prt1_p2 t2_1
-                     ->  Seq Scan on prt1_p3 t2_2
+                     ->  Seq Scan on prt1_p1 t2_1
+                     ->  Seq Scan on prt1_p2 t2_2
+                     ->  Seq Scan on prt1_p3 t2_3
          ->  Hash
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: t1.c
                      ->  Append
-                           ->  Seq Scan on prt1_n_p1 t1
-                           ->  Seq Scan on prt1_n_p2 t1_1
+                           ->  Seq Scan on prt1_n_p1 t1_1
+                           ->  Seq Scan on prt1_n_p2 t1_2
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Hash Full Join
-   Hash Cond: ((t2.c)::text = (t1.c)::text)
-   ->  Append
-         ->  Seq Scan on prt1_p1 t2_1
-         ->  Seq Scan on prt1_p2 t2_2
-         ->  Seq Scan on prt1_p3 t2_3
-   ->  Hash
-         ->  Append
-               ->  Seq Scan on prt1_n_p1 t1_1
-               ->  Seq Scan on prt1_n_p2 t1_2
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- partitionwise join can not be applied if only one of joining tables has
 -- default partition
@@ -3670,7 +2390,6 @@ ALTER TABLE prt2 ATTACH PARTITION prt2_p3 FOR VALUES FROM (500) TO (600);
 ANALYZE prt2;
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b = 0 ORDER BY t1.a, t2.b;
-<<<<<<< HEAD
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -3681,40 +2400,19 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM prt1 t1, prt2 t2 WHERE t1.a = t2.b AND t1.b =
                Hash Cond: (t2.b = t1.a)
                ->  Append
                      Partition Selectors: $0
-                     ->  Seq Scan on prt2_p1 t2
-                     ->  Seq Scan on prt2_p2 t2_1
-                     ->  Seq Scan on prt2_p3 t2_2
+                     ->  Seq Scan on prt2_p1 t2_1
+                     ->  Seq Scan on prt2_p2 t2_2
+                     ->  Seq Scan on prt2_p3 t2_3
                ->  Hash
                      ->  Partition Selector (selector id: $0)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                  ->  Append
-                                       ->  Seq Scan on prt1_p1 t1
+                                       ->  Seq Scan on prt1_p1 t1_1
                                              Filter: (b = 0)
-                                       ->  Seq Scan on prt1_p2 t1_1
+                                       ->  Seq Scan on prt1_p2 t1_2
                                              Filter: (b = 0)
-                                       ->  Seq Scan on prt1_p3 t1_2
+                                       ->  Seq Scan on prt1_p3 t1_3
                                              Filter: (b = 0)
  Optimizer: Postgres query optimizer
 (22 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Sort
-   Sort Key: t1.a
-   ->  Hash Join
-         Hash Cond: (t2.b = t1.a)
-         ->  Append
-               ->  Seq Scan on prt2_p1 t2_1
-               ->  Seq Scan on prt2_p2 t2_2
-               ->  Seq Scan on prt2_p3 t2_3
-         ->  Hash
-               ->  Append
-                     ->  Seq Scan on prt1_p1 t1_1
-                           Filter: (b = 0)
-                     ->  Seq Scan on prt1_p2 t1_2
-                           Filter: (b = 0)
-                     ->  Seq Scan on prt1_p3 t1_3
-                           Filter: (b = 0)
-(16 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 

--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -42,17 +42,16 @@ create table lp_bc partition of lp for values in ('b', 'c');
 create table lp_g partition of lp for values in ('g');
 create table lp_null partition of lp for values in (null);
 explain (costs off) select * from lp;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_ad lp
-         ->  Seq Scan on lp_bc lp_1
-         ->  Seq Scan on lp_ef lp_2
-         ->  Seq Scan on lp_g lp_3
-         ->  Seq Scan on lp_null lp_4
-         ->  Seq Scan on lp_default lp_5
+         ->  Seq Scan on lp_ad lp_1
+         ->  Seq Scan on lp_bc lp_2
+         ->  Seq Scan on lp_ef lp_3
+         ->  Seq Scan on lp_g lp_4
+         ->  Seq Scan on lp_null lp_5
+         ->  Seq Scan on lp_default lp_6
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -61,44 +60,11 @@ explain (costs off) select * from lp where a > 'a' and a < 'd';
 -----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_bc lp
+         ->  Seq Scan on lp_bc lp_1
                Filter: ((a > 'a'::bpchar) AND (a < 'd'::bpchar))
-         ->  Seq Scan on lp_default lp_1
+         ->  Seq Scan on lp_default lp_2
                Filter: ((a > 'a'::bpchar) AND (a < 'd'::bpchar))
  Optimizer: Postgres query optimizer
-=======
-            QUERY PLAN             
------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-   ->  Seq Scan on lp_bc lp_2
-   ->  Seq Scan on lp_ef lp_3
-   ->  Seq Scan on lp_g lp_4
-   ->  Seq Scan on lp_null lp_5
-   ->  Seq Scan on lp_default lp_6
-(7 rows)
-
-explain (costs off) select * from lp where a > 'a' and a < 'd';
-                        QUERY PLAN                         
------------------------------------------------------------
- Append
-   ->  Seq Scan on lp_bc lp_1
-         Filter: ((a > 'a'::bpchar) AND (a < 'd'::bpchar))
-   ->  Seq Scan on lp_default lp_2
-         Filter: ((a > 'a'::bpchar) AND (a < 'd'::bpchar))
-(5 rows)
-
-explain (costs off) select * from lp where a > 'a' and a <= 'd';
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-         Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
-   ->  Seq Scan on lp_bc lp_2
-         Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
-   ->  Seq Scan on lp_default lp_3
-         Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (7 rows)
 
 explain (costs off) select * from lp where a > 'a' and a <= 'd';
@@ -106,11 +72,11 @@ explain (costs off) select * from lp where a > 'a' and a <= 'd';
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_ad lp
+         ->  Seq Scan on lp_ad lp_1
                Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
-         ->  Seq Scan on lp_bc lp_1
+         ->  Seq Scan on lp_bc lp_2
                Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
-         ->  Seq Scan on lp_default lp_2
+         ->  Seq Scan on lp_default lp_3
                Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -134,39 +100,22 @@ explain (costs off) select * from lp where 'a' = a;	/* commuted */
 (4 rows)
 
 explain (costs off) select * from lp where a is not null;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_ad lp
+         ->  Seq Scan on lp_ad lp_1
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on lp_bc lp_1
+         ->  Seq Scan on lp_bc lp_2
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on lp_ef lp_2
+         ->  Seq Scan on lp_ef lp_3
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on lp_g lp_3
+         ->  Seq Scan on lp_g lp_4
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on lp_default lp_4
+         ->  Seq Scan on lp_default lp_5
                Filter: (a IS NOT NULL)
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-            QUERY PLAN             
------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on lp_bc lp_2
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on lp_ef lp_3
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on lp_g lp_4
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on lp_default lp_5
-         Filter: (a IS NOT NULL)
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from lp where a is null;
                 QUERY PLAN                
@@ -178,14 +127,13 @@ explain (costs off) select * from lp where a is null;
 (4 rows)
 
 explain (costs off) select * from lp where a = 'a' or a = 'c';
-<<<<<<< HEAD
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on lp_ad lp
+         ->  Seq Scan on lp_ad lp_1
                Filter: ((a = 'a'::bpchar) OR (a = 'c'::bpchar))
-         ->  Seq Scan on lp_bc lp_1
+         ->  Seq Scan on lp_bc lp_2
                Filter: ((a = 'a'::bpchar) OR (a = 'c'::bpchar))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -195,9 +143,9 @@ explain (costs off) select * from lp where a is not null and (a = 'a' or a = 'c'
 --------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on lp_ad lp
+         ->  Seq Scan on lp_ad lp_1
                Filter: ((a IS NOT NULL) AND ((a = 'a'::bpchar) OR (a = 'c'::bpchar)))
-         ->  Seq Scan on lp_bc lp_1
+         ->  Seq Scan on lp_bc lp_2
                Filter: ((a IS NOT NULL) AND ((a = 'a'::bpchar) OR (a = 'c'::bpchar)))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -207,13 +155,13 @@ explain (costs off) select * from lp where a <> 'g';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_ad lp
+         ->  Seq Scan on lp_ad lp_1
                Filter: (a <> 'g'::bpchar)
-         ->  Seq Scan on lp_bc lp_1
+         ->  Seq Scan on lp_bc lp_2
                Filter: (a <> 'g'::bpchar)
-         ->  Seq Scan on lp_ef lp_2
+         ->  Seq Scan on lp_ef lp_3
                Filter: (a <> 'g'::bpchar)
-         ->  Seq Scan on lp_default lp_3
+         ->  Seq Scan on lp_default lp_4
                Filter: (a <> 'g'::bpchar)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -223,13 +171,13 @@ explain (costs off) select * from lp where a <> 'a' and a <> 'd';
 -------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_bc lp
+         ->  Seq Scan on lp_bc lp_1
                Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-         ->  Seq Scan on lp_ef lp_1
+         ->  Seq Scan on lp_ef lp_2
                Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-         ->  Seq Scan on lp_g lp_2
+         ->  Seq Scan on lp_g lp_3
                Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-         ->  Seq Scan on lp_default lp_3
+         ->  Seq Scan on lp_default lp_4
                Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -239,78 +187,16 @@ explain (costs off) select * from lp where a not in ('a', 'd');
 ------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_bc lp
+         ->  Seq Scan on lp_bc lp_1
                Filter: (a <> ALL ('{a,d}'::bpchar[]))
-         ->  Seq Scan on lp_ef lp_1
+         ->  Seq Scan on lp_ef lp_2
                Filter: (a <> ALL ('{a,d}'::bpchar[]))
-         ->  Seq Scan on lp_g lp_2
+         ->  Seq Scan on lp_g lp_3
                Filter: (a <> ALL ('{a,d}'::bpchar[]))
-         ->  Seq Scan on lp_default lp_3
+         ->  Seq Scan on lp_default lp_4
                Filter: (a <> ALL ('{a,d}'::bpchar[]))
  Optimizer: Postgres query optimizer
 (11 rows)
-=======
-                        QUERY PLAN                        
-----------------------------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-         Filter: ((a = 'a'::bpchar) OR (a = 'c'::bpchar))
-   ->  Seq Scan on lp_bc lp_2
-         Filter: ((a = 'a'::bpchar) OR (a = 'c'::bpchar))
-(5 rows)
-
-explain (costs off) select * from lp where a is not null and (a = 'a' or a = 'c');
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-         Filter: ((a IS NOT NULL) AND ((a = 'a'::bpchar) OR (a = 'c'::bpchar)))
-   ->  Seq Scan on lp_bc lp_2
-         Filter: ((a IS NOT NULL) AND ((a = 'a'::bpchar) OR (a = 'c'::bpchar)))
-(5 rows)
-
-explain (costs off) select * from lp where a <> 'g';
-             QUERY PLAN             
-------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-         Filter: (a <> 'g'::bpchar)
-   ->  Seq Scan on lp_bc lp_2
-         Filter: (a <> 'g'::bpchar)
-   ->  Seq Scan on lp_ef lp_3
-         Filter: (a <> 'g'::bpchar)
-   ->  Seq Scan on lp_default lp_4
-         Filter: (a <> 'g'::bpchar)
-(9 rows)
-
-explain (costs off) select * from lp where a <> 'a' and a <> 'd';
-                         QUERY PLAN                          
--------------------------------------------------------------
- Append
-   ->  Seq Scan on lp_bc lp_1
-         Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-   ->  Seq Scan on lp_ef lp_2
-         Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-   ->  Seq Scan on lp_g lp_3
-         Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-   ->  Seq Scan on lp_default lp_4
-         Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
-(9 rows)
-
-explain (costs off) select * from lp where a not in ('a', 'd');
-                   QUERY PLAN                   
-------------------------------------------------
- Append
-   ->  Seq Scan on lp_bc lp_1
-         Filter: (a <> ALL ('{a,d}'::bpchar[]))
-   ->  Seq Scan on lp_ef lp_2
-         Filter: (a <> ALL ('{a,d}'::bpchar[]))
-   ->  Seq Scan on lp_g lp_3
-         Filter: (a <> ALL ('{a,d}'::bpchar[]))
-   ->  Seq Scan on lp_default lp_4
-         Filter: (a <> ALL ('{a,d}'::bpchar[]))
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- collation matches the partitioning collation, pruning works
 create table coll_pruning (a text collate "C") partition by list (a);
@@ -328,31 +214,18 @@ explain (costs off) select * from coll_pruning where a collate "C" = 'a' collate
 
 -- collation doesn't match the partitioning collation, no pruning occurs
 explain (costs off) select * from coll_pruning where a collate "POSIX" = 'a' collate "POSIX";
-<<<<<<< HEAD
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on coll_pruning_a coll_pruning
+         ->  Seq Scan on coll_pruning_a coll_pruning_1
                Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on coll_pruning_b coll_pruning_1
+         ->  Seq Scan on coll_pruning_b coll_pruning_2
                Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on coll_pruning_def coll_pruning_2
+         ->  Seq Scan on coll_pruning_def coll_pruning_3
                Filter: ((a)::text = 'a'::text COLLATE "POSIX")
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                       QUERY PLAN                        
----------------------------------------------------------
- Append
-   ->  Seq Scan on coll_pruning_a coll_pruning_1
-         Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on coll_pruning_b coll_pruning_2
-         Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on coll_pruning_def coll_pruning_3
-         Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 create table rlp (a int, b varchar) partition by range (a);
 create table rlp_default partition of rlp default partition by list (a);
@@ -396,287 +269,15 @@ explain (costs off) select * from rlp where 1 > a;	/* commuted */
 (4 rows)
 
 explain (costs off) select * from rlp where a <= 1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 1)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 1)
  Optimizer: Postgres query optimizer
-=======
-          QUERY PLAN          
-------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: (a <= 1)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: (a <= 1)
-(5 rows)
-
-explain (costs off) select * from rlp where a = 1;
-      QUERY PLAN      
-----------------------
- Seq Scan on rlp2 rlp
-   Filter: (a = 1)
-(2 rows)
-
-explain (costs off) select * from rlp where a = 1::bigint;		/* same as above */
-         QUERY PLAN          
------------------------------
- Seq Scan on rlp2 rlp
-   Filter: (a = '1'::bigint)
-(2 rows)
-
-explain (costs off) select * from rlp where a = 1::numeric;		/* no pruning */
-                  QUERY PLAN                   
------------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp3abcd rlp_3
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp3efgh rlp_4
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp3nullxy rlp_5
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp3_default rlp_6
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp4_1 rlp_7
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp4_2 rlp_8
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp4_default rlp_9
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp5_1 rlp_10
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp5_default rlp_11
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp_default_10 rlp_12
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp_default_30 rlp_13
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp_default_null rlp_14
-         Filter: ((a)::numeric = '1'::numeric)
-   ->  Seq Scan on rlp_default_default rlp_15
-         Filter: ((a)::numeric = '1'::numeric)
-(31 rows)
-
-explain (costs off) select * from rlp where a <= 10;
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: (a <= 10)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: (a <= 10)
-   ->  Seq Scan on rlp_default_10 rlp_3
-         Filter: (a <= 10)
-   ->  Seq Scan on rlp_default_default rlp_4
-         Filter: (a <= 10)
-(9 rows)
-
-explain (costs off) select * from rlp where a > 10;
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on rlp3abcd rlp_1
-         Filter: (a > 10)
-   ->  Seq Scan on rlp3efgh rlp_2
-         Filter: (a > 10)
-   ->  Seq Scan on rlp3nullxy rlp_3
-         Filter: (a > 10)
-   ->  Seq Scan on rlp3_default rlp_4
-         Filter: (a > 10)
-   ->  Seq Scan on rlp4_1 rlp_5
-         Filter: (a > 10)
-   ->  Seq Scan on rlp4_2 rlp_6
-         Filter: (a > 10)
-   ->  Seq Scan on rlp4_default rlp_7
-         Filter: (a > 10)
-   ->  Seq Scan on rlp5_1 rlp_8
-         Filter: (a > 10)
-   ->  Seq Scan on rlp5_default rlp_9
-         Filter: (a > 10)
-   ->  Seq Scan on rlp_default_30 rlp_10
-         Filter: (a > 10)
-   ->  Seq Scan on rlp_default_default rlp_11
-         Filter: (a > 10)
-(23 rows)
-
-explain (costs off) select * from rlp where a < 15;
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: (a < 15)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: (a < 15)
-   ->  Seq Scan on rlp_default_10 rlp_3
-         Filter: (a < 15)
-   ->  Seq Scan on rlp_default_default rlp_4
-         Filter: (a < 15)
-(9 rows)
-
-explain (costs off) select * from rlp where a <= 15;
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp3abcd rlp_3
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp3efgh rlp_4
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp3nullxy rlp_5
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp3_default rlp_6
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp_default_10 rlp_7
-         Filter: (a <= 15)
-   ->  Seq Scan on rlp_default_default rlp_8
-         Filter: (a <= 15)
-(17 rows)
-
-explain (costs off) select * from rlp where a > 15 and b = 'ab';
-                       QUERY PLAN                        
----------------------------------------------------------
- Append
-   ->  Seq Scan on rlp3abcd rlp_1
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp4_1 rlp_2
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp4_2 rlp_3
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp4_default rlp_4
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp5_1 rlp_5
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp5_default rlp_6
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp_default_30 rlp_7
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp_default_default rlp_8
-         Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-(17 rows)
-
-explain (costs off) select * from rlp where a = 16;
-              QUERY PLAN              
---------------------------------------
- Append
-   ->  Seq Scan on rlp3abcd rlp_1
-         Filter: (a = 16)
-   ->  Seq Scan on rlp3efgh rlp_2
-         Filter: (a = 16)
-   ->  Seq Scan on rlp3nullxy rlp_3
-         Filter: (a = 16)
-   ->  Seq Scan on rlp3_default rlp_4
-         Filter: (a = 16)
-(9 rows)
-
-explain (costs off) select * from rlp where a = 16 and b in ('not', 'in', 'here');
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Seq Scan on rlp3_default rlp
-   Filter: ((a = 16) AND ((b)::text = ANY ('{not,in,here}'::text[])))
-(2 rows)
-
-explain (costs off) select * from rlp where a = 16 and b < 'ab';
-                    QUERY PLAN                     
----------------------------------------------------
- Seq Scan on rlp3_default rlp
-   Filter: (((b)::text < 'ab'::text) AND (a = 16))
-(2 rows)
-
-explain (costs off) select * from rlp where a = 16 and b <= 'ab';
-                        QUERY PLAN                        
-----------------------------------------------------------
- Append
-   ->  Seq Scan on rlp3abcd rlp_1
-         Filter: (((b)::text <= 'ab'::text) AND (a = 16))
-   ->  Seq Scan on rlp3_default rlp_2
-         Filter: (((b)::text <= 'ab'::text) AND (a = 16))
-(5 rows)
-
-explain (costs off) select * from rlp where a = 16 and b is null;
-              QUERY PLAN              
---------------------------------------
- Seq Scan on rlp3nullxy rlp
-   Filter: ((b IS NULL) AND (a = 16))
-(2 rows)
-
-explain (costs off) select * from rlp where a = 16 and b is not null;
-                   QUERY PLAN                   
-------------------------------------------------
- Append
-   ->  Seq Scan on rlp3abcd rlp_1
-         Filter: ((b IS NOT NULL) AND (a = 16))
-   ->  Seq Scan on rlp3efgh rlp_2
-         Filter: ((b IS NOT NULL) AND (a = 16))
-   ->  Seq Scan on rlp3nullxy rlp_3
-         Filter: ((b IS NOT NULL) AND (a = 16))
-   ->  Seq Scan on rlp3_default rlp_4
-         Filter: ((b IS NOT NULL) AND (a = 16))
-(9 rows)
-
-explain (costs off) select * from rlp where a is null;
-            QUERY PLAN            
-----------------------------------
- Seq Scan on rlp_default_null rlp
-   Filter: (a IS NULL)
-(2 rows)
-
-explain (costs off) select * from rlp where a is not null;
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp3abcd rlp_3
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp3efgh rlp_4
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp3nullxy rlp_5
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp3_default rlp_6
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp4_1 rlp_7
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp4_2 rlp_8
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp4_default rlp_9
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp5_1 rlp_10
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp5_default rlp_11
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp_default_10 rlp_12
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp_default_30 rlp_13
-         Filter: (a IS NOT NULL)
-   ->  Seq Scan on rlp_default_default rlp_14
-         Filter: (a IS NOT NULL)
-(29 rows)
-
-explain (costs off) select * from rlp where a > 30;
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on rlp5_1 rlp_1
-         Filter: (a > 30)
-   ->  Seq Scan on rlp5_default rlp_2
-         Filter: (a > 30)
-   ->  Seq Scan on rlp_default_default rlp_3
-         Filter: (a > 30)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (7 rows)
 
 explain (costs off) select * from rlp where a = 1;
@@ -688,7 +289,6 @@ explain (costs off) select * from rlp where a = 1;
  Optimizer: Postgres query optimizer
 (4 rows)
 
-<<<<<<< HEAD
 explain (costs off) select * from rlp where a = 1::bigint;		/* same as above */
                 QUERY PLAN                
 ------------------------------------------
@@ -697,156 +297,59 @@ explain (costs off) select * from rlp where a = 1::bigint;		/* same as above */
          Filter: (a = '1'::bigint)
  Optimizer: Postgres query optimizer
 (4 rows)
-=======
-explain (costs off) select * from rlp where a <= 31;
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp3abcd rlp_3
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp3efgh rlp_4
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp3nullxy rlp_5
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp3_default rlp_6
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp4_1 rlp_7
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp4_2 rlp_8
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp4_default rlp_9
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp5_1 rlp_10
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp_default_10 rlp_11
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp_default_30 rlp_12
-         Filter: (a <= 31)
-   ->  Seq Scan on rlp_default_default rlp_13
-         Filter: (a <= 31)
-(27 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from rlp where a = 1::numeric;		/* no pruning */
                      QUERY PLAN                      
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp4_1 rlp_6
+         ->  Seq Scan on rlp4_1 rlp_7
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp4_2 rlp_7
+         ->  Seq Scan on rlp4_2 rlp_8
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp4_default rlp_8
+         ->  Seq Scan on rlp4_default rlp_9
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp5_1 rlp_9
+         ->  Seq Scan on rlp5_1 rlp_10
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp5_default rlp_10
+         ->  Seq Scan on rlp5_default rlp_11
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_10 rlp_11
+         ->  Seq Scan on rlp_default_10 rlp_12
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_30 rlp_12
+         ->  Seq Scan on rlp_default_30 rlp_13
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_null rlp_13
+         ->  Seq Scan on rlp_default_null rlp_14
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_default rlp_14
+         ->  Seq Scan on rlp_default_default rlp_15
                Filter: ((a)::numeric = '1'::numeric)
  Optimizer: Postgres query optimizer
 (33 rows)
 
-<<<<<<< HEAD
 explain (costs off) select * from rlp where a <= 10;
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 10)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 10)
-         ->  Seq Scan on rlp_default_10 rlp_2
+         ->  Seq Scan on rlp_default_10 rlp_3
                Filter: (a <= 10)
-         ->  Seq Scan on rlp_default_default rlp_3
+         ->  Seq Scan on rlp_default_default rlp_4
                Filter: (a <= 10)
  Optimizer: Postgres query optimizer
-=======
-explain (costs off) select * from rlp where a = 1 or b = 'ab';
-                      QUERY PLAN                       
--------------------------------------------------------
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp2 rlp_2
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp3abcd rlp_3
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp4_1 rlp_4
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp4_2 rlp_5
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp4_default rlp_6
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp5_1 rlp_7
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp5_default rlp_8
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp_default_10 rlp_9
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp_default_30 rlp_10
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp_default_null rlp_11
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-   ->  Seq Scan on rlp_default_default rlp_12
-         Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-(25 rows)
-
-explain (costs off) select * from rlp where a > 20 and a < 27;
-               QUERY PLAN                
------------------------------------------
- Append
-   ->  Seq Scan on rlp4_1 rlp_1
-         Filter: ((a > 20) AND (a < 27))
-   ->  Seq Scan on rlp4_2 rlp_2
-         Filter: ((a > 20) AND (a < 27))
-(5 rows)
-
-explain (costs off) select * from rlp where a = 29;
-          QUERY PLAN          
-------------------------------
- Seq Scan on rlp4_default rlp
-   Filter: (a = 29)
-(2 rows)
-
-explain (costs off) select * from rlp where a >= 29;
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on rlp4_default rlp_1
-         Filter: (a >= 29)
-   ->  Seq Scan on rlp5_1 rlp_2
-         Filter: (a >= 29)
-   ->  Seq Scan on rlp5_default rlp_3
-         Filter: (a >= 29)
-   ->  Seq Scan on rlp_default_30 rlp_4
-         Filter: (a >= 29)
-   ->  Seq Scan on rlp_default_default rlp_5
-         Filter: (a >= 29)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (11 rows)
 
 explain (costs off) select * from rlp where a > 10;
@@ -854,27 +357,27 @@ explain (costs off) select * from rlp where a > 10;
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: (a > 10)
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: (a > 10)
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: (a > 10)
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: (a > 10)
-         ->  Seq Scan on rlp4_1 rlp_4
+         ->  Seq Scan on rlp4_1 rlp_5
                Filter: (a > 10)
-         ->  Seq Scan on rlp4_2 rlp_5
+         ->  Seq Scan on rlp4_2 rlp_6
                Filter: (a > 10)
-         ->  Seq Scan on rlp4_default rlp_6
+         ->  Seq Scan on rlp4_default rlp_7
                Filter: (a > 10)
-         ->  Seq Scan on rlp5_1 rlp_7
+         ->  Seq Scan on rlp5_1 rlp_8
                Filter: (a > 10)
-         ->  Seq Scan on rlp5_default rlp_8
+         ->  Seq Scan on rlp5_default rlp_9
                Filter: (a > 10)
-         ->  Seq Scan on rlp_default_30 rlp_9
+         ->  Seq Scan on rlp_default_30 rlp_10
                Filter: (a > 10)
-         ->  Seq Scan on rlp_default_default rlp_10
+         ->  Seq Scan on rlp_default_default rlp_11
                Filter: (a > 10)
  Optimizer: Postgres query optimizer
 (25 rows)
@@ -884,13 +387,13 @@ explain (costs off) select * from rlp where a < 15;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a < 15)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a < 15)
-         ->  Seq Scan on rlp_default_10 rlp_2
+         ->  Seq Scan on rlp_default_10 rlp_3
                Filter: (a < 15)
-         ->  Seq Scan on rlp_default_default rlp_3
+         ->  Seq Scan on rlp_default_default rlp_4
                Filter: (a < 15)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -900,21 +403,21 @@ explain (costs off) select * from rlp where a <= 15;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 15)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: (a <= 15)
-         ->  Seq Scan on rlp_default_10 rlp_6
+         ->  Seq Scan on rlp_default_10 rlp_7
                Filter: (a <= 15)
-         ->  Seq Scan on rlp_default_default rlp_7
+         ->  Seq Scan on rlp_default_default rlp_8
                Filter: (a <= 15)
  Optimizer: Postgres query optimizer
 (19 rows)
@@ -924,21 +427,21 @@ explain (costs off) select * from rlp where a > 15 and b = 'ab';
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_1 rlp_1
+         ->  Seq Scan on rlp4_1 rlp_2
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_2 rlp_2
+         ->  Seq Scan on rlp4_2 rlp_3
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_default rlp_3
+         ->  Seq Scan on rlp4_default rlp_4
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_1 rlp_4
+         ->  Seq Scan on rlp5_1 rlp_5
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_default rlp_5
+         ->  Seq Scan on rlp5_default rlp_6
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_30 rlp_6
+         ->  Seq Scan on rlp_default_30 rlp_7
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_default rlp_7
+         ->  Seq Scan on rlp_default_default rlp_8
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
  Optimizer: Postgres query optimizer
 (19 rows)
@@ -948,13 +451,13 @@ explain (costs off) select * from rlp where a = 16;
 --------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: (a = 16)
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: (a = 16)
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: (a = 16)
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: (a = 16)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -982,9 +485,9 @@ explain (costs off) select * from rlp where a = 16 and b <= 'ab';
 ----------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: (((b)::text <= 'ab'::text) AND (a = 16))
-         ->  Seq Scan on rlp3_default rlp_1
+         ->  Seq Scan on rlp3_default rlp_2
                Filter: (((b)::text <= 'ab'::text) AND (a = 16))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1001,16 +504,15 @@ explain (costs off) select * from rlp where a = 16 and b is null;
 explain (costs off) select * from rlp where a = 16 and b is not null;
                       QUERY PLAN                      
 ------------------------------------------------------
-<<<<<<< HEAD
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: ((b IS NOT NULL) AND (a = 16))
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: ((b IS NOT NULL) AND (a = 16))
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: ((b IS NOT NULL) AND (a = 16))
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: ((b IS NOT NULL) AND (a = 16))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1029,33 +531,33 @@ explain (costs off) select * from rlp where a is not null;
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp4_1 rlp_6
+         ->  Seq Scan on rlp4_1 rlp_7
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp4_2 rlp_7
+         ->  Seq Scan on rlp4_2 rlp_8
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp4_default rlp_8
+         ->  Seq Scan on rlp4_default rlp_9
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp5_1 rlp_9
+         ->  Seq Scan on rlp5_1 rlp_10
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp5_default rlp_10
+         ->  Seq Scan on rlp5_default rlp_11
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp_default_10 rlp_11
+         ->  Seq Scan on rlp_default_10 rlp_12
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp_default_30 rlp_12
+         ->  Seq Scan on rlp_default_30 rlp_13
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp_default_default rlp_13
+         ->  Seq Scan on rlp_default_default rlp_14
                Filter: (a IS NOT NULL)
  Optimizer: Postgres query optimizer
 (31 rows)
@@ -1065,11 +567,11 @@ explain (costs off) select * from rlp where a > 30;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp5_1 rlp
+         ->  Seq Scan on rlp5_1 rlp_1
                Filter: (a > 30)
-         ->  Seq Scan on rlp5_default rlp_1
+         ->  Seq Scan on rlp5_default rlp_2
                Filter: (a > 30)
-         ->  Seq Scan on rlp_default_default rlp_2
+         ->  Seq Scan on rlp_default_default rlp_3
                Filter: (a > 30)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -1088,31 +590,31 @@ explain (costs off) select * from rlp where a <= 31;
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 31)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: (a <= 31)
-         ->  Seq Scan on rlp4_1 rlp_6
+         ->  Seq Scan on rlp4_1 rlp_7
                Filter: (a <= 31)
-         ->  Seq Scan on rlp4_2 rlp_7
+         ->  Seq Scan on rlp4_2 rlp_8
                Filter: (a <= 31)
-         ->  Seq Scan on rlp4_default rlp_8
+         ->  Seq Scan on rlp4_default rlp_9
                Filter: (a <= 31)
-         ->  Seq Scan on rlp5_1 rlp_9
+         ->  Seq Scan on rlp5_1 rlp_10
                Filter: (a <= 31)
-         ->  Seq Scan on rlp_default_10 rlp_10
+         ->  Seq Scan on rlp_default_10 rlp_11
                Filter: (a <= 31)
-         ->  Seq Scan on rlp_default_30 rlp_11
+         ->  Seq Scan on rlp_default_30 rlp_12
                Filter: (a <= 31)
-         ->  Seq Scan on rlp_default_default rlp_12
+         ->  Seq Scan on rlp_default_default rlp_13
                Filter: (a <= 31)
  Optimizer: Postgres query optimizer
 (29 rows)
@@ -1131,29 +633,29 @@ explain (costs off) select * from rlp where a = 1 or b = 'ab';
 -------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_1 rlp_3
+         ->  Seq Scan on rlp4_1 rlp_4
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_2 rlp_4
+         ->  Seq Scan on rlp4_2 rlp_5
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_default rlp_5
+         ->  Seq Scan on rlp4_default rlp_6
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_1 rlp_6
+         ->  Seq Scan on rlp5_1 rlp_7
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_default rlp_7
+         ->  Seq Scan on rlp5_default rlp_8
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_10 rlp_8
+         ->  Seq Scan on rlp_default_10 rlp_9
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_30 rlp_9
+         ->  Seq Scan on rlp_default_30 rlp_10
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_null rlp_10
+         ->  Seq Scan on rlp_default_null rlp_11
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_default rlp_11
+         ->  Seq Scan on rlp_default_default rlp_12
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
  Optimizer: Postgres query optimizer
 (27 rows)
@@ -1163,9 +665,9 @@ explain (costs off) select * from rlp where a > 20 and a < 27;
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp4_1 rlp
+         ->  Seq Scan on rlp4_1 rlp_1
                Filter: ((a > 20) AND (a < 27))
-         ->  Seq Scan on rlp4_2 rlp_1
+         ->  Seq Scan on rlp4_2 rlp_2
                Filter: ((a > 20) AND (a < 27))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1184,15 +686,15 @@ explain (costs off) select * from rlp where a >= 29;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp4_default rlp
+         ->  Seq Scan on rlp4_default rlp_1
                Filter: (a >= 29)
-         ->  Seq Scan on rlp5_1 rlp_1
+         ->  Seq Scan on rlp5_1 rlp_2
                Filter: (a >= 29)
-         ->  Seq Scan on rlp5_default rlp_2
+         ->  Seq Scan on rlp5_default rlp_3
                Filter: (a >= 29)
-         ->  Seq Scan on rlp_default_30 rlp_3
+         ->  Seq Scan on rlp_default_30 rlp_4
                Filter: (a >= 29)
-         ->  Seq Scan on rlp_default_default rlp_4
+         ->  Seq Scan on rlp_default_default rlp_5
                Filter: (a >= 29)
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -1202,9 +704,9 @@ explain (costs off) select * from rlp where a < 1 or (a > 20 and a < 25);
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: ((a < 1) OR ((a > 20) AND (a < 25)))
-         ->  Seq Scan on rlp4_1 rlp_1
+         ->  Seq Scan on rlp4_1 rlp_2
                Filter: ((a < 1) OR ((a > 20) AND (a < 25)))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1215,31 +717,12 @@ explain (costs off) select * from rlp where a = 20 or a = 40;
 ----------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp4_1 rlp
+         ->  Seq Scan on rlp4_1 rlp_1
                Filter: ((a = 20) OR (a = 40))
-         ->  Seq Scan on rlp5_default rlp_1
+         ->  Seq Scan on rlp5_default rlp_2
                Filter: ((a = 20) OR (a = 40))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
- Append
-   ->  Seq Scan on rlp1 rlp_1
-         Filter: ((a < 1) OR ((a > 20) AND (a < 25)))
-   ->  Seq Scan on rlp4_1 rlp_2
-         Filter: ((a < 1) OR ((a > 20) AND (a < 25)))
-(5 rows)
-
--- where clause contradicts sub-partition's constraint
-explain (costs off) select * from rlp where a = 20 or a = 40;
-               QUERY PLAN               
-----------------------------------------
- Append
-   ->  Seq Scan on rlp4_1 rlp_1
-         Filter: ((a = 20) OR (a = 40))
-   ->  Seq Scan on rlp5_default rlp_2
-         Filter: ((a = 20) OR (a = 40))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from rlp3 where a = 20;   /* empty */
         QUERY PLAN        
@@ -1259,63 +742,34 @@ explain (costs off) select * from rlp where a > 1 and a = 10;	/* only default */
 (4 rows)
 
 explain (costs off) select * from rlp where a > 1 and a >=15;	/* rlp3 onwards, including default */
-<<<<<<< HEAD
                      QUERY PLAN                     
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp4_1 rlp_4
+         ->  Seq Scan on rlp4_1 rlp_5
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp4_2 rlp_5
+         ->  Seq Scan on rlp4_2 rlp_6
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp4_default rlp_6
+         ->  Seq Scan on rlp4_default rlp_7
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp5_1 rlp_7
+         ->  Seq Scan on rlp5_1 rlp_8
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp5_default rlp_8
+         ->  Seq Scan on rlp5_default rlp_9
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp_default_30 rlp_9
+         ->  Seq Scan on rlp_default_30 rlp_10
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp_default_default rlp_10
+         ->  Seq Scan on rlp_default_default rlp_11
                Filter: ((a > 1) AND (a >= 15))
  Optimizer: Postgres query optimizer
 (25 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on rlp3abcd rlp_1
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp3efgh rlp_2
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp3nullxy rlp_3
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp3_default rlp_4
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp4_1 rlp_5
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp4_2 rlp_6
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp4_default rlp_7
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp5_1 rlp_8
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp5_default rlp_9
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp_default_30 rlp_10
-         Filter: ((a > 1) AND (a >= 15))
-   ->  Seq Scan on rlp_default_default rlp_11
-         Filter: ((a > 1) AND (a >= 15))
-(23 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from rlp where a = 1 and a = 3;	/* empty */
         QUERY PLAN        
@@ -1325,39 +779,22 @@ explain (costs off) select * from rlp where a = 1 and a = 3;	/* empty */
 (2 rows)
 
 explain (costs off) select * from rlp where (a = 1 and a = 3) or (a > 1 and a = 15);
-<<<<<<< HEAD
                                QUERY PLAN                                
 -------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp2 rlp
+         ->  Seq Scan on rlp2 rlp_1
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3abcd rlp_1
+         ->  Seq Scan on rlp3abcd rlp_2
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3efgh rlp_2
+         ->  Seq Scan on rlp3efgh rlp_3
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3nullxy rlp_3
+         ->  Seq Scan on rlp3nullxy rlp_4
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3_default rlp_4
+         ->  Seq Scan on rlp3_default rlp_5
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Append
-   ->  Seq Scan on rlp2 rlp_1
-         Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-   ->  Seq Scan on rlp3abcd rlp_2
-         Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-   ->  Seq Scan on rlp3efgh rlp_3
-         Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-   ->  Seq Scan on rlp3nullxy rlp_4
-         Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-   ->  Seq Scan on rlp3_default rlp_5
-         Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- multi-column keys
 create table mc3p (a int, b int, c int) partition by range (a, abs(b), c);
@@ -1371,16 +808,15 @@ create table mc3p5 partition of mc3p for values from (11, 1, 1) to (20, 10, 10);
 create table mc3p6 partition of mc3p for values from (20, 10, 10) to (20, 20, 20);
 create table mc3p7 partition of mc3p for values from (20, 20, 20) to (maxvalue, maxvalue, maxvalue);
 explain (costs off) select * from mc3p where a = 1;
-<<<<<<< HEAD
                  QUERY PLAN                  
 ---------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (a = 1)
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (a = 1)
-         ->  Seq Scan on mc3p_default mc3p_2
+         ->  Seq Scan on mc3p_default mc3p_3
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -1390,9 +826,9 @@ explain (costs off) select * from mc3p where a = 1 and abs(b) < 1;
 --------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a = 1) AND (abs(b) < 1))
-         ->  Seq Scan on mc3p_default mc3p_1
+         ->  Seq Scan on mc3p_default mc3p_2
                Filter: ((a = 1) AND (abs(b) < 1))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1402,11 +838,11 @@ explain (costs off) select * from mc3p where a = 1 and abs(b) = 1;
 --------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a = 1) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((a = 1) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p_default mc3p_2
+         ->  Seq Scan on mc3p_default mc3p_3
                Filter: ((a = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -1416,9 +852,9 @@ explain (costs off) select * from mc3p where a = 1 and abs(b) = 1 and c < 8;
 --------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((c < 8) AND (a = 1) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((c < 8) AND (a = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1428,332 +864,71 @@ explain (costs off) select * from mc3p where a = 10 and abs(b) between 5 and 35;
 -----------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p1 mc3p
-               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p2 mc3p_1
-               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p3 mc3p_2
-               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p4 mc3p_3
-               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p_default mc3p_4
-               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
- Optimizer: Postgres query optimizer
-(13 rows)
-
-explain (costs off) select * from mc3p where a > 10;
-                 QUERY PLAN                  
----------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  Seq Scan on mc3p5 mc3p
-               Filter: (a > 10)
-         ->  Seq Scan on mc3p6 mc3p_1
-               Filter: (a > 10)
-         ->  Seq Scan on mc3p7 mc3p_2
-               Filter: (a > 10)
-         ->  Seq Scan on mc3p_default mc3p_3
-               Filter: (a > 10)
- Optimizer: Postgres query optimizer
-(11 rows)
-
-explain (costs off) select * from mc3p where a >= 10;
-                 QUERY PLAN                  
----------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  Seq Scan on mc3p1 mc3p
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p2 mc3p_1
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p3 mc3p_2
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p4 mc3p_3
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p5 mc3p_4
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p6 mc3p_5
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p7 mc3p_6
-               Filter: (a >= 10)
-         ->  Seq Scan on mc3p_default mc3p_7
-               Filter: (a >= 10)
- Optimizer: Postgres query optimizer
-(19 rows)
-
-explain (costs off) select * from mc3p where a < 10;
-                 QUERY PLAN                  
----------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  Seq Scan on mc3p0 mc3p
-               Filter: (a < 10)
          ->  Seq Scan on mc3p1 mc3p_1
-               Filter: (a < 10)
-         ->  Seq Scan on mc3p_default mc3p_2
-               Filter: (a < 10)
+               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
+         ->  Seq Scan on mc3p2 mc3p_2
+               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
+         ->  Seq Scan on mc3p3 mc3p_3
+               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
+         ->  Seq Scan on mc3p4 mc3p_4
+               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
+         ->  Seq Scan on mc3p_default mc3p_5
+               Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
  Optimizer: Postgres query optimizer
-=======
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: (a = 1)
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: (a = 1)
-   ->  Seq Scan on mc3p_default mc3p_3
-         Filter: (a = 1)
-(7 rows)
-
-explain (costs off) select * from mc3p where a = 1 and abs(b) < 1;
-                 QUERY PLAN                 
---------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: ((a = 1) AND (abs(b) < 1))
-   ->  Seq Scan on mc3p_default mc3p_2
-         Filter: ((a = 1) AND (abs(b) < 1))
-(5 rows)
-
-explain (costs off) select * from mc3p where a = 1 and abs(b) = 1;
-                 QUERY PLAN                 
---------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: ((a = 1) AND (abs(b) = 1))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: ((a = 1) AND (abs(b) = 1))
-   ->  Seq Scan on mc3p_default mc3p_3
-         Filter: ((a = 1) AND (abs(b) = 1))
-(7 rows)
-
-explain (costs off) select * from mc3p where a = 1 and abs(b) = 1 and c < 8;
-                       QUERY PLAN                       
---------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: ((c < 8) AND (a = 1) AND (abs(b) = 1))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: ((c < 8) AND (a = 1) AND (abs(b) = 1))
-(5 rows)
-
-explain (costs off) select * from mc3p where a = 10 and abs(b) between 5 and 35;
-                           QUERY PLAN                            
------------------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p1 mc3p_1
-         Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-   ->  Seq Scan on mc3p2 mc3p_2
-         Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-   ->  Seq Scan on mc3p3 mc3p_3
-         Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-   ->  Seq Scan on mc3p4 mc3p_4
-         Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-   ->  Seq Scan on mc3p_default mc3p_5
-         Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-(11 rows)
-
-explain (costs off) select * from mc3p where a > 10;
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc3p5 mc3p_1
-         Filter: (a > 10)
-   ->  Seq Scan on mc3p6 mc3p_2
-         Filter: (a > 10)
-   ->  Seq Scan on mc3p7 mc3p_3
-         Filter: (a > 10)
-   ->  Seq Scan on mc3p_default mc3p_4
-         Filter: (a > 10)
-(9 rows)
-
-explain (costs off) select * from mc3p where a >= 10;
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc3p1 mc3p_1
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p2 mc3p_2
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p3 mc3p_3
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p4 mc3p_4
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p5 mc3p_5
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p6 mc3p_6
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p7 mc3p_7
-         Filter: (a >= 10)
-   ->  Seq Scan on mc3p_default mc3p_8
-         Filter: (a >= 10)
-(17 rows)
-
-explain (costs off) select * from mc3p where a < 10;
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: (a < 10)
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: (a < 10)
-   ->  Seq Scan on mc3p_default mc3p_3
-         Filter: (a < 10)
-(7 rows)
-
-explain (costs off) select * from mc3p where a <= 10 and abs(b) < 10;
-                  QUERY PLAN                   
------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: ((a <= 10) AND (abs(b) < 10))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: ((a <= 10) AND (abs(b) < 10))
-   ->  Seq Scan on mc3p2 mc3p_3
-         Filter: ((a <= 10) AND (abs(b) < 10))
-   ->  Seq Scan on mc3p_default mc3p_4
-         Filter: ((a <= 10) AND (abs(b) < 10))
-(9 rows)
-
-explain (costs off) select * from mc3p where a = 11 and abs(b) = 0;
-              QUERY PLAN               
----------------------------------------
- Seq Scan on mc3p_default mc3p
-   Filter: ((a = 11) AND (abs(b) = 0))
-(2 rows)
-
-explain (costs off) select * from mc3p where a = 20 and abs(b) = 10 and c = 100;
-                      QUERY PLAN                      
-------------------------------------------------------
- Seq Scan on mc3p6 mc3p
-   Filter: ((a = 20) AND (c = 100) AND (abs(b) = 10))
-(2 rows)
-
-explain (costs off) select * from mc3p where a > 20;
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc3p7 mc3p_1
-         Filter: (a > 20)
-   ->  Seq Scan on mc3p_default mc3p_2
-         Filter: (a > 20)
-(5 rows)
-
-explain (costs off) select * from mc3p where a >= 20;
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc3p5 mc3p_1
-         Filter: (a >= 20)
-   ->  Seq Scan on mc3p6 mc3p_2
-         Filter: (a >= 20)
-   ->  Seq Scan on mc3p7 mc3p_3
-         Filter: (a >= 20)
-   ->  Seq Scan on mc3p_default mc3p_4
-         Filter: (a >= 20)
-(9 rows)
-
-explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or (a = 10 and abs(b) = 5 and c = 10) or (a > 11 and a < 20);
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p1 mc3p_1
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-   ->  Seq Scan on mc3p2 mc3p_2
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-   ->  Seq Scan on mc3p5 mc3p_3
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-   ->  Seq Scan on mc3p_default mc3p_4
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-(9 rows)
-
-explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or (a = 10 and abs(b) = 5 and c = 10) or (a > 11 and a < 20) or a < 1;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-   ->  Seq Scan on mc3p2 mc3p_3
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-   ->  Seq Scan on mc3p5 mc3p_4
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-   ->  Seq Scan on mc3p_default mc3p_5
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-(11 rows)
-
-explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or (a = 10 and abs(b) = 5 and c = 10) or (a > 11 and a < 20) or a < 1 or a = 1;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-   ->  Seq Scan on mc3p2 mc3p_3
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-   ->  Seq Scan on mc3p5 mc3p_4
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-   ->  Seq Scan on mc3p_default mc3p_5
-         Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-(11 rows)
-
-explain (costs off) select * from mc3p where a = 1 or abs(b) = 1 or c = 1;
-                      QUERY PLAN                      
-------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p2 mc3p_3
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p3 mc3p_4
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p4 mc3p_5
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p5 mc3p_6
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p6 mc3p_7
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p7 mc3p_8
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-   ->  Seq Scan on mc3p_default mc3p_9
-         Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-(19 rows)
-
-explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1) or (a = 10 and abs(b) = 10);
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-   ->  Seq Scan on mc3p2 mc3p_3
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-   ->  Seq Scan on mc3p3 mc3p_4
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-   ->  Seq Scan on mc3p4 mc3p_5
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-   ->  Seq Scan on mc3p_default mc3p_6
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
 (13 rows)
 
-explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1) or (a = 10 and abs(b) = 9);
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on mc3p0 mc3p_1
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-   ->  Seq Scan on mc3p1 mc3p_2
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-   ->  Seq Scan on mc3p2 mc3p_3
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-   ->  Seq Scan on mc3p_default mc3p_4
-         Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+explain (costs off) select * from mc3p where a > 10;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on mc3p5 mc3p_1
+               Filter: (a > 10)
+         ->  Seq Scan on mc3p6 mc3p_2
+               Filter: (a > 10)
+         ->  Seq Scan on mc3p7 mc3p_3
+               Filter: (a > 10)
+         ->  Seq Scan on mc3p_default mc3p_4
+               Filter: (a > 10)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+explain (costs off) select * from mc3p where a >= 10;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on mc3p1 mc3p_1
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p2 mc3p_2
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p3 mc3p_3
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p4 mc3p_4
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p5 mc3p_5
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p6 mc3p_6
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p7 mc3p_7
+               Filter: (a >= 10)
+         ->  Seq Scan on mc3p_default mc3p_8
+               Filter: (a >= 10)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+explain (costs off) select * from mc3p where a < 10;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on mc3p0 mc3p_1
+               Filter: (a < 10)
+         ->  Seq Scan on mc3p1 mc3p_2
+               Filter: (a < 10)
+         ->  Seq Scan on mc3p_default mc3p_3
+               Filter: (a < 10)
+ Optimizer: Postgres query optimizer
 (9 rows)
 
 explain (costs off) select * from mc3p where a <= 10 and abs(b) < 10;
@@ -1761,13 +936,13 @@ explain (costs off) select * from mc3p where a <= 10 and abs(b) < 10;
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a <= 10) AND (abs(b) < 10))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((a <= 10) AND (abs(b) < 10))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: ((a <= 10) AND (abs(b) < 10))
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: ((a <= 10) AND (abs(b) < 10))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1795,9 +970,9 @@ explain (costs off) select * from mc3p where a > 20;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p7 mc3p
+         ->  Seq Scan on mc3p7 mc3p_1
                Filter: (a > 20)
-         ->  Seq Scan on mc3p_default mc3p_1
+         ->  Seq Scan on mc3p_default mc3p_2
                Filter: (a > 20)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1807,13 +982,13 @@ explain (costs off) select * from mc3p where a >= 20;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p5 mc3p
+         ->  Seq Scan on mc3p5 mc3p_1
                Filter: (a >= 20)
-         ->  Seq Scan on mc3p6 mc3p_1
+         ->  Seq Scan on mc3p6 mc3p_2
                Filter: (a >= 20)
-         ->  Seq Scan on mc3p7 mc3p_2
+         ->  Seq Scan on mc3p7 mc3p_3
                Filter: (a >= 20)
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (a >= 20)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1823,13 +998,13 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or
 ---------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p1 mc3p
+         ->  Seq Scan on mc3p1 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-         ->  Seq Scan on mc3p2 mc3p_1
+         ->  Seq Scan on mc3p2 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-         ->  Seq Scan on mc3p5 mc3p_2
+         ->  Seq Scan on mc3p5 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1839,15 +1014,15 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or
 --------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p5 mc3p_3
+         ->  Seq Scan on mc3p5 mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p_default mc3p_4
+         ->  Seq Scan on mc3p_default mc3p_5
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -1857,15 +1032,15 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p5 mc3p_3
+         ->  Seq Scan on mc3p5 mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p_default mc3p_4
+         ->  Seq Scan on mc3p_default mc3p_5
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -1875,23 +1050,23 @@ explain (costs off) select * from mc3p where a = 1 or abs(b) = 1 or c = 1;
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p3 mc3p_3
+         ->  Seq Scan on mc3p3 mc3p_4
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p4 mc3p_4
+         ->  Seq Scan on mc3p4 mc3p_5
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p5 mc3p_5
+         ->  Seq Scan on mc3p5 mc3p_6
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p6 mc3p_6
+         ->  Seq Scan on mc3p6 mc3p_7
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p7 mc3p_7
+         ->  Seq Scan on mc3p7 mc3p_8
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p_default mc3p_8
+         ->  Seq Scan on mc3p_default mc3p_9
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
  Optimizer: Postgres query optimizer
 (21 rows)
@@ -1901,17 +1076,17 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1) or (a = 10 a
 ------------------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p3 mc3p_3
+         ->  Seq Scan on mc3p3 mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p4 mc3p_4
+         ->  Seq Scan on mc3p4 mc3p_5
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p_default mc3p_5
+         ->  Seq Scan on mc3p_default mc3p_6
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
  Optimizer: Postgres query optimizer
 (15 rows)
@@ -1921,13 +1096,13 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1) or (a = 10 a
 -----------------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1942,56 +1117,19 @@ create table mc2p3 partition of mc2p for values from (2, minvalue) to (2, 1);
 create table mc2p4 partition of mc2p for values from (2, 1) to (2, maxvalue);
 create table mc2p5 partition of mc2p for values from (2, maxvalue) to (maxvalue, maxvalue);
 explain (costs off) select * from mc2p where a < 2;
-<<<<<<< HEAD
                  QUERY PLAN                  
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc2p0 mc2p
+         ->  Seq Scan on mc2p0 mc2p_1
                Filter: (a < 2)
-         ->  Seq Scan on mc2p1 mc2p_1
+         ->  Seq Scan on mc2p1 mc2p_2
                Filter: (a < 2)
-         ->  Seq Scan on mc2p2 mc2p_2
+         ->  Seq Scan on mc2p2 mc2p_3
                Filter: (a < 2)
-         ->  Seq Scan on mc2p_default mc2p_3
+         ->  Seq Scan on mc2p_default mc2p_4
                Filter: (a < 2)
  Optimizer: Postgres query optimizer
-=======
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc2p0 mc2p_1
-         Filter: (a < 2)
-   ->  Seq Scan on mc2p1 mc2p_2
-         Filter: (a < 2)
-   ->  Seq Scan on mc2p2 mc2p_3
-         Filter: (a < 2)
-   ->  Seq Scan on mc2p_default mc2p_4
-         Filter: (a < 2)
-(9 rows)
-
-explain (costs off) select * from mc2p where a = 2 and b < 1;
-           QUERY PLAN            
----------------------------------
- Seq Scan on mc2p3 mc2p
-   Filter: ((b < 1) AND (a = 2))
-(2 rows)
-
-explain (costs off) select * from mc2p where a > 1;
-              QUERY PLAN               
----------------------------------------
- Append
-   ->  Seq Scan on mc2p2 mc2p_1
-         Filter: (a > 1)
-   ->  Seq Scan on mc2p3 mc2p_2
-         Filter: (a > 1)
-   ->  Seq Scan on mc2p4 mc2p_3
-         Filter: (a > 1)
-   ->  Seq Scan on mc2p5 mc2p_4
-         Filter: (a > 1)
-   ->  Seq Scan on mc2p_default mc2p_5
-         Filter: (a > 1)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (11 rows)
 
 explain (costs off) select * from mc2p where a = 2 and b < 1;
@@ -2008,15 +1146,15 @@ explain (costs off) select * from mc2p where a > 1;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc2p2 mc2p
+         ->  Seq Scan on mc2p2 mc2p_1
                Filter: (a > 1)
-         ->  Seq Scan on mc2p3 mc2p_1
+         ->  Seq Scan on mc2p3 mc2p_2
                Filter: (a > 1)
-         ->  Seq Scan on mc2p4 mc2p_2
+         ->  Seq Scan on mc2p4 mc2p_3
                Filter: (a > 1)
-         ->  Seq Scan on mc2p5 mc2p_3
+         ->  Seq Scan on mc2p5 mc2p_4
                Filter: (a > 1)
-         ->  Seq Scan on mc2p_default mc2p_4
+         ->  Seq Scan on mc2p_default mc2p_5
                Filter: (a > 1)
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -2082,27 +1220,16 @@ create table boolpart_default partition of boolpart default;
 create table boolpart_t partition of boolpart for values in ('true');
 create table boolpart_f partition of boolpart for values in ('false');
 explain (costs off) select * from boolpart where a in (true, false);
-<<<<<<< HEAD
                       QUERY PLAN                      
 ------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on boolpart_f boolpart
+         ->  Seq Scan on boolpart_f boolpart_1
                Filter: (a = ANY ('{t,f}'::boolean[]))
-         ->  Seq Scan on boolpart_t boolpart_1
+         ->  Seq Scan on boolpart_t boolpart_2
                Filter: (a = ANY ('{t,f}'::boolean[]))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                   QUERY PLAN                   
-------------------------------------------------
- Append
-   ->  Seq Scan on boolpart_f boolpart_1
-         Filter: (a = ANY ('{t,f}'::boolean[]))
-   ->  Seq Scan on boolpart_t boolpart_2
-         Filter: (a = ANY ('{t,f}'::boolean[]))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from boolpart where a = false;
                 QUERY PLAN                
@@ -2123,27 +1250,16 @@ explain (costs off) select * from boolpart where not a = false;
 (4 rows)
 
 explain (costs off) select * from boolpart where a is true or a is not true;
-<<<<<<< HEAD
                        QUERY PLAN                       
 --------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on boolpart_f boolpart
+         ->  Seq Scan on boolpart_f boolpart_1
                Filter: ((a IS TRUE) OR (a IS NOT TRUE))
-         ->  Seq Scan on boolpart_t boolpart_1
+         ->  Seq Scan on boolpart_t boolpart_2
                Filter: ((a IS TRUE) OR (a IS NOT TRUE))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                    QUERY PLAN                    
---------------------------------------------------
- Append
-   ->  Seq Scan on boolpart_f boolpart_1
-         Filter: ((a IS TRUE) OR (a IS NOT TRUE))
-   ->  Seq Scan on boolpart_t boolpart_2
-         Filter: ((a IS TRUE) OR (a IS NOT TRUE))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from boolpart where a is not true;
                 QUERY PLAN                
@@ -2162,16 +1278,15 @@ explain (costs off) select * from boolpart where a is not true and a is not fals
 (2 rows)
 
 explain (costs off) select * from boolpart where a is unknown;
-<<<<<<< HEAD
                      QUERY PLAN                      
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on boolpart_f boolpart
+         ->  Seq Scan on boolpart_f boolpart_1
                Filter: (a IS UNKNOWN)
-         ->  Seq Scan on boolpart_t boolpart_1
+         ->  Seq Scan on boolpart_t boolpart_2
                Filter: (a IS UNKNOWN)
-         ->  Seq Scan on boolpart_default boolpart_2
+         ->  Seq Scan on boolpart_default boolpart_3
                Filter: (a IS UNKNOWN)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2181,38 +1296,14 @@ explain (costs off) select * from boolpart where a is not unknown;
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on boolpart_f boolpart
+         ->  Seq Scan on boolpart_f boolpart_1
                Filter: (a IS NOT UNKNOWN)
-         ->  Seq Scan on boolpart_t boolpart_1
+         ->  Seq Scan on boolpart_t boolpart_2
                Filter: (a IS NOT UNKNOWN)
-         ->  Seq Scan on boolpart_default boolpart_2
+         ->  Seq Scan on boolpart_default boolpart_3
                Filter: (a IS NOT UNKNOWN)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                  QUERY PLAN                   
------------------------------------------------
- Append
-   ->  Seq Scan on boolpart_f boolpart_1
-         Filter: (a IS UNKNOWN)
-   ->  Seq Scan on boolpart_t boolpart_2
-         Filter: (a IS UNKNOWN)
-   ->  Seq Scan on boolpart_default boolpart_3
-         Filter: (a IS UNKNOWN)
-(7 rows)
-
-explain (costs off) select * from boolpart where a is not unknown;
-                  QUERY PLAN                   
------------------------------------------------
- Append
-   ->  Seq Scan on boolpart_f boolpart_1
-         Filter: (a IS NOT UNKNOWN)
-   ->  Seq Scan on boolpart_t boolpart_2
-         Filter: (a IS NOT UNKNOWN)
-   ->  Seq Scan on boolpart_default boolpart_3
-         Filter: (a IS NOT UNKNOWN)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 create table boolrangep (a bool, b bool, c int) partition by range (a,b,c);
 create table boolrangep_tf partition of boolrangep for values from ('true', 'false', 0) to ('true', 'false', 100);
@@ -2235,7 +1326,6 @@ create table coercepart_ab partition of coercepart for values in ('ab');
 create table coercepart_bc partition of coercepart for values in ('bc');
 create table coercepart_cd partition of coercepart for values in ('cd');
 explain (costs off) select * from coercepart where a in ('ab', to_char(125, '999'));
-<<<<<<< HEAD
                         QUERY PLAN                         
 -----------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
@@ -2249,11 +1339,11 @@ explain (costs off) select * from coercepart where a ~ any ('{ab}');
 ----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coercepart_ab coercepart
+         ->  Seq Scan on coercepart_ab coercepart_1
                Filter: ((a)::text ~ ANY ('{ab}'::text[]))
-         ->  Seq Scan on coercepart_bc coercepart_1
+         ->  Seq Scan on coercepart_bc coercepart_2
                Filter: ((a)::text ~ ANY ('{ab}'::text[]))
-         ->  Seq Scan on coercepart_cd coercepart_2
+         ->  Seq Scan on coercepart_cd coercepart_3
                Filter: ((a)::text ~ ANY ('{ab}'::text[]))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2263,11 +1353,11 @@ explain (costs off) select * from coercepart where a !~ all ('{ab}');
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coercepart_ab coercepart
+         ->  Seq Scan on coercepart_ab coercepart_1
                Filter: ((a)::text !~ ALL ('{ab}'::text[]))
-         ->  Seq Scan on coercepart_bc coercepart_1
+         ->  Seq Scan on coercepart_bc coercepart_2
                Filter: ((a)::text !~ ALL ('{ab}'::text[]))
-         ->  Seq Scan on coercepart_cd coercepart_2
+         ->  Seq Scan on coercepart_cd coercepart_3
                Filter: ((a)::text !~ ALL ('{ab}'::text[]))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2277,11 +1367,11 @@ explain (costs off) select * from coercepart where a ~ any ('{ab,bc}');
 -------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coercepart_ab coercepart
+         ->  Seq Scan on coercepart_ab coercepart_1
                Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
-         ->  Seq Scan on coercepart_bc coercepart_1
+         ->  Seq Scan on coercepart_bc coercepart_2
                Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
-         ->  Seq Scan on coercepart_cd coercepart_2
+         ->  Seq Scan on coercepart_cd coercepart_3
                Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2291,11 +1381,11 @@ explain (costs off) select * from coercepart where a !~ all ('{ab,bc}');
 --------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coercepart_ab coercepart
+         ->  Seq Scan on coercepart_ab coercepart_1
                Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
-         ->  Seq Scan on coercepart_bc coercepart_1
+         ->  Seq Scan on coercepart_bc coercepart_2
                Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
-         ->  Seq Scan on coercepart_cd coercepart_2
+         ->  Seq Scan on coercepart_cd coercepart_3
                Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2305,82 +1395,12 @@ explain (costs off) select * from coercepart where a = any ('{ab,bc}');
 -------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on coercepart_ab coercepart
+         ->  Seq Scan on coercepart_ab coercepart_1
                Filter: ((a)::text = ANY ('{ab,bc}'::text[]))
-         ->  Seq Scan on coercepart_bc coercepart_1
+         ->  Seq Scan on coercepart_bc coercepart_2
                Filter: ((a)::text = ANY ('{ab,bc}'::text[]))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on coercepart_ab coercepart_1
-         Filter: ((a)::text = ANY ((ARRAY['ab'::character varying, (to_char(125, '999'::text))::character varying])::text[]))
-   ->  Seq Scan on coercepart_bc coercepart_2
-         Filter: ((a)::text = ANY ((ARRAY['ab'::character varying, (to_char(125, '999'::text))::character varying])::text[]))
-   ->  Seq Scan on coercepart_cd coercepart_3
-         Filter: ((a)::text = ANY ((ARRAY['ab'::character varying, (to_char(125, '999'::text))::character varying])::text[]))
-(7 rows)
-
-explain (costs off) select * from coercepart where a ~ any ('{ab}');
-                     QUERY PLAN                     
-----------------------------------------------------
- Append
-   ->  Seq Scan on coercepart_ab coercepart_1
-         Filter: ((a)::text ~ ANY ('{ab}'::text[]))
-   ->  Seq Scan on coercepart_bc coercepart_2
-         Filter: ((a)::text ~ ANY ('{ab}'::text[]))
-   ->  Seq Scan on coercepart_cd coercepart_3
-         Filter: ((a)::text ~ ANY ('{ab}'::text[]))
-(7 rows)
-
-explain (costs off) select * from coercepart where a !~ all ('{ab}');
-                     QUERY PLAN                      
------------------------------------------------------
- Append
-   ->  Seq Scan on coercepart_ab coercepart_1
-         Filter: ((a)::text !~ ALL ('{ab}'::text[]))
-   ->  Seq Scan on coercepart_bc coercepart_2
-         Filter: ((a)::text !~ ALL ('{ab}'::text[]))
-   ->  Seq Scan on coercepart_cd coercepart_3
-         Filter: ((a)::text !~ ALL ('{ab}'::text[]))
-(7 rows)
-
-explain (costs off) select * from coercepart where a ~ any ('{ab,bc}');
-                      QUERY PLAN                       
--------------------------------------------------------
- Append
-   ->  Seq Scan on coercepart_ab coercepart_1
-         Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
-   ->  Seq Scan on coercepart_bc coercepart_2
-         Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
-   ->  Seq Scan on coercepart_cd coercepart_3
-         Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
-(7 rows)
-
-explain (costs off) select * from coercepart where a !~ all ('{ab,bc}');
-                       QUERY PLAN                       
---------------------------------------------------------
- Append
-   ->  Seq Scan on coercepart_ab coercepart_1
-         Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
-   ->  Seq Scan on coercepart_bc coercepart_2
-         Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
-   ->  Seq Scan on coercepart_cd coercepart_3
-         Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
-(7 rows)
-
-explain (costs off) select * from coercepart where a = any ('{ab,bc}');
-                      QUERY PLAN                       
--------------------------------------------------------
- Append
-   ->  Seq Scan on coercepart_ab coercepart_1
-         Filter: ((a)::text = ANY ('{ab,bc}'::text[]))
-   ->  Seq Scan on coercepart_bc coercepart_2
-         Filter: ((a)::text = ANY ('{ab,bc}'::text[]))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from coercepart where a = any ('{ab,null}');
                        QUERY PLAN                        
@@ -2457,32 +1477,20 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM part p(x) ORDER BY x;
 ---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: p.x, p.b
-<<<<<<< HEAD
    Merge Key: p.x
    ->  Sort
          Output: p.x, p.b
          Sort Key: p.x
          ->  Append
-               ->  Seq Scan on public.part_p1 p
-                     Output: p.x, p.b
-               ->  Seq Scan on public.part_rev p_1
+               ->  Seq Scan on public.part_p1 p_1
                      Output: p_1.x, p_1.b
-               ->  Seq Scan on public.part_p2_p1 p_2
+               ->  Seq Scan on public.part_rev p_2
                      Output: p_2.x, p_2.b
+               ->  Seq Scan on public.part_p2_p1 p_3
+                     Output: p_3.x, p_3.b
  Optimizer: Postgres query optimizer
  Settings: optimizer = 'off', plan_cache_mode = 'force_generic_plan'
 (15 rows)
-=======
-   Sort Key: p.x
-   ->  Append
-         ->  Seq Scan on public.part_p1 p_1
-               Output: p_1.x, p_1.b
-         ->  Seq Scan on public.part_rev p_2
-               Output: p_2.x, p_2.b
-         ->  Seq Scan on public.part_p2_p1 p_3
-               Output: p_3.x, p_3.b
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- some more cases
@@ -2495,14 +1503,13 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Nested Loop
-<<<<<<< HEAD
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Append
-               ->  Seq Scan on mc2p1 t1
+               ->  Seq Scan on mc2p1 t1_1
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p2 t1_1
+               ->  Seq Scan on mc2p2 t1_2
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p_default t1_2
+               ->  Seq Scan on mc2p_default t1_3
                      Filter: (a = 1)
    ->  Materialize
          ->  Aggregate
@@ -2511,56 +1518,26 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                      ->  Materialize
                            ->  Gather Motion 3:1  (slice2; segments: 3)
                                  ->  Append
-                                       ->  Seq Scan on mc3p0 t2
+                                       ->  Seq Scan on mc3p0 t2_1
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p1 t2_1
+                                       ->  Seq Scan on mc3p1 t2_2
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p2 t2_2
+                                       ->  Seq Scan on mc3p2 t2_3
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p3 t2_3
+                                       ->  Seq Scan on mc3p3 t2_4
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p4 t2_4
+                                       ->  Seq Scan on mc3p4 t2_5
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p5 t2_5
+                                       ->  Seq Scan on mc3p5 t2_6
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p6 t2_6
+                                       ->  Seq Scan on mc3p6 t2_7
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p7 t2_7
+                                       ->  Seq Scan on mc3p7 t2_8
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p_default t2_8
+                                       ->  Seq Scan on mc3p_default t2_9
                                              Filter: ((c = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (35 rows)
-=======
-   ->  Append
-         ->  Seq Scan on mc2p1 t1_1
-               Filter: (a = 1)
-         ->  Seq Scan on mc2p2 t1_2
-               Filter: (a = 1)
-         ->  Seq Scan on mc2p_default t1_3
-               Filter: (a = 1)
-   ->  Aggregate
-         ->  Append
-               ->  Seq Scan on mc3p0 t2_1
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p1 t2_2
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p2 t2_3
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p3 t2_4
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p4 t2_5
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p5 t2_6
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p6 t2_7
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p7 t2_8
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p_default t2_9
-                     Filter: ((a = t1.b) AND (c = 1) AND (abs(b) = 1))
-(28 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- pruning should work fine, because values for a prefix of keys (a, b) are
 -- available
@@ -2568,14 +1545,13 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Nested Loop
-<<<<<<< HEAD
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Append
-               ->  Seq Scan on mc2p1 t1
+               ->  Seq Scan on mc2p1 t1_1
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p2 t1_1
+               ->  Seq Scan on mc2p2 t1_2
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p_default t1_2
+               ->  Seq Scan on mc2p_default t1_3
                      Filter: (a = 1)
    ->  Materialize
          ->  Aggregate
@@ -2584,11 +1560,11 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                      ->  Materialize
                            ->  Gather Motion 1:1  (slice2; segments: 1)
                                  ->  Append
-                                       ->  Seq Scan on mc3p0 t2
+                                       ->  Seq Scan on mc3p0 t2_1
                                              Filter: ((a = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p1 t2_1
+                                       ->  Seq Scan on mc3p1 t2_2
                                              Filter: ((a = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p_default t2_2
+                                       ->  Seq Scan on mc3p_default t2_3
                                              Filter: ((a = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (23 rows)
@@ -2606,49 +1582,14 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                            ->  Seq Scan on mc3p1 t2
                                  Filter: ((a = 1) AND (c = 1) AND (abs(b) = 1))
          ->  Append
-               ->  Seq Scan on mc2p1 t1
+               ->  Seq Scan on mc2p1 t1_1
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p2 t1_1
+               ->  Seq Scan on mc2p2 t1_2
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p_default t1_2
+               ->  Seq Scan on mc2p_default t1_3
                      Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-   ->  Append
-         ->  Seq Scan on mc2p1 t1_1
-               Filter: (a = 1)
-         ->  Seq Scan on mc2p2 t1_2
-               Filter: (a = 1)
-         ->  Seq Scan on mc2p_default t1_3
-               Filter: (a = 1)
-   ->  Aggregate
-         ->  Append
-               ->  Seq Scan on mc3p0 t2_1
-                     Filter: ((c = t1.b) AND (a = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p1 t2_2
-                     Filter: ((c = t1.b) AND (a = 1) AND (abs(b) = 1))
-               ->  Seq Scan on mc3p_default t2_3
-                     Filter: ((c = t1.b) AND (a = 1) AND (abs(b) = 1))
-(16 rows)
-
--- also here, because values for all keys are provided
-explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2 where t2.a = 1 and abs(t2.b) = 1 and t2.c = 1) s where t1.a = 1;
-                          QUERY PLAN                          
---------------------------------------------------------------
- Nested Loop
-   ->  Aggregate
-         ->  Seq Scan on mc3p1 t2
-               Filter: ((a = 1) AND (c = 1) AND (abs(b) = 1))
-   ->  Append
-         ->  Seq Scan on mc2p1 t1_1
-               Filter: (a = 1)
-         ->  Seq Scan on mc2p2 t1_2
-               Filter: (a = 1)
-         ->  Seq Scan on mc2p_default t1_3
-               Filter: (a = 1)
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- pruning with clauses containing <> operator
@@ -2659,16 +1600,15 @@ create table rp0 partition of rp for values from (minvalue) to (1);
 create table rp1 partition of rp for values from (1) to (2);
 create table rp2 partition of rp for values from (2) to (maxvalue);
 explain (costs off) select * from rp where a <> 1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rp0 rp
+         ->  Seq Scan on rp0 rp_1
                Filter: (a <> 1)
-         ->  Seq Scan on rp1 rp_1
+         ->  Seq Scan on rp1 rp_2
                Filter: (a <> 1)
-         ->  Seq Scan on rp2 rp_2
+         ->  Seq Scan on rp2 rp_3
                Filter: (a <> 1)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2678,11 +1618,11 @@ explain (costs off) select * from rp where a <> 1 and a <> 2;
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rp0 rp
+         ->  Seq Scan on rp0 rp_1
                Filter: ((a <> 1) AND (a <> 2))
-         ->  Seq Scan on rp1 rp_1
+         ->  Seq Scan on rp1 rp_2
                Filter: ((a <> 1) AND (a <> 2))
-         ->  Seq Scan on rp2 rp_2
+         ->  Seq Scan on rp2 rp_3
                Filter: ((a <> 1) AND (a <> 2))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2693,59 +1633,18 @@ explain (costs off) select * from lp where a <> 'a';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_ad lp
+         ->  Seq Scan on lp_ad lp_1
                Filter: (a <> 'a'::bpchar)
-         ->  Seq Scan on lp_bc lp_1
+         ->  Seq Scan on lp_bc lp_2
                Filter: (a <> 'a'::bpchar)
-         ->  Seq Scan on lp_ef lp_2
+         ->  Seq Scan on lp_ef lp_3
                Filter: (a <> 'a'::bpchar)
-         ->  Seq Scan on lp_g lp_3
+         ->  Seq Scan on lp_g lp_4
                Filter: (a <> 'a'::bpchar)
-         ->  Seq Scan on lp_default lp_4
+         ->  Seq Scan on lp_default lp_5
                Filter: (a <> 'a'::bpchar)
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-         QUERY PLAN         
-----------------------------
- Append
-   ->  Seq Scan on rp0 rp_1
-         Filter: (a <> 1)
-   ->  Seq Scan on rp1 rp_2
-         Filter: (a <> 1)
-   ->  Seq Scan on rp2 rp_3
-         Filter: (a <> 1)
-(7 rows)
-
-explain (costs off) select * from rp where a <> 1 and a <> 2;
-               QUERY PLAN                
------------------------------------------
- Append
-   ->  Seq Scan on rp0 rp_1
-         Filter: ((a <> 1) AND (a <> 2))
-   ->  Seq Scan on rp1 rp_2
-         Filter: ((a <> 1) AND (a <> 2))
-   ->  Seq Scan on rp2 rp_3
-         Filter: ((a <> 1) AND (a <> 2))
-(7 rows)
-
--- null partition should be eliminated due to strict <> clause.
-explain (costs off) select * from lp where a <> 'a';
-             QUERY PLAN             
-------------------------------------
- Append
-   ->  Seq Scan on lp_ad lp_1
-         Filter: (a <> 'a'::bpchar)
-   ->  Seq Scan on lp_bc lp_2
-         Filter: (a <> 'a'::bpchar)
-   ->  Seq Scan on lp_ef lp_3
-         Filter: (a <> 'a'::bpchar)
-   ->  Seq Scan on lp_g lp_4
-         Filter: (a <> 'a'::bpchar)
-   ->  Seq Scan on lp_default lp_5
-         Filter: (a <> 'a'::bpchar)
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- ensure we detect contradictions in clauses; a can't be NULL and NOT NULL.
 explain (costs off) select * from lp where a <> 'a' and a is null;
@@ -2756,65 +1655,37 @@ explain (costs off) select * from lp where a <> 'a' and a is null;
 (2 rows)
 
 explain (costs off) select * from lp where (a <> 'a' and a <> 'd') or a is null;
-<<<<<<< HEAD
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on lp_bc lp
+         ->  Seq Scan on lp_bc lp_1
                Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-         ->  Seq Scan on lp_ef lp_1
+         ->  Seq Scan on lp_ef lp_2
                Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-         ->  Seq Scan on lp_g lp_2
+         ->  Seq Scan on lp_g lp_3
                Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-         ->  Seq Scan on lp_null lp_3
+         ->  Seq Scan on lp_null lp_4
                Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-         ->  Seq Scan on lp_default lp_4
+         ->  Seq Scan on lp_default lp_5
                Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on lp_bc lp_1
-         Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-   ->  Seq Scan on lp_ef lp_2
-         Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-   ->  Seq Scan on lp_g lp_3
-         Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-   ->  Seq Scan on lp_null lp_4
-         Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-   ->  Seq Scan on lp_default lp_5
-         Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- check that it also works for a partitioned table that's not root,
 -- which in this case are partitions of rlp that are themselves
 -- list-partitioned on b
 explain (costs off) select * from rlp where a = 15 and b <> 'ab' and b <> 'cd' and b <> 'xy' and b is not null;
-<<<<<<< HEAD
                                                                    QUERY PLAN                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3efgh rlp
+         ->  Seq Scan on rlp3efgh rlp_1
                Filter: ((b IS NOT NULL) AND ((b)::text <> 'ab'::text) AND ((b)::text <> 'cd'::text) AND ((b)::text <> 'xy'::text) AND (a = 15))
-         ->  Seq Scan on rlp3_default rlp_1
+         ->  Seq Scan on rlp3_default rlp_2
                Filter: ((b IS NOT NULL) AND ((b)::text <> 'ab'::text) AND ((b)::text <> 'cd'::text) AND ((b)::text <> 'xy'::text) AND (a = 15))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on rlp3efgh rlp_1
-         Filter: ((b IS NOT NULL) AND ((b)::text <> 'ab'::text) AND ((b)::text <> 'cd'::text) AND ((b)::text <> 'xy'::text) AND (a = 15))
-   ->  Seq Scan on rlp3_default rlp_2
-         Filter: ((b IS NOT NULL) AND ((b)::text <> 'ab'::text) AND ((b)::text <> 'cd'::text) AND ((b)::text <> 'xy'::text) AND (a = 15))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- different collations for different keys with same expression
@@ -2825,16 +1696,15 @@ create table coll_pruning_multi2 partition of coll_pruning_multi for values from
 create table coll_pruning_multi3 partition of coll_pruning_multi for values from ('b', 'a') to ('b', 'e');
 -- no pruning, because no value for the leading key
 explain (costs off) select * from coll_pruning_multi where substr(a, 1) = 'e' collate "C";
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi
+         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi_1
                Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_1
+         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_2
                Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-         ->  Seq Scan on coll_pruning_multi3 coll_pruning_multi_2
+         ->  Seq Scan on coll_pruning_multi3 coll_pruning_multi_3
                Filter: (substr(a, 1) = 'e'::text COLLATE "C")
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -2845,35 +1715,12 @@ explain (costs off) select * from coll_pruning_multi where substr(a, 1) = 'a' co
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi
+         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi_1
                Filter: (substr(a, 1) = 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_1
+         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_2
                Filter: (substr(a, 1) = 'a'::text COLLATE "POSIX")
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi_1
-         Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-   ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_2
-         Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-   ->  Seq Scan on coll_pruning_multi3 coll_pruning_multi_3
-         Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-(7 rows)
-
--- pruning, with a value provided for the leading key
-explain (costs off) select * from coll_pruning_multi where substr(a, 1) = 'a' collate "POSIX";
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi_1
-         Filter: (substr(a, 1) = 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_2
-         Filter: (substr(a, 1) = 'a'::text COLLATE "POSIX")
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- pruning, with values provided for both keys
 explain (costs off) select * from coll_pruning_multi where substr(a, 1) = 'e' collate "C" and substr(a, 1) = 'a' collate "POSIX";
@@ -2892,27 +1739,16 @@ create table like_op_noprune (a text) partition by list (a);
 create table like_op_noprune1 partition of like_op_noprune for values in ('ABC');
 create table like_op_noprune2 partition of like_op_noprune for values in ('BCD');
 explain (costs off) select * from like_op_noprune where a like '%BC';
-<<<<<<< HEAD
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on like_op_noprune1 like_op_noprune
+         ->  Seq Scan on like_op_noprune1 like_op_noprune_1
                Filter: (a ~~ '%BC'::text)
-         ->  Seq Scan on like_op_noprune2 like_op_noprune_1
+         ->  Seq Scan on like_op_noprune2 like_op_noprune_2
                Filter: (a ~~ '%BC'::text)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                      QUERY PLAN                      
-------------------------------------------------------
- Append
-   ->  Seq Scan on like_op_noprune1 like_op_noprune_1
-         Filter: (a ~~ '%BC'::text)
-   ->  Seq Scan on like_op_noprune2 like_op_noprune_2
-         Filter: (a ~~ '%BC'::text)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- tests wherein clause value requires a cross-type comparison function
@@ -2981,18 +1817,17 @@ select tableoid::regclass, * from hp;
 
 -- partial keys won't prune, nor would non-equality conditions
 explain (costs off) select * from hp where a = 1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (a = 1)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (a = 1)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (a = 1)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3002,13 +1837,13 @@ explain (costs off) select * from hp where b = 'xxx';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (b = 'xxx'::text)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (b = 'xxx'::text)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (b = 'xxx'::text)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (b = 'xxx'::text)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3018,13 +1853,13 @@ explain (costs off) select * from hp where a is null;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (a IS NULL)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (a IS NULL)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (a IS NULL)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (a IS NULL)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3034,13 +1869,13 @@ explain (costs off) select * from hp where b is null;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (b IS NULL)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (b IS NULL)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (b IS NULL)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (b IS NULL)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3050,13 +1885,13 @@ explain (costs off) select * from hp where a < 1 and b = 'xxx';
 -------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: ((a < 1) AND (b = 'xxx'::text))
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: ((a < 1) AND (b = 'xxx'::text))
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: ((a < 1) AND (b = 'xxx'::text))
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: ((a < 1) AND (b = 'xxx'::text))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3066,13 +1901,13 @@ explain (costs off) select * from hp where a <> 1 and b = 'yyy';
 --------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: ((a <> 1) AND (b = 'yyy'::text))
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: ((a <> 1) AND (b = 'yyy'::text))
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: ((a <> 1) AND (b = 'yyy'::text))
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: ((a <> 1) AND (b = 'yyy'::text))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3082,114 +1917,16 @@ explain (costs off) select * from hp where a <> 1 and b <> 'xxx';
 ---------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
  Optimizer: Postgres query optimizer
 (11 rows)
-=======
-         QUERY PLAN         
-----------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: (a = 1)
-   ->  Seq Scan on hp1 hp_2
-         Filter: (a = 1)
-   ->  Seq Scan on hp2 hp_3
-         Filter: (a = 1)
-   ->  Seq Scan on hp3 hp_4
-         Filter: (a = 1)
-(9 rows)
-
-explain (costs off) select * from hp where b = 'xxx';
-            QUERY PLAN             
------------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: (b = 'xxx'::text)
-   ->  Seq Scan on hp1 hp_2
-         Filter: (b = 'xxx'::text)
-   ->  Seq Scan on hp2 hp_3
-         Filter: (b = 'xxx'::text)
-   ->  Seq Scan on hp3 hp_4
-         Filter: (b = 'xxx'::text)
-(9 rows)
-
-explain (costs off) select * from hp where a is null;
-         QUERY PLAN          
------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: (a IS NULL)
-   ->  Seq Scan on hp1 hp_2
-         Filter: (a IS NULL)
-   ->  Seq Scan on hp2 hp_3
-         Filter: (a IS NULL)
-   ->  Seq Scan on hp3 hp_4
-         Filter: (a IS NULL)
-(9 rows)
-
-explain (costs off) select * from hp where b is null;
-         QUERY PLAN          
------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: (b IS NULL)
-   ->  Seq Scan on hp1 hp_2
-         Filter: (b IS NULL)
-   ->  Seq Scan on hp2 hp_3
-         Filter: (b IS NULL)
-   ->  Seq Scan on hp3 hp_4
-         Filter: (b IS NULL)
-(9 rows)
-
-explain (costs off) select * from hp where a < 1 and b = 'xxx';
-                   QUERY PLAN                    
--------------------------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: ((a < 1) AND (b = 'xxx'::text))
-   ->  Seq Scan on hp1 hp_2
-         Filter: ((a < 1) AND (b = 'xxx'::text))
-   ->  Seq Scan on hp2 hp_3
-         Filter: ((a < 1) AND (b = 'xxx'::text))
-   ->  Seq Scan on hp3 hp_4
-         Filter: ((a < 1) AND (b = 'xxx'::text))
-(9 rows)
-
-explain (costs off) select * from hp where a <> 1 and b = 'yyy';
-                    QUERY PLAN                    
---------------------------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: ((a <> 1) AND (b = 'yyy'::text))
-   ->  Seq Scan on hp1 hp_2
-         Filter: ((a <> 1) AND (b = 'yyy'::text))
-   ->  Seq Scan on hp2 hp_3
-         Filter: ((a <> 1) AND (b = 'yyy'::text))
-   ->  Seq Scan on hp3 hp_4
-         Filter: ((a <> 1) AND (b = 'yyy'::text))
-(9 rows)
-
-explain (costs off) select * from hp where a <> 1 and b <> 'xxx';
-                    QUERY PLAN                     
----------------------------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: ((a <> 1) AND (b <> 'xxx'::text))
-   ->  Seq Scan on hp1 hp_2
-         Filter: ((a <> 1) AND (b <> 'xxx'::text))
-   ->  Seq Scan on hp2 hp_3
-         Filter: ((a <> 1) AND (b <> 'xxx'::text))
-   ->  Seq Scan on hp3 hp_4
-         Filter: ((a <> 1) AND (b <> 'xxx'::text))
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- pruning should work if either a value or a IS NULL clause is provided for
 -- each of the keys
@@ -3248,31 +1985,18 @@ explain (costs off) select * from hp where a = 1 and b = 'abcde';
 (4 rows)
 
 explain (costs off) select * from hp where (a = 1 and b = 'abcde') or (a = 2 and b = 'xxx') or (a is null and b is null);
-<<<<<<< HEAD
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-         ->  Seq Scan on hp2 hp_1
+         ->  Seq Scan on hp2 hp_2
                Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-         ->  Seq Scan on hp3 hp_2
+         ->  Seq Scan on hp3 hp_3
                Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Append
-   ->  Seq Scan on hp0 hp_1
-         Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-   ->  Seq Scan on hp2 hp_2
-         Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-   ->  Seq Scan on hp3 hp_3
-         Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table hp;
 --
@@ -3298,17 +2022,16 @@ set enable_indexonlyscan = off;
 prepare ab_q1 (int, int, int) as
 select * from ab where a between $1 and $2 and b <= $3;
 explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2, 3);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 ab_2 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -3319,67 +2042,34 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (1, 2, 3);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 3
-         ->  Seq Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b3 ab_2 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b1 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 ab_4 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_5 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 ab_5 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b3 ab_6 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (16 rows)
-=======
-                       QUERY PLAN                        
----------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 6
-   ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-(8 rows)
-
-explain (analyze, costs off, summary off, timing off) execute ab_q1 (1, 2, 3);
-                       QUERY PLAN                        
----------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 3
-   ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a1_b2 ab_2 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a2_b2 ab_5 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-   ->  Seq Scan on ab_a2_b3 ab_6 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-(14 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 deallocate ab_q1;
 -- Runtime pruning after optimizer pruning
 prepare ab_q1 (int, int) as
 select a from ab where a between $1 and $2 and b < 3;
 explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 4
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -3390,42 +2080,16 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b1 ab_2 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b1 ab_3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b2 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b2 ab_4 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-                       QUERY PLAN                        
----------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 4
-   ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-   ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-(6 rows)
-
-explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
-                       QUERY PLAN                        
----------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 2
-   ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-   ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-   ->  Seq Scan on ab_a3_b1 ab_3 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-   ->  Seq Scan on ab_a3_b2 ab_4 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Ensure a mix of PARAM_EXTERN and PARAM_EXEC Params work together at
 -- different levels of partitioning.
@@ -3437,27 +2101,16 @@ explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-<<<<<<< HEAD
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-         ->  Seq Scan on ab_a2_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a2_b3 ab_3 (never executed)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-   Subplans Removed: 6
-   ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-   ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-   ->  Seq Scan on ab_a2_b3 ab_3 (never executed)
-         Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- As above, but swap the PARAM_EXEC Param to the first partition level
 prepare ab_q3 (int, int) as
@@ -3468,27 +2121,16 @@ explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-<<<<<<< HEAD
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a1_b2 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-         ->  Seq Scan on ab_a3_b2 ab_2 (never executed)
+         ->  Seq Scan on ab_a3_b2 ab_3 (never executed)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-   Subplans Removed: 6
-   ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=0 loops=1)
-         Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-   ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
-         Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-   ->  Seq Scan on ab_a3_b2 ab_3 (never executed)
-         Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Test a backwards Append scan
 create table list_part (a int) partition by list (a);
@@ -3514,33 +2156,25 @@ create function list_part_fn(int) returns int as $$ begin return $1; end;$$ lang
 explain (analyze, costs off, summary off, timing off) select * from list_part where a = list_part_fn(1);
                             QUERY PLAN                            
 ------------------------------------------------------------------
-<<<<<<< HEAD
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
    ->  Seq Scan on list_part1 list_part (actual rows=1 loops=1)
          Filter: (a = 1)
  Optimizer: Postgres query optimizer
-=======
- Append (actual rows=1 loops=1)
-   Subplans Removed: 3
-   ->  Seq Scan on list_part1 list_part_1 (actual rows=1 loops=1)
-         Filter: (a = list_part_fn(1))
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (4 rows)
 
 -- Ensure pruning does not take place when the function has a Var parameter
 explain (analyze, costs off, summary off, timing off) select * from list_part where a = list_part_fn(a);
-<<<<<<< HEAD
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Append (actual rows=3 loops=1)
-         ->  Seq Scan on list_part1 list_part (actual rows=1 loops=1)
+         ->  Seq Scan on list_part1 list_part_1 (actual rows=1 loops=1)
                Filter: (a = list_part_fn(a))
-         ->  Seq Scan on list_part2 list_part_1 (actual rows=1 loops=1)
+         ->  Seq Scan on list_part2 list_part_2 (actual rows=1 loops=1)
                Filter: (a = list_part_fn(a))
-         ->  Seq Scan on list_part3 list_part_2 (actual rows=1 loops=1)
+         ->  Seq Scan on list_part3 list_part_3 (actual rows=1 loops=1)
                Filter: (a = list_part_fn(a))
-         ->  Seq Scan on list_part4 list_part_3 (actual rows=1 loops=1)
+         ->  Seq Scan on list_part4 list_part_4 (actual rows=1 loops=1)
                Filter: (a = list_part_fn(a))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -3551,49 +2185,16 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on list_part1 list_part (actual rows=0 loops=1)
+         ->  Seq Scan on list_part1 list_part_1 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
-         ->  Seq Scan on list_part2 list_part_1 (actual rows=0 loops=1)
+         ->  Seq Scan on list_part2 list_part_2 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
-         ->  Seq Scan on list_part3 list_part_2 (actual rows=0 loops=1)
+         ->  Seq Scan on list_part3 list_part_3 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
-         ->  Seq Scan on list_part4 list_part_3 (actual rows=0 loops=1)
+         ->  Seq Scan on list_part4 list_part_4 (actual rows=0 loops=1)
                Filter: (a = (1 + a))
  Optimizer: Postgres query optimizer
 (11 rows)
-=======
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Append (actual rows=4 loops=1)
-   ->  Seq Scan on list_part1 list_part_1 (actual rows=1 loops=1)
-         Filter: (a = list_part_fn(a))
-   ->  Seq Scan on list_part2 list_part_2 (actual rows=1 loops=1)
-         Filter: (a = list_part_fn(a))
-   ->  Seq Scan on list_part3 list_part_3 (actual rows=1 loops=1)
-         Filter: (a = list_part_fn(a))
-   ->  Seq Scan on list_part4 list_part_4 (actual rows=1 loops=1)
-         Filter: (a = list_part_fn(a))
-(9 rows)
-
--- Ensure pruning does not take place when the expression contains a Var.
-explain (analyze, costs off, summary off, timing off) select * from list_part where a = list_part_fn(1) + a;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   ->  Seq Scan on list_part1 list_part_1 (actual rows=0 loops=1)
-         Filter: (a = (list_part_fn(1) + a))
-         Rows Removed by Filter: 1
-   ->  Seq Scan on list_part2 list_part_2 (actual rows=0 loops=1)
-         Filter: (a = (list_part_fn(1) + a))
-         Rows Removed by Filter: 1
-   ->  Seq Scan on list_part3 list_part_3 (actual rows=0 loops=1)
-         Filter: (a = (list_part_fn(1) + a))
-         Rows Removed by Filter: 1
-   ->  Seq Scan on list_part4 list_part_4 (actual rows=0 loops=1)
-         Filter: (a = (list_part_fn(1) + a))
-         Rows Removed by Filter: 1
-(13 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 rollback;
 drop table list_part;
@@ -3638,19 +2239,11 @@ select explain_parallel_append('execute ab_q4 (2, 2)');
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-<<<<<<< HEAD
-                     ->  Seq Scan on ab_a2_b1 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b3 ab_2 (actual rows=N loops=N)
-=======
-                     ->  Parallel Seq Scan on ab_a2_b1 ab_1 (actual rows=N loops=N)
-                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Parallel Seq Scan on ab_a2_b2 ab_2 (actual rows=N loops=N)
-                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Parallel Seq Scan on ab_a2_b3 ab_3 (actual rows=N loops=N)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                     ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -3666,19 +2259,11 @@ select explain_parallel_append('execute ab_q5 (1, 1, 1)');
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-<<<<<<< HEAD
-                     ->  Seq Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
-=======
-                     ->  Parallel Seq Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                     ->  Seq Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -3691,54 +2276,32 @@ select explain_parallel_append('execute ab_q5 (2, 3, 3)');
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
                      Subplans Removed: 3
-<<<<<<< HEAD
-                     ->  Seq Scan on ab_a2_b1 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b3 ab_2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b1 ab_3 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b1 ab_4 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b2 ab_4 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b2 ab_5 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b3 ab_5 (actual rows=N loops=N)
-=======
-                     ->  Parallel Seq Scan on ab_a2_b1 ab_1 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a2_b2 ab_2 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a2_b3 ab_3 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a3_b1 ab_4 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a3_b2 ab_5 (actual rows=N loops=N)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a3_b3 ab_6 (actual rows=N loops=N)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                     ->  Seq Scan on ab_a3_b3 ab_6 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
 
 -- Try some params whose values do not belong to any partition.
 select explain_parallel_append('execute ab_q5 (33, 44, 55)');
-                  explain_parallel_append                  
------------------------------------------------------------
+                        explain_parallel_append                         
+------------------------------------------------------------------------
  Finalize Aggregate (actual rows=N loops=N)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-<<<<<<< HEAD
                ->  Append (actual rows=N loops=N)
-                     Subplans Removed: 8
-                     ->  Seq Scan on ab_a1_b1 ab (never executed)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
+                     Subplans Removed: 9
  Optimizer: Postgres query optimizer
 (8 rows)
-=======
-               ->  Parallel Append (actual rows=N loops=N)
-                     Subplans Removed: 9
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Test Parallel Append with PARAM_EXEC Params
 select explain_parallel_append('select count(*) from ab where (a = (select 1) or a = (select 3)) and b = 2');
@@ -3749,32 +2312,17 @@ select explain_parallel_append('select count(*) from ab where (a = (select 1) or
      ->  Result (actual rows=N loops=N)
    InitPlan 2 (returns $1)  (slice3)
      ->  Result (actual rows=N loops=N)
-<<<<<<< HEAD
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
-                     ->  Seq Scan on ab_a1_b2 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a2_b2 ab_1 (never executed)
+                     ->  Seq Scan on ab_a2_b2 ab_2 (never executed)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a3_b2 ab_2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b2 ab_3 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
  Optimizer: Postgres query optimizer
 (15 rows)
-=======
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 2
-         Params Evaluated: $0, $1
-         Workers Launched: N
-         ->  Parallel Append (actual rows=N loops=N)
-               ->  Parallel Seq Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
-                     Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-               ->  Parallel Seq Scan on ab_a2_b2 ab_2 (never executed)
-                     Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-               ->  Parallel Seq Scan on ab_a3_b2 ab_3 (actual rows=N loops=N)
-                     Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-(16 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Test pruning during parallel nested loop query
 create table lprt_a (a int not null);
@@ -3800,7 +2348,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=N loops=N)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-<<<<<<< HEAD
                ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab.a = a.a)
                      ->  Sort (actual rows=N loops=N)
@@ -3809,15 +2356,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
@@ -3830,31 +2377,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                        Filter: (a = ANY ('{0,0,1}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
-=======
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{0,0,1}'::integer[]))
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 ab_1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 ab_2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 ab_3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 ab_4 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 ab_5 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 ab_6 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 ab_7 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 ab_8 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 ab_9 (never executed)
-                                 Index Cond: (a = a.a)
-(27 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Ensure the same partitions are pruned when we make the nested loop
 -- parameter an Expr rather than a plain Param.
@@ -3898,7 +2420,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=N loops=N)
    ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-<<<<<<< HEAD
                ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab.a = a.a)
                      ->  Sort (actual rows=N loops=N)
@@ -3907,27 +2428,27 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 51kB  Segments: 2  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b1 ab_3 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a3_b1 ab_4 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b2 ab_4 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a3_b2 ab_5 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b3 ab_5 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a3_b3 ab_6 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
@@ -3940,31 +2461,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                        Filter: (a = ANY ('{1,0,3}'::integer[]))
  Optimizer: Postgres query optimizer
 (43 rows)
-=======
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{1,0,3}'::integer[]))
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 ab_1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 ab_2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 ab_3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 ab_4 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 ab_5 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 ab_6 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 ab_7 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 ab_8 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 ab_9 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-(27 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
                                         explain_parallel_append                                        
@@ -3972,7 +2468,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=N loops=N)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-<<<<<<< HEAD
                ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab.a = a.a)
                      ->  Sort (actual rows=N loops=N)
@@ -3981,15 +2476,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -4002,32 +2497,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
-=======
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{1,0,0}'::integer[]))
-                           Rows Removed by Filter: N
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 ab_1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 ab_2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 ab_3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 ab_4 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 ab_5 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 ab_6 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 ab_7 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 ab_8 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 ab_9 (never executed)
-                                 Index Cond: (a = a.a)
-(28 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 delete from lprt_a where a = 1;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
@@ -4036,7 +2505,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
  Finalize Aggregate (actual rows=N loops=N)
    ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-<<<<<<< HEAD
                ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab.a = a.a)
                      ->  Sort (actual rows=N loops=N)
@@ -4045,15 +2513,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -4066,32 +2534,6 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
-=======
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{1,0,0}'::integer[]))
-                           Rows Removed by Filter: N
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 ab_1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 ab_2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 ab_3 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 ab_4 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 ab_5 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 ab_6 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 ab_7 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 ab_8 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 ab_9 (never executed)
-                                 Index Cond: (a = a.a)
-(28 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 reset enable_hashjoin;
 reset enable_mergejoin;
@@ -4102,7 +2544,6 @@ reset max_parallel_workers_per_gather;
 -- Test run-time partition pruning with an initplan
 explain (analyze, costs off, summary off, timing off)
 select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 from lprt_a);
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
@@ -4117,110 +2558,53 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
                  ->  Partial Aggregate (actual rows=1 loops=1)
                        ->  Seq Scan on lprt_a lprt_a_1 (actual rows=100 loops=1)
    ->  Append (actual rows=0 loops=1)
-         ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+         ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a2_b1 ab_3 (never executed)
+         ->  Bitmap Heap Scan on ab_a2_b1 ab_4 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a2_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a2_b2 ab_4 (never executed)
+         ->  Bitmap Heap Scan on ab_a2_b2 ab_5 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a2_b2_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a2_b3 ab_5 (never executed)
+         ->  Bitmap Heap Scan on ab_a2_b3 ab_6 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a2_b3_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b1 ab_6 (never executed)
+         ->  Bitmap Heap Scan on ab_a3_b1 ab_7 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b2 ab_7 (actual rows=0 loops=1)
+         ->  Bitmap Heap Scan on ab_a3_b2 ab_8 (actual rows=0 loops=1)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b3 ab_8 (never executed)
+         ->  Bitmap Heap Scan on ab_a3_b3 ab_9 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b3_a_idx (never executed)
                      Index Cond: (a = $0)
  Optimizer: Postgres query optimizer
 (58 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   InitPlan 1 (returns $0)
-     ->  Aggregate (actual rows=1 loops=1)
-           ->  Seq Scan on lprt_a (actual rows=102 loops=1)
-   InitPlan 2 (returns $1)
-     ->  Aggregate (actual rows=1 loops=1)
-           ->  Seq Scan on lprt_a lprt_a_1 (actual rows=102 loops=1)
-   ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a2_b1 ab_4 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a2_b1_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a2_b2 ab_5 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a2_b2_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a2_b3 ab_6 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a2_b3_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a3_b1 ab_7 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a3_b2 ab_8 (actual rows=0 loops=1)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
-               Index Cond: (a = $0)
-   ->  Bitmap Heap Scan on ab_a3_b3 ab_9 (never executed)
-         Recheck Cond: (a = $0)
-         Filter: (b = $1)
-         ->  Bitmap Index Scan on ab_a3_b3_a_idx (never executed)
-               Index Cond: (a = $0)
-(52 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Test run-time partition pruning with UNION ALL parents
 explain (analyze, costs off, summary off, timing off)
@@ -4231,79 +2615,42 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
-<<<<<<< HEAD
          ->  Append (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_9 (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_11 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_10 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b2 ab_12 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_11 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b3 ab_13 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
-         ->  Seq Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b2 ab_4 (never executed)
+         ->  Seq Scan on ab_a2_b2 ab_5 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b3 ab_5 (never executed)
+         ->  Seq Scan on ab_a2_b3 ab_6 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 ab_6 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b1 ab_7 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b2 ab_7 (never executed)
+         ->  Seq Scan on ab_a3_b2 ab_8 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b3 ab_8 (never executed)
+         ->  Seq Scan on ab_a3_b3 ab_9 (never executed)
                Filter: (b = $0)
  Optimizer: Postgres query optimizer
 (39 rows)
-=======
-         ->  Bitmap Heap Scan on ab_a1_b1 ab_11 (actual rows=0 loops=1)
-               Recheck Cond: (a = 1)
-               Filter: (b = $0)
-               ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                     Index Cond: (a = 1)
-         ->  Bitmap Heap Scan on ab_a1_b2 ab_12 (never executed)
-               Recheck Cond: (a = 1)
-               Filter: (b = $0)
-               ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
-                     Index Cond: (a = 1)
-         ->  Bitmap Heap Scan on ab_a1_b3 ab_13 (never executed)
-               Recheck Cond: (a = 1)
-               Filter: (b = $0)
-               ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
-                     Index Cond: (a = 1)
-   ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a2_b2 ab_5 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a2_b3 ab_6 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a3_b1 ab_7 (actual rows=0 loops=1)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a3_b2 ab_8 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a3_b3 ab_9 (never executed)
-         Filter: (b = $0)
-(37 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- A case containing a UNION ALL with a non-partitioned child.
 explain (analyze, costs off, summary off, timing off)
@@ -4314,85 +2661,46 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
-<<<<<<< HEAD
          ->  Append (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_9 (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_11 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_10 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b2 ab_12 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_11 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b3 ab_13 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
          ->  Result (actual rows=0 loops=1)
-               One-Time Filter: (gp_execution_segment() = 2)
+               One-Time Filter: (gp_execution_segment() = 0)
                ->  Result (actual rows=0 loops=1)
                      One-Time Filter: (5 = $0)
-         ->  Seq Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b2 ab_4 (never executed)
+         ->  Seq Scan on ab_a2_b2 ab_5 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b3 ab_5 (never executed)
+         ->  Seq Scan on ab_a2_b3 ab_6 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 ab_6 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b1 ab_7 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b2 ab_7 (never executed)
+         ->  Seq Scan on ab_a3_b2 ab_8 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b3 ab_8 (never executed)
+         ->  Seq Scan on ab_a3_b3 ab_9 (never executed)
                Filter: (b = $0)
  Optimizer: Postgres query optimizer
 (43 rows)
-=======
-         ->  Bitmap Heap Scan on ab_a1_b1 ab_11 (actual rows=0 loops=1)
-               Recheck Cond: (a = 1)
-               Filter: (b = $0)
-               ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                     Index Cond: (a = 1)
-         ->  Bitmap Heap Scan on ab_a1_b2 ab_12 (never executed)
-               Recheck Cond: (a = 1)
-               Filter: (b = $0)
-               ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
-                     Index Cond: (a = 1)
-         ->  Bitmap Heap Scan on ab_a1_b3 ab_13 (never executed)
-               Recheck Cond: (a = 1)
-               Filter: (b = $0)
-               ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
-                     Index Cond: (a = 1)
-   ->  Result (actual rows=0 loops=1)
-         One-Time Filter: (5 = $0)
-   ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a2_b2 ab_5 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a2_b3 ab_6 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a3_b1 ab_7 (actual rows=0 loops=1)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a3_b2 ab_8 (never executed)
-         Filter: (b = $0)
-   ->  Seq Scan on ab_a3_b3 ab_9 (never executed)
-         Filter: (b = $0)
-(39 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Another UNION ALL test, but containing a mix of exec init and exec run-time pruning.
 create table xy_1 (x int, y int);
@@ -4414,44 +2722,24 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-<<<<<<< HEAD
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 12
-         ->  Seq Scan on ab_a1_b1 ab (never executed)
+         ->  Seq Scan on ab_a1_b1 ab_1 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
                Filter: ((a = $1) AND (b = $0))
          ->  Seq Scan on xy_1 (actual rows=0 loops=1)
                Filter: ((x = $1) AND (y = $0))
-         ->  Seq Scan on ab_a1_b1 ab_3 (never executed)
+         ->  Seq Scan on ab_a1_b1 ab_4 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b2 ab_4 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_5 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b3 ab_5 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_6 (never executed)
                Filter: ((a = $1) AND (b = $0))
  Optimizer: Postgres query optimizer
 (20 rows)
-=======
-   Subplans Removed: 12
-   ->  Seq Scan on ab_a1_b1 ab_1 (never executed)
-         Filter: ((a = $1) AND (b = $0))
-   ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
-         Filter: ((a = $1) AND (b = $0))
-   ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
-         Filter: ((a = $1) AND (b = $0))
-   ->  Seq Scan on xy_1 (actual rows=0 loops=1)
-         Filter: ((x = $1) AND (y = $0))
-         Rows Removed by Filter: 1
-   ->  Seq Scan on ab_a1_b1 ab_4 (never executed)
-         Filter: ((a = $1) AND (b = $0))
-   ->  Seq Scan on ab_a1_b2 ab_5 (never executed)
-         Filter: ((a = $1) AND (b = $0))
-   ->  Seq Scan on ab_a1_b3 ab_6 (never executed)
-         Filter: ((a = $1) AND (b = $0))
-(19 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Ensure we see just the xy_1 row.
 execute ab_q6(100);
@@ -4479,22 +2767,21 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
    Update on ab_a1_b2 ab_a1_2
    Update on ab_a1_b3 ab_a1_3
    ->  Nested Loop (actual rows=0 loops=1)
-<<<<<<< HEAD
          ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_1 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
                ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                  Index Cond: (a = 1)
@@ -4503,100 +2790,41 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                Recheck Cond: (a = 1)
                ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
                      Index Cond: (a = 1)
-=======
-         ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=1 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-         ->  Materialize (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-   ->  Nested Loop (actual rows=1 loops=1)
-         ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=1 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
          ->  Materialize (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=1 loops=1)
+                     ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=1 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=0 loops=1)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
    ->  Nested Loop (actual rows=0 loops=1)
-<<<<<<< HEAD
          ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_3 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
                ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                  Index Cond: (a = 1)
  Optimizer: Postgres query optimizer
 (62 rows)
-=======
-         ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=1 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-         ->  Materialize (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_3 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-(65 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 table ab;
  a | b 
@@ -4609,13 +2837,8 @@ truncate ab;
 insert into ab values (1, 1), (1, 2), (1, 3), (2, 1);
 explain (analyze, costs off, summary off, timing off)
 update ab_a1 set b = 3 from ab_a2 where ab_a2.b = (select 1);
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
-=======
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
  Update on ab_a1 (actual rows=0 loops=1)
    Update on ab_a1_b1 ab_a1_1
    Update on ab_a1_b2 ab_a1_2
@@ -4692,7 +2915,6 @@ set enable_mergejoin = off;
 set enable_seqscan=off;
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 join tprt on tbl1.col1 > tprt.col1;
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=6 loops=1)
@@ -4700,27 +2922,27 @@ select * from tbl1 join tprt on tbl1.col1 > tprt.col1;
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
                ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Append (actual rows=1 loops=2)
-               ->  Bitmap Heap Scan on tprt_1 tprt (actual rows=1 loops=2)
+               ->  Bitmap Heap Scan on tprt_1 (actual rows=1 loops=2)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt1_idx (actual rows=1 loops=2)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_2 tprt_1 (actual rows=2 loops=1)
+               ->  Bitmap Heap Scan on tprt_2 (actual rows=2 loops=1)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt2_idx (actual rows=2 loops=1)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_3 tprt_2 (never executed)
+               ->  Bitmap Heap Scan on tprt_3 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt3_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_4 tprt_3 (never executed)
+               ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt4_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_5 tprt_4 (never executed)
+               ->  Bitmap Heap Scan on tprt_5 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt5_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_6 tprt_5 (never executed)
+               ->  Bitmap Heap Scan on tprt_6 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt6_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
@@ -4735,73 +2957,32 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
    ->  Nested Loop (actual rows=1 loops=1)
          ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on tprt_1 tprt (never executed)
+               ->  Bitmap Heap Scan on tprt_1 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt1_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_2 tprt_1 (actual rows=1 loops=1)
+               ->  Bitmap Heap Scan on tprt_2 (actual rows=1 loops=1)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt2_idx (actual rows=1 loops=1)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_3 tprt_2 (never executed)
+               ->  Bitmap Heap Scan on tprt_3 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt3_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_4 tprt_3 (never executed)
+               ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt4_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_5 tprt_4 (never executed)
+               ->  Bitmap Heap Scan on tprt_5 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt5_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_6 tprt_5 (never executed)
+               ->  Bitmap Heap Scan on tprt_6 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt6_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
  Optimizer: Postgres query optimizer
 (29 rows)
-=======
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Nested Loop (actual rows=6 loops=1)
-   ->  Seq Scan on tbl1 (actual rows=2 loops=1)
-   ->  Append (actual rows=3 loops=2)
-         ->  Index Scan using tprt1_idx on tprt_1 (actual rows=2 loops=2)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt2_idx on tprt_2 (actual rows=2 loops=1)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt3_idx on tprt_3 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt4_idx on tprt_4 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt5_idx on tprt_5 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt6_idx on tprt_6 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-(15 rows)
-
-explain (analyze, costs off, summary off, timing off)
-select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Nested Loop (actual rows=2 loops=1)
-   ->  Seq Scan on tbl1 (actual rows=2 loops=1)
-   ->  Append (actual rows=1 loops=2)
-         ->  Index Scan using tprt1_idx on tprt_1 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt2_idx on tprt_2 (actual rows=1 loops=2)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt3_idx on tprt_3 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt4_idx on tprt_4 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt5_idx on tprt_5 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt6_idx on tprt_6 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 > tprt.col1
@@ -4829,7 +3010,6 @@ order by tbl1.col1, tprt.col1;
 insert into tbl1 values (1001), (1010), (1011);
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 inner join tprt on tbl1.col1 > tprt.col1;
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=23 loops=1)
@@ -4837,27 +3017,27 @@ select * from tbl1 inner join tprt on tbl1.col1 > tprt.col1;
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=5 loops=1)
                ->  Seq Scan on tbl1 (actual rows=3 loops=1)
          ->  Append (actual rows=2 loops=5)
-               ->  Bitmap Heap Scan on tprt_1 tprt (actual rows=1 loops=5)
+               ->  Bitmap Heap Scan on tprt_1 (actual rows=1 loops=5)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt1_idx (actual rows=1 loops=5)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_2 tprt_1 (actual rows=2 loops=4)
+               ->  Bitmap Heap Scan on tprt_2 (actual rows=2 loops=4)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt2_idx (actual rows=2 loops=4)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_3 tprt_2 (actual rows=1 loops=2)
+               ->  Bitmap Heap Scan on tprt_3 (actual rows=1 loops=2)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt3_idx (actual rows=1 loops=2)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_4 tprt_3 (never executed)
+               ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt4_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_5 tprt_4 (never executed)
+               ->  Bitmap Heap Scan on tprt_5 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt5_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_6 tprt_5 (never executed)
+               ->  Bitmap Heap Scan on tprt_6 (never executed)
                      Recheck Cond: (tbl1.col1 > col1)
                      ->  Bitmap Index Scan on tprt6_idx (never executed)
                            Index Cond: (col1 < tbl1.col1)
@@ -4872,73 +3052,32 @@ select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
    ->  Nested Loop (actual rows=2 loops=1)
          ->  Seq Scan on tbl1 (actual rows=3 loops=1)
          ->  Append (actual rows=1 loops=3)
-               ->  Bitmap Heap Scan on tprt_1 tprt (never executed)
+               ->  Bitmap Heap Scan on tprt_1 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt1_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_2 tprt_1 (actual rows=1 loops=1)
+               ->  Bitmap Heap Scan on tprt_2 (actual rows=1 loops=1)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt2_idx (actual rows=1 loops=1)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_3 tprt_2 (actual rows=0 loops=2)
+               ->  Bitmap Heap Scan on tprt_3 (actual rows=0 loops=2)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt3_idx (actual rows=0 loops=2)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_4 tprt_3 (never executed)
+               ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt4_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_5 tprt_4 (never executed)
+               ->  Bitmap Heap Scan on tprt_5 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt5_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_6 tprt_5 (never executed)
+               ->  Bitmap Heap Scan on tprt_6 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt6_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
  Optimizer: Postgres query optimizer
 (29 rows)
-=======
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Nested Loop (actual rows=23 loops=1)
-   ->  Seq Scan on tbl1 (actual rows=5 loops=1)
-   ->  Append (actual rows=5 loops=5)
-         ->  Index Scan using tprt1_idx on tprt_1 (actual rows=2 loops=5)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt2_idx on tprt_2 (actual rows=3 loops=4)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt3_idx on tprt_3 (actual rows=1 loops=2)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt4_idx on tprt_4 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt5_idx on tprt_5 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-         ->  Index Scan using tprt6_idx on tprt_6 (never executed)
-               Index Cond: (col1 < tbl1.col1)
-(15 rows)
-
-explain (analyze, costs off, summary off, timing off)
-select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Nested Loop (actual rows=3 loops=1)
-   ->  Seq Scan on tbl1 (actual rows=5 loops=1)
-   ->  Append (actual rows=1 loops=5)
-         ->  Index Scan using tprt1_idx on tprt_1 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt2_idx on tprt_2 (actual rows=1 loops=2)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt3_idx on tprt_3 (actual rows=0 loops=3)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt4_idx on tprt_4 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt5_idx on tprt_5 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt6_idx on tprt_6 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 > tprt.col1
@@ -4985,7 +3124,6 @@ delete from tbl1;
 insert into tbl1 values (4400);
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 join tprt on tbl1.col1 < tprt.col1;
-<<<<<<< HEAD
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
@@ -4993,52 +3131,32 @@ select * from tbl1 join tprt on tbl1.col1 < tprt.col1;
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
                ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on tprt_1 tprt (never executed)
+               ->  Bitmap Heap Scan on tprt_1 (never executed)
                      Recheck Cond: (tbl1.col1 < col1)
                      ->  Bitmap Index Scan on tprt1_idx (never executed)
                            Index Cond: (col1 > tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_2 tprt_1 (never executed)
+               ->  Bitmap Heap Scan on tprt_2 (never executed)
                      Recheck Cond: (tbl1.col1 < col1)
                      ->  Bitmap Index Scan on tprt2_idx (never executed)
                            Index Cond: (col1 > tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_3 tprt_2 (never executed)
+               ->  Bitmap Heap Scan on tprt_3 (never executed)
                      Recheck Cond: (tbl1.col1 < col1)
                      ->  Bitmap Index Scan on tprt3_idx (never executed)
                            Index Cond: (col1 > tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_4 tprt_3 (never executed)
+               ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (tbl1.col1 < col1)
                      ->  Bitmap Index Scan on tprt4_idx (never executed)
                            Index Cond: (col1 > tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_5 tprt_4 (never executed)
+               ->  Bitmap Heap Scan on tprt_5 (never executed)
                      Recheck Cond: (tbl1.col1 < col1)
                      ->  Bitmap Index Scan on tprt5_idx (never executed)
                            Index Cond: (col1 > tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_6 tprt_5 (actual rows=1 loops=1)
+               ->  Bitmap Heap Scan on tprt_6 (actual rows=1 loops=1)
                      Recheck Cond: (tbl1.col1 < col1)
                      ->  Bitmap Index Scan on tprt6_idx (actual rows=1 loops=1)
                            Index Cond: (col1 > tbl1.col1)
  Optimizer: Postgres query optimizer
 (30 rows)
-=======
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Nested Loop (actual rows=1 loops=1)
-   ->  Seq Scan on tbl1 (actual rows=1 loops=1)
-   ->  Append (actual rows=1 loops=1)
-         ->  Index Scan using tprt1_idx on tprt_1 (never executed)
-               Index Cond: (col1 > tbl1.col1)
-         ->  Index Scan using tprt2_idx on tprt_2 (never executed)
-               Index Cond: (col1 > tbl1.col1)
-         ->  Index Scan using tprt3_idx on tprt_3 (never executed)
-               Index Cond: (col1 > tbl1.col1)
-         ->  Index Scan using tprt4_idx on tprt_4 (never executed)
-               Index Cond: (col1 > tbl1.col1)
-         ->  Index Scan using tprt5_idx on tprt_5 (never executed)
-               Index Cond: (col1 > tbl1.col1)
-         ->  Index Scan using tprt6_idx on tprt_6 (actual rows=1 loops=1)
-               Index Cond: (col1 > tbl1.col1)
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 < tprt.col1
@@ -5054,59 +3172,38 @@ delete from tbl1;
 insert into tbl1 values (10000);
 explain (analyze, costs off, summary off, timing off)
 select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
-<<<<<<< HEAD
                                QUERY PLAN                                
 -------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Seq Scan on tbl1 (actual rows=1 loops=1)
          ->  Append (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on tprt_1 tprt (never executed)
+               ->  Bitmap Heap Scan on tprt_1 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt1_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_2 tprt_1 (never executed)
+               ->  Bitmap Heap Scan on tprt_2 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt2_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_3 tprt_2 (never executed)
+               ->  Bitmap Heap Scan on tprt_3 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt3_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_4 tprt_3 (never executed)
+               ->  Bitmap Heap Scan on tprt_4 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt4_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_5 tprt_4 (never executed)
+               ->  Bitmap Heap Scan on tprt_5 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt5_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
-               ->  Bitmap Heap Scan on tprt_6 tprt_5 (never executed)
+               ->  Bitmap Heap Scan on tprt_6 (never executed)
                      Recheck Cond: (col1 = tbl1.col1)
                      ->  Bitmap Index Scan on tprt6_idx (never executed)
                            Index Cond: (col1 = tbl1.col1)
  Optimizer: Postgres query optimizer
 (29 rows)
-=======
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Nested Loop (actual rows=0 loops=1)
-   ->  Seq Scan on tbl1 (actual rows=1 loops=1)
-   ->  Append (actual rows=0 loops=1)
-         ->  Index Scan using tprt1_idx on tprt_1 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt2_idx on tprt_2 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt3_idx on tprt_3 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt4_idx on tprt_4 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt5_idx on tprt_5 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-         ->  Index Scan using tprt6_idx on tprt_6 (never executed)
-               Index Cond: (col1 = tbl1.col1)
-(15 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select tbl1.col1, tprt.col1 from tbl1
 inner join tprt on tbl1.col1 = tprt.col1
@@ -5159,110 +3256,61 @@ select * from listp where b = 1;
 -- which match the given parameter.
 prepare q1 (int,int) as select * from listp where b in ($1,$2);
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,1);
-<<<<<<< HEAD
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (actual rows=0 loops=1)
+         ->  Seq Scan on listp_1_1 listp_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
 
 explain (analyze, costs off, summary off, timing off)  execute q1 (2,2);
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_2_1 listp (actual rows=0 loops=1)
+         ->  Seq Scan on listp_2_1 listp_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                         QUERY PLAN                          
--------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 1
-   ->  Seq Scan on listp_1_1 listp_1 (actual rows=0 loops=1)
-         Filter: (b = ANY (ARRAY[$1, $2]))
-(4 rows)
-
-explain (analyze, costs off, summary off, timing off)  execute q1 (2,2);
-                         QUERY PLAN                          
--------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 1
-   ->  Seq Scan on listp_2_1 listp_1 (actual rows=0 loops=1)
-         Filter: (b = ANY (ARRAY[$1, $2]))
-(4 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Try with no matching partitions.
 explain (analyze, costs off, summary off, timing off)  execute q1 (0,0);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (never executed)
-               Filter: (b = ANY (ARRAY[$1, $2]))
+         Subplans Removed: 2
  Optimizer: Postgres query optimizer
-(6 rows)
-=======
-           QUERY PLAN           
---------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 2
-(2 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+(4 rows)
 
 deallocate q1;
 -- Test more complex cases where a not-equal condition further eliminates partitions.
 prepare q1 (int,int,int,int) as select * from listp where b in($1,$2) and $3 <> b and $4 <> b;
 -- Both partitions allowed by IN clause, but one disallowed by <> clause
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,0);
-<<<<<<< HEAD
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (actual rows=0 loops=1)
+         ->  Seq Scan on listp_1_1 listp_1 (actual rows=0 loops=1)
                Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 1
-   ->  Seq Scan on listp_1_1 listp_1 (actual rows=0 loops=1)
-         Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
-(4 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- Both partitions allowed by IN clause, then both excluded again by <> clauses.
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,1);
-<<<<<<< HEAD
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (never executed)
-               Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
+         Subplans Removed: 2
  Optimizer: Postgres query optimizer
-(6 rows)
-=======
-           QUERY PLAN           
---------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 2
-(2 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+(4 rows)
 
 -- Ensure Params that evaluate to NULL properly prune away all partitions
 explain (analyze, costs off, summary off, timing off)
@@ -5272,21 +3320,13 @@ select * from listp where a = (select null::int);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-<<<<<<< HEAD
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on listp_1_1 listp (never executed)
+         ->  Seq Scan on listp_1_1 listp_1 (never executed)
                Filter: (a = $0)
-         ->  Seq Scan on listp_2_1 listp_1 (never executed)
+         ->  Seq Scan on listp_2_1 listp_2 (never executed)
                Filter: (a = $0)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-   ->  Seq Scan on listp_1_1 listp_1 (never executed)
-         Filter: (a = $0)
-   ->  Seq Scan on listp_2_1 listp_2 (never executed)
-         Filter: (a = $0)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table listp;
 --
@@ -5304,51 +3344,29 @@ create table stable_qual_pruning3 partition of stable_qual_pruning
 -- comparison against a stable value requires run-time pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning where a < localtimestamp;
-<<<<<<< HEAD
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning (actual rows=0 loops=1)
-               Filter: (a < 'Thu Jul 03 00:41:49.344804 2025'::timestamp without time zone)
-         ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_1 (actual rows=0 loops=1)
-               Filter: (a < 'Thu Jul 03 00:41:49.344804 2025'::timestamp without time zone)
+         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning_1 (actual rows=0 loops=1)
+               Filter: (a < 'Wed Jul 23 03:08:45.23423 2025'::timestamp without time zone)
+         ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_2 (actual rows=0 loops=1)
+               Filter: (a < 'Wed Jul 23 03:08:45.23423 2025'::timestamp without time zone)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 1
-   ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning_1 (actual rows=0 loops=1)
-         Filter: (a < LOCALTIMESTAMP)
-   ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_2 (actual rows=0 loops=1)
-         Filter: (a < LOCALTIMESTAMP)
-(6 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- timestamp < timestamptz comparison is only stable, not immutable
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning where a < '2000-02-01'::timestamptz;
-<<<<<<< HEAD
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning (actual rows=0 loops=1)
+         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning_1 (actual rows=0 loops=1)
                Filter: (a < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 2
-   ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning_1 (actual rows=0 loops=1)
-         Filter: (a < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
-(4 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- check ScalarArrayOp cases
 explain (analyze, costs off, summary off, timing off)
@@ -5374,95 +3392,53 @@ select * from stable_qual_pruning
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(array['2000-02-01', localtimestamp]::timestamp[]);
-<<<<<<< HEAD
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning (actual rows=0 loops=1)
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Thu Sep 15 22:18:08.839445 2022"}'::timestamp without time zone[]))
  Optimizer: Postgres query optimizer
-=======
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 2
-   ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_1 (actual rows=0 loops=1)
-         Filter: (a = ANY (ARRAY['Tue Feb 01 00:00:00 2000'::timestamp without time zone, LOCALTIMESTAMP]))
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (4 rows)
 
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(array['2010-02-01', '2020-01-01']::timestamptz[]);
-<<<<<<< HEAD
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         Subplans Removed: 2
-         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning (never executed)
-               Filter: (a = ANY ('{"Mon Feb 01 00:00:00 2010 PST","Wed Jan 01 00:00:00 2020 PST"}'::timestamp with time zone[]))
+         Subplans Removed: 3
  Optimizer: Postgres query optimizer
-(6 rows)
-=======
-           QUERY PLAN           
---------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 3
-(2 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+(4 rows)
 
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(array['2000-02-01', '2010-01-01']::timestamptz[]);
-<<<<<<< HEAD
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning (actual rows=0 loops=1)
+         ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_1 (actual rows=0 loops=1)
                Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000 PST","Fri Jan 01 00:00:00 2010 PST"}'::timestamp with time zone[]))
  Optimizer: Postgres query optimizer
 (6 rows)
-=======
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   Subplans Removed: 2
-   ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_1 (actual rows=0 loops=1)
-         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000 PST","Fri Jan 01 00:00:00 2010 PST"}'::timestamp with time zone[]))
-(4 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (analyze, costs off, summary off, timing off)
 select * from stable_qual_pruning
   where a = any(null::timestamptz[]);
-<<<<<<< HEAD
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning (actual rows=0 loops=1)
+         ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning_1 (actual rows=0 loops=1)
                Filter: (a = ANY (NULL::timestamp with time zone[]))
-         ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_1 (actual rows=0 loops=1)
+         ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_2 (actual rows=0 loops=1)
                Filter: (a = ANY (NULL::timestamp with time zone[]))
-         ->  Seq Scan on stable_qual_pruning3 stable_qual_pruning_2 (actual rows=0 loops=1)
+         ->  Seq Scan on stable_qual_pruning3 stable_qual_pruning_3 (actual rows=0 loops=1)
                Filter: (a = ANY (NULL::timestamp with time zone[]))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   ->  Seq Scan on stable_qual_pruning1 stable_qual_pruning_1 (actual rows=0 loops=1)
-         Filter: (a = ANY (NULL::timestamp with time zone[]))
-   ->  Seq Scan on stable_qual_pruning2 stable_qual_pruning_2 (actual rows=0 loops=1)
-         Filter: (a = ANY (NULL::timestamp with time zone[]))
-   ->  Seq Scan on stable_qual_pruning3 stable_qual_pruning_3 (actual rows=0 loops=1)
-         Filter: (a = ANY (NULL::timestamp with time zone[]))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table stable_qual_pruning;
 --
@@ -5480,31 +3456,18 @@ create table mc3p2 partition of mc3p
 insert into mc3p values (0, 1, 1), (1, 1, 1), (2, 1, 1);
 explain (analyze, costs off, summary off, timing off)
 select * from mc3p where a < 3 and abs(b) = 1;
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
    ->  Append (actual rows=2 loops=1)
-         ->  Seq Scan on mc3p0 mc3p (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p0 mc3p_1 (actual rows=1 loops=1)
                Filter: ((a < 3) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p1 mc3p_2 (actual rows=1 loops=1)
                Filter: ((a < 3) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p2 mc3p_2 (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p2 mc3p_3 (actual rows=1 loops=1)
                Filter: ((a < 3) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                       QUERY PLAN                       
---------------------------------------------------------
- Append (actual rows=3 loops=1)
-   ->  Seq Scan on mc3p0 mc3p_1 (actual rows=1 loops=1)
-         Filter: ((a < 3) AND (abs(b) = 1))
-   ->  Seq Scan on mc3p1 mc3p_2 (actual rows=1 loops=1)
-         Filter: ((a < 3) AND (abs(b) = 1))
-   ->  Seq Scan on mc3p2 mc3p_3 (actual rows=1 loops=1)
-         Filter: ((a < 3) AND (abs(b) = 1))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- Check that pruning with composite range partitioning works correctly when
@@ -5515,7 +3478,6 @@ prepare ps1 as
   select * from mc3p where a = $1 and abs(b) < (select 3);
 explain (analyze, costs off, summary off, timing off)
 execute ps1(1);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
@@ -5523,21 +3485,10 @@ execute ps1(1);
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=1 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on mc3p1 mc3p (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
                Filter: ((a = $1) AND (abs(b) < $0))
  Optimizer: Postgres query optimizer
 (8 rows)
-=======
-                       QUERY PLAN                       
---------------------------------------------------------
- Append (actual rows=1 loops=1)
-   InitPlan 1 (returns $0)
-     ->  Result (actual rows=1 loops=1)
-   Subplans Removed: 2
-   ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
-         Filter: ((a = $1) AND (abs(b) < $0))
-(6 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 deallocate ps1;
 prepare ps2 as
@@ -5549,23 +3500,14 @@ execute ps2(1);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
-<<<<<<< HEAD
    ->  Append (actual rows=2 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on mc3p0 mc3p (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p0 mc3p_1 (actual rows=1 loops=1)
                Filter: ((a <= $1) AND (abs(b) < $0))
-         ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p1 mc3p_2 (actual rows=1 loops=1)
                Filter: ((a <= $1) AND (abs(b) < $0))
  Optimizer: Postgres query optimizer
 (10 rows)
-=======
-   Subplans Removed: 1
-   ->  Seq Scan on mc3p0 mc3p_1 (actual rows=1 loops=1)
-         Filter: ((a <= $1) AND (abs(b) < $0))
-   ->  Seq Scan on mc3p1 mc3p_2 (actual rows=1 loops=1)
-         Filter: ((a <= $1) AND (abs(b) < $0))
-(8 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 deallocate ps2;
 drop table mc3p;
@@ -5577,7 +3519,6 @@ create table boolp_t partition of boolp for values in('t');
 create table boolp_f partition of boolp for values in('f');
 explain (analyze, costs off, summary off, timing off)
 select * from boolp where a = (select value from boolvalues where value);
-<<<<<<< HEAD
                                 QUERY PLAN                                
 --------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
@@ -5587,9 +3528,9 @@ select * from boolp where a = (select value from boolvalues where value);
                  Filter: value
                  Rows Removed by Filter: 1
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on boolp_f boolp (never executed)
+         ->  Seq Scan on boolp_f boolp_1 (never executed)
                Filter: (a = $0)
-         ->  Seq Scan on boolp_t boolp_1 (actual rows=0 loops=1)
+         ->  Seq Scan on boolp_t boolp_2 (actual rows=0 loops=1)
                Filter: (a = $0)
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -5605,41 +3546,12 @@ select * from boolp where a = (select value from boolvalues where not value);
                  Filter: (NOT value)
                  Rows Removed by Filter: 1
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on boolp_f boolp (actual rows=0 loops=1)
+         ->  Seq Scan on boolp_f boolp_1 (actual rows=0 loops=1)
                Filter: (a = $0)
-         ->  Seq Scan on boolp_t boolp_1 (never executed)
+         ->  Seq Scan on boolp_t boolp_2 (never executed)
                Filter: (a = $0)
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-                        QUERY PLAN                         
------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   InitPlan 1 (returns $0)
-     ->  Seq Scan on boolvalues (actual rows=1 loops=1)
-           Filter: value
-           Rows Removed by Filter: 1
-   ->  Seq Scan on boolp_f boolp_1 (never executed)
-         Filter: (a = $0)
-   ->  Seq Scan on boolp_t boolp_2 (actual rows=0 loops=1)
-         Filter: (a = $0)
-(9 rows)
-
-explain (analyze, costs off, summary off, timing off)
-select * from boolp where a = (select value from boolvalues where not value);
-                        QUERY PLAN                         
------------------------------------------------------------
- Append (actual rows=0 loops=1)
-   InitPlan 1 (returns $0)
-     ->  Seq Scan on boolvalues (actual rows=1 loops=1)
-           Filter: (NOT value)
-           Rows Removed by Filter: 1
-   ->  Seq Scan on boolp_f boolp_1 (actual rows=0 loops=1)
-         Filter: (a = $0)
-   ->  Seq Scan on boolp_t boolp_2 (never executed)
-         Filter: (a = $0)
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table boolp;
 --
@@ -5656,7 +3568,6 @@ create index on ma_test (b);
 analyze ma_test;
 prepare mt_q1 (int) as select a from ma_test where a >= $1 and a % 10 = 5 order by b;
 explain (analyze, costs off, summary off, timing off) execute mt_q1(15);
-<<<<<<< HEAD
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
@@ -5664,28 +3575,14 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(15);
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: ma_test.b
          Subplans Removed: 1
-         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test (actual rows=1 loops=1)
+         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test_1 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 1
-         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_1 (actual rows=1 loops=1)
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_2 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 2
  Optimizer: Postgres query optimizer
 (12 rows)
-=======
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Merge Append (actual rows=2 loops=1)
-   Sort Key: ma_test.b
-   Subplans Removed: 1
-   ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test_1 (actual rows=1 loops=1)
-         Filter: ((a >= $1) AND ((a % 10) = 5))
-         Rows Removed by Filter: 9
-   ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_2 (actual rows=1 loops=1)
-         Filter: ((a >= $1) AND ((a % 10) = 5))
-         Rows Removed by Filter: 9
-(9 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 execute mt_q1(15);
  a  
@@ -5695,30 +3592,18 @@ execute mt_q1(15);
 (2 rows)
 
 explain (analyze, costs off, summary off, timing off) execute mt_q1(25);
-<<<<<<< HEAD
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    Merge Key: ma_test.b
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: ma_test.b
          Subplans Removed: 2
-         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test (actual rows=1 loops=1)
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_1 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 2
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Merge Append (actual rows=1 loops=1)
-   Sort Key: ma_test.b
-   Subplans Removed: 2
-   ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_1 (actual rows=1 loops=1)
-         Filter: ((a >= $1) AND ((a % 10) = 5))
-         Rows Removed by Filter: 9
-(6 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 execute mt_q1(25);
  a  
@@ -5728,26 +3613,15 @@ execute mt_q1(25);
 
 -- Ensure MergeAppend behaves correctly when no subplans match
 explain (analyze, costs off, summary off, timing off) execute mt_q1(35);
-<<<<<<< HEAD
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    Merge Key: ma_test.b
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: ma_test.b
-         Subplans Removed: 2
-         ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 ma_test (never executed)
-               Filter: ((a >= $1) AND ((a % 10) = 5))
+         Subplans Removed: 3
  Optimizer: Postgres query optimizer
-(8 rows)
-=======
-              QUERY PLAN              
---------------------------------------
- Merge Append (actual rows=0 loops=1)
-   Sort Key: ma_test.b
-   Subplans Removed: 3
-(3 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+(6 rows)
 
 execute mt_q1(35);
  a 
@@ -5758,14 +3632,21 @@ deallocate mt_q1;
 prepare mt_q2 (int) as select * from ma_test where a >= $1 order by b limit 1;
 -- Ensure output list looks sane when the MergeAppend has no subplans.
 explain (analyze, verbose, costs off, summary off, timing off) execute mt_q2 (35);
-                 QUERY PLAN                 
---------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    Output: ma_test.a, ma_test.b
-   ->  Merge Append (actual rows=0 loops=1)
-         Sort Key: ma_test.b
-         Subplans Removed: 3
-(5 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+         Output: ma_test.a, ma_test.b
+         Merge Key: ma_test.b
+         ->  Limit (actual rows=0 loops=1)
+               Output: ma_test.a, ma_test.b
+               ->  Merge Append (actual rows=0 loops=1)
+                     Sort Key: ma_test.b
+                     Subplans Removed: 3
+ Optimizer: Postgres query optimizer
+ Settings: enable_hashjoin = 'off', enable_indexonlyscan = 'off', enable_seqscan = 'off', enable_sort = 'off', optimizer = 'off', plan_cache_mode = 'force_generic_plan'
+(12 rows)
 
 deallocate mt_q2;
 -- ensure initplan params properly prune partitions
@@ -5778,32 +3659,20 @@ explain (analyze, costs off, summary off, timing off) select * from ma_test wher
      ->  Result (actual rows=1 loops=1)
            InitPlan 1 (returns $0)  (slice3)
              ->  Limit (actual rows=1 loops=1)
-<<<<<<< HEAD
                    ->  Gather Motion 3:1  (slice4; segments: 3) (actual rows=1 loops=1)
                          Merge Key: ma_test_p2.b
                          ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 (actual rows=5 loops=1)
                                Index Cond: (b IS NOT NULL)
    ->  Merge Append (actual rows=8 loops=1)
          Sort Key: ma_test.b
-         ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 ma_test (never executed)
+         ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 ma_test_1 (never executed)
                Filter: (a >= $1)
-         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test_1 (actual rows=5 loops=1)
+         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test_2 (actual rows=5 loops=1)
                Filter: (a >= $1)
-         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_2 (actual rows=4 loops=1)
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_3 (actual rows=4 loops=1)
                Filter: (a >= $1)
  Optimizer: Postgres query optimizer
 (19 rows)
-=======
-                   ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 (actual rows=1 loops=1)
-                         Index Cond: (b IS NOT NULL)
-   ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 ma_test_1 (never executed)
-         Filter: (a >= $1)
-   ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test_2 (actual rows=10 loops=1)
-         Filter: (a >= $1)
-   ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_3 (actual rows=10 loops=1)
-         Filter: (a >= $1)
-(14 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 reset enable_seqscan;
 reset enable_sort;
@@ -5834,27 +3703,16 @@ explain (costs off) select * from pp_arrpart where a = '{1, 2}';
 (2 rows)
 
 explain (costs off) select * from pp_arrpart where a in ('{4, 5}', '{1}');
-<<<<<<< HEAD
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on pp_arrpart1 pp_arrpart
+         ->  Seq Scan on pp_arrpart1 pp_arrpart_1
                Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-         ->  Seq Scan on pp_arrpart2 pp_arrpart_1
+         ->  Seq Scan on pp_arrpart2 pp_arrpart_2
                Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Append
-   ->  Seq Scan on pp_arrpart1 pp_arrpart_1
-         Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-   ->  Seq Scan on pp_arrpart2 pp_arrpart_2
-         Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) update pp_arrpart set a = a where a = '{1}';
                  QUERY PLAN                 
@@ -5907,27 +3765,16 @@ explain (costs off) select * from pph_arrpart where a = '{1, 2}';
 (4 rows)
 
 explain (costs off) select * from pph_arrpart where a in ('{4, 5}', '{1}');
-<<<<<<< HEAD
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on pph_arrpart1 pph_arrpart
+         ->  Seq Scan on pph_arrpart1 pph_arrpart_1
                Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-         ->  Seq Scan on pph_arrpart2 pph_arrpart_1
+         ->  Seq Scan on pph_arrpart2 pph_arrpart_2
                Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Append
-   ->  Seq Scan on pph_arrpart1 pph_arrpart_1
-         Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-   ->  Seq Scan on pph_arrpart2 pph_arrpart_2
-         Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table pph_arrpart;
 -- enum type list partition key
@@ -6033,27 +3880,16 @@ explain (costs off) delete from pp_lp where a = 1;
 set enable_partition_pruning = off;
 set constraint_exclusion = 'partition'; -- this should not affect the result.
 explain (costs off) select * from pp_lp where a = 1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on pp_lp1 pp_lp
+         ->  Seq Scan on pp_lp1 pp_lp_1
                Filter: (a = 1)
-         ->  Seq Scan on pp_lp2 pp_lp_1
+         ->  Seq Scan on pp_lp2 pp_lp_2
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-            QUERY PLAN            
-----------------------------------
- Append
-   ->  Seq Scan on pp_lp1 pp_lp_1
-         Filter: (a = 1)
-   ->  Seq Scan on pp_lp2 pp_lp_2
-         Filter: (a = 1)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) update pp_lp set value = 10 where a = 1;
             QUERY PLAN            
@@ -6081,27 +3917,16 @@ explain (costs off) delete from pp_lp where a = 1;
 
 set constraint_exclusion = 'off'; -- this should not affect the result.
 explain (costs off) select * from pp_lp where a = 1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on pp_lp1 pp_lp
+         ->  Seq Scan on pp_lp1 pp_lp_1
                Filter: (a = 1)
-         ->  Seq Scan on pp_lp2 pp_lp_1
+         ->  Seq Scan on pp_lp2 pp_lp_2
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-            QUERY PLAN            
-----------------------------------
- Append
-   ->  Seq Scan on pp_lp1 pp_lp_1
-         Filter: (a = 1)
-   ->  Seq Scan on pp_lp2 pp_lp_2
-         Filter: (a = 1)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) update pp_lp set value = 10 where a = 1;
             QUERY PLAN            
@@ -6139,27 +3964,16 @@ NOTICE:  merging column "value" with inherited definition
 set constraint_exclusion = 'partition';
 -- inh_lp2 should be removed in the following 3 cases.
 explain (costs off) select * from inh_lp where a = 1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on inh_lp
+         ->  Seq Scan on inh_lp inh_lp_1
                Filter: (a = 1)
-         ->  Seq Scan on inh_lp1 inh_lp_1
+         ->  Seq Scan on inh_lp1 inh_lp_2
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-             QUERY PLAN             
-------------------------------------
- Append
-   ->  Seq Scan on inh_lp inh_lp_1
-         Filter: (a = 1)
-   ->  Seq Scan on inh_lp1 inh_lp_2
-         Filter: (a = 1)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) update inh_lp set value = 10 where a = 1;
              QUERY PLAN             
@@ -6206,23 +4020,14 @@ create temp table pp_temp_parent (a int) partition by list (a);
 create temp table pp_temp_part_1 partition of pp_temp_parent for values in (1);
 create temp table pp_temp_part_def partition of pp_temp_parent default;
 explain (costs off) select * from pp_temp_parent where true;
-<<<<<<< HEAD
                         QUERY PLAN                         
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on pp_temp_part_1 pp_temp_parent
-         ->  Seq Scan on pp_temp_part_def pp_temp_parent_1
+         ->  Seq Scan on pp_temp_part_1 pp_temp_parent_1
+         ->  Seq Scan on pp_temp_part_def pp_temp_parent_2
  Optimizer: Postgres query optimizer
 (5 rows)
-=======
-                     QUERY PLAN                      
------------------------------------------------------
- Append
-   ->  Seq Scan on pp_temp_part_1 pp_temp_parent_1
-   ->  Seq Scan on pp_temp_part_def pp_temp_parent_2
-(3 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 explain (costs off) select * from pp_temp_parent where a = 2;
                     QUERY PLAN                     

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -180,11 +180,11 @@ explain (costs off) select * from coll_pruning where a collate "POSIX" = 'a' col
 ---------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on coll_pruning_a coll_pruning
+         ->  Seq Scan on coll_pruning_a coll_pruning_1
                Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on coll_pruning_b coll_pruning_1
+         ->  Seq Scan on coll_pruning_b coll_pruning_2
                Filter: ((a)::text = 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on coll_pruning_def coll_pruning_2
+         ->  Seq Scan on coll_pruning_def coll_pruning_3
                Filter: ((a)::text = 'a'::text COLLATE "POSIX")
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -235,9 +235,9 @@ explain (costs off) select * from rlp where a <= 1;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 1)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 1)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -265,35 +265,35 @@ explain (costs off) select * from rlp where a = 1::numeric;		/* no pruning */
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp4_1 rlp_6
+         ->  Seq Scan on rlp4_1 rlp_7
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp4_2 rlp_7
+         ->  Seq Scan on rlp4_2 rlp_8
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp4_default rlp_8
+         ->  Seq Scan on rlp4_default rlp_9
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp5_1 rlp_9
+         ->  Seq Scan on rlp5_1 rlp_10
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp5_default rlp_10
+         ->  Seq Scan on rlp5_default rlp_11
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_10 rlp_11
+         ->  Seq Scan on rlp_default_10 rlp_12
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_30 rlp_12
+         ->  Seq Scan on rlp_default_30 rlp_13
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_null rlp_13
+         ->  Seq Scan on rlp_default_null rlp_14
                Filter: ((a)::numeric = '1'::numeric)
-         ->  Seq Scan on rlp_default_default rlp_14
+         ->  Seq Scan on rlp_default_default rlp_15
                Filter: ((a)::numeric = '1'::numeric)
  Optimizer: Postgres query optimizer
 (33 rows)
@@ -303,13 +303,13 @@ explain (costs off) select * from rlp where a <= 10;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 10)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 10)
-         ->  Seq Scan on rlp_default_10 rlp_2
+         ->  Seq Scan on rlp_default_10 rlp_3
                Filter: (a <= 10)
-         ->  Seq Scan on rlp_default_default rlp_3
+         ->  Seq Scan on rlp_default_default rlp_4
                Filter: (a <= 10)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -319,27 +319,27 @@ explain (costs off) select * from rlp where a > 10;
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: (a > 10)
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: (a > 10)
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: (a > 10)
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: (a > 10)
-         ->  Seq Scan on rlp4_1 rlp_4
+         ->  Seq Scan on rlp4_1 rlp_5
                Filter: (a > 10)
-         ->  Seq Scan on rlp4_2 rlp_5
+         ->  Seq Scan on rlp4_2 rlp_6
                Filter: (a > 10)
-         ->  Seq Scan on rlp4_default rlp_6
+         ->  Seq Scan on rlp4_default rlp_7
                Filter: (a > 10)
-         ->  Seq Scan on rlp5_1 rlp_7
+         ->  Seq Scan on rlp5_1 rlp_8
                Filter: (a > 10)
-         ->  Seq Scan on rlp5_default rlp_8
+         ->  Seq Scan on rlp5_default rlp_9
                Filter: (a > 10)
-         ->  Seq Scan on rlp_default_30 rlp_9
+         ->  Seq Scan on rlp_default_30 rlp_10
                Filter: (a > 10)
-         ->  Seq Scan on rlp_default_default rlp_10
+         ->  Seq Scan on rlp_default_default rlp_11
                Filter: (a > 10)
  Optimizer: Postgres query optimizer
 (25 rows)
@@ -349,13 +349,13 @@ explain (costs off) select * from rlp where a < 15;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a < 15)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a < 15)
-         ->  Seq Scan on rlp_default_10 rlp_2
+         ->  Seq Scan on rlp_default_10 rlp_3
                Filter: (a < 15)
-         ->  Seq Scan on rlp_default_default rlp_3
+         ->  Seq Scan on rlp_default_default rlp_4
                Filter: (a < 15)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -365,21 +365,21 @@ explain (costs off) select * from rlp where a <= 15;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 15)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: (a <= 15)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: (a <= 15)
-         ->  Seq Scan on rlp_default_10 rlp_6
+         ->  Seq Scan on rlp_default_10 rlp_7
                Filter: (a <= 15)
-         ->  Seq Scan on rlp_default_default rlp_7
+         ->  Seq Scan on rlp_default_default rlp_8
                Filter: (a <= 15)
  Optimizer: Postgres query optimizer
 (19 rows)
@@ -389,21 +389,21 @@ explain (costs off) select * from rlp where a > 15 and b = 'ab';
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_1 rlp_1
+         ->  Seq Scan on rlp4_1 rlp_2
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_2 rlp_2
+         ->  Seq Scan on rlp4_2 rlp_3
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_default rlp_3
+         ->  Seq Scan on rlp4_default rlp_4
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_1 rlp_4
+         ->  Seq Scan on rlp5_1 rlp_5
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_default rlp_5
+         ->  Seq Scan on rlp5_default rlp_6
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_30 rlp_6
+         ->  Seq Scan on rlp_default_30 rlp_7
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_default rlp_7
+         ->  Seq Scan on rlp_default_default rlp_8
                Filter: ((a > 15) AND ((b)::text = 'ab'::text))
  Optimizer: Postgres query optimizer
 (19 rows)
@@ -413,13 +413,13 @@ explain (costs off) select * from rlp where a = 16;
 --------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: (a = 16)
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: (a = 16)
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: (a = 16)
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: (a = 16)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -447,9 +447,9 @@ explain (costs off) select * from rlp where a = 16 and b <= 'ab';
 ----------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: (((b)::text <= 'ab'::text) AND (a = 16))
-         ->  Seq Scan on rlp3_default rlp_1
+         ->  Seq Scan on rlp3_default rlp_2
                Filter: (((b)::text <= 'ab'::text) AND (a = 16))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -468,13 +468,13 @@ explain (costs off) select * from rlp where a = 16 and b is not null;
 ------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: ((b IS NOT NULL) AND (a = 16))
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: ((b IS NOT NULL) AND (a = 16))
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: ((b IS NOT NULL) AND (a = 16))
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: ((b IS NOT NULL) AND (a = 16))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -493,33 +493,33 @@ explain (costs off) select * from rlp where a is not null;
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp4_1 rlp_6
+         ->  Seq Scan on rlp4_1 rlp_7
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp4_2 rlp_7
+         ->  Seq Scan on rlp4_2 rlp_8
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp4_default rlp_8
+         ->  Seq Scan on rlp4_default rlp_9
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp5_1 rlp_9
+         ->  Seq Scan on rlp5_1 rlp_10
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp5_default rlp_10
+         ->  Seq Scan on rlp5_default rlp_11
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp_default_10 rlp_11
+         ->  Seq Scan on rlp_default_10 rlp_12
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp_default_30 rlp_12
+         ->  Seq Scan on rlp_default_30 rlp_13
                Filter: (a IS NOT NULL)
-         ->  Seq Scan on rlp_default_default rlp_13
+         ->  Seq Scan on rlp_default_default rlp_14
                Filter: (a IS NOT NULL)
  Optimizer: Postgres query optimizer
 (31 rows)
@@ -529,11 +529,11 @@ explain (costs off) select * from rlp where a > 30;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp5_1 rlp
+         ->  Seq Scan on rlp5_1 rlp_1
                Filter: (a > 30)
-         ->  Seq Scan on rlp5_default rlp_1
+         ->  Seq Scan on rlp5_default rlp_2
                Filter: (a > 30)
-         ->  Seq Scan on rlp_default_default rlp_2
+         ->  Seq Scan on rlp_default_default rlp_3
                Filter: (a > 30)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -552,31 +552,31 @@ explain (costs off) select * from rlp where a <= 31;
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: (a <= 31)
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3efgh rlp_3
+         ->  Seq Scan on rlp3efgh rlp_4
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3nullxy rlp_4
+         ->  Seq Scan on rlp3nullxy rlp_5
                Filter: (a <= 31)
-         ->  Seq Scan on rlp3_default rlp_5
+         ->  Seq Scan on rlp3_default rlp_6
                Filter: (a <= 31)
-         ->  Seq Scan on rlp4_1 rlp_6
+         ->  Seq Scan on rlp4_1 rlp_7
                Filter: (a <= 31)
-         ->  Seq Scan on rlp4_2 rlp_7
+         ->  Seq Scan on rlp4_2 rlp_8
                Filter: (a <= 31)
-         ->  Seq Scan on rlp4_default rlp_8
+         ->  Seq Scan on rlp4_default rlp_9
                Filter: (a <= 31)
-         ->  Seq Scan on rlp5_1 rlp_9
+         ->  Seq Scan on rlp5_1 rlp_10
                Filter: (a <= 31)
-         ->  Seq Scan on rlp_default_10 rlp_10
+         ->  Seq Scan on rlp_default_10 rlp_11
                Filter: (a <= 31)
-         ->  Seq Scan on rlp_default_30 rlp_11
+         ->  Seq Scan on rlp_default_30 rlp_12
                Filter: (a <= 31)
-         ->  Seq Scan on rlp_default_default rlp_12
+         ->  Seq Scan on rlp_default_default rlp_13
                Filter: (a <= 31)
  Optimizer: Postgres query optimizer
 (29 rows)
@@ -595,29 +595,29 @@ explain (costs off) select * from rlp where a = 1 or b = 'ab';
 -------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp2 rlp_1
+         ->  Seq Scan on rlp2 rlp_2
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp3abcd rlp_2
+         ->  Seq Scan on rlp3abcd rlp_3
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_1 rlp_3
+         ->  Seq Scan on rlp4_1 rlp_4
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_2 rlp_4
+         ->  Seq Scan on rlp4_2 rlp_5
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp4_default rlp_5
+         ->  Seq Scan on rlp4_default rlp_6
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_1 rlp_6
+         ->  Seq Scan on rlp5_1 rlp_7
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp5_default rlp_7
+         ->  Seq Scan on rlp5_default rlp_8
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_10 rlp_8
+         ->  Seq Scan on rlp_default_10 rlp_9
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_30 rlp_9
+         ->  Seq Scan on rlp_default_30 rlp_10
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_null rlp_10
+         ->  Seq Scan on rlp_default_null rlp_11
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
-         ->  Seq Scan on rlp_default_default rlp_11
+         ->  Seq Scan on rlp_default_default rlp_12
                Filter: ((a = 1) OR ((b)::text = 'ab'::text))
  Optimizer: Postgres query optimizer
 (27 rows)
@@ -627,9 +627,9 @@ explain (costs off) select * from rlp where a > 20 and a < 27;
 -----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp4_1 rlp
+         ->  Seq Scan on rlp4_1 rlp_1
                Filter: ((a > 20) AND (a < 27))
-         ->  Seq Scan on rlp4_2 rlp_1
+         ->  Seq Scan on rlp4_2 rlp_2
                Filter: ((a > 20) AND (a < 27))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -648,15 +648,15 @@ explain (costs off) select * from rlp where a >= 29;
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp4_default rlp
+         ->  Seq Scan on rlp4_default rlp_1
                Filter: (a >= 29)
-         ->  Seq Scan on rlp5_1 rlp_1
+         ->  Seq Scan on rlp5_1 rlp_2
                Filter: (a >= 29)
-         ->  Seq Scan on rlp5_default rlp_2
+         ->  Seq Scan on rlp5_default rlp_3
                Filter: (a >= 29)
-         ->  Seq Scan on rlp_default_30 rlp_3
+         ->  Seq Scan on rlp_default_30 rlp_4
                Filter: (a >= 29)
-         ->  Seq Scan on rlp_default_default rlp_4
+         ->  Seq Scan on rlp_default_default rlp_5
                Filter: (a >= 29)
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -666,9 +666,9 @@ explain (costs off) select * from rlp where a < 1 or (a > 20 and a < 25);
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp1 rlp
+         ->  Seq Scan on rlp1 rlp_1
                Filter: ((a < 1) OR ((a > 20) AND (a < 25)))
-         ->  Seq Scan on rlp4_1 rlp_1
+         ->  Seq Scan on rlp4_1 rlp_2
                Filter: ((a < 1) OR ((a > 20) AND (a < 25)))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -679,9 +679,9 @@ explain (costs off) select * from rlp where a = 20 or a = 40;
 ----------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp4_1 rlp
+         ->  Seq Scan on rlp4_1 rlp_1
                Filter: ((a = 20) OR (a = 40))
-         ->  Seq Scan on rlp5_default rlp_1
+         ->  Seq Scan on rlp5_default rlp_2
                Filter: ((a = 20) OR (a = 40))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -709,27 +709,27 @@ explain (costs off) select * from rlp where a > 1 and a >=15;	/* rlp3 onwards, i
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on rlp3abcd rlp
+         ->  Seq Scan on rlp3abcd rlp_1
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp3efgh rlp_1
+         ->  Seq Scan on rlp3efgh rlp_2
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp3nullxy rlp_2
+         ->  Seq Scan on rlp3nullxy rlp_3
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp3_default rlp_3
+         ->  Seq Scan on rlp3_default rlp_4
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp4_1 rlp_4
+         ->  Seq Scan on rlp4_1 rlp_5
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp4_2 rlp_5
+         ->  Seq Scan on rlp4_2 rlp_6
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp4_default rlp_6
+         ->  Seq Scan on rlp4_default rlp_7
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp5_1 rlp_7
+         ->  Seq Scan on rlp5_1 rlp_8
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp5_default rlp_8
+         ->  Seq Scan on rlp5_default rlp_9
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp_default_30 rlp_9
+         ->  Seq Scan on rlp_default_30 rlp_10
                Filter: ((a > 1) AND (a >= 15))
-         ->  Seq Scan on rlp_default_default rlp_10
+         ->  Seq Scan on rlp_default_default rlp_11
                Filter: ((a > 1) AND (a >= 15))
  Optimizer: Postgres query optimizer
 (25 rows)
@@ -747,15 +747,15 @@ explain (costs off) select * from rlp where (a = 1 and a = 3) or (a > 1 and a = 
 -------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp2 rlp
+         ->  Seq Scan on rlp2 rlp_1
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3abcd rlp_1
+         ->  Seq Scan on rlp3abcd rlp_2
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3efgh rlp_2
+         ->  Seq Scan on rlp3efgh rlp_3
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3nullxy rlp_3
+         ->  Seq Scan on rlp3nullxy rlp_4
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
-         ->  Seq Scan on rlp3_default rlp_4
+         ->  Seq Scan on rlp3_default rlp_5
                Filter: (((a = 1) AND (a = 3)) OR ((a > 1) AND (a = 15)))
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -776,11 +776,11 @@ explain (costs off) select * from mc3p where a = 1;
 ---------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (a = 1)
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (a = 1)
-         ->  Seq Scan on mc3p_default mc3p_2
+         ->  Seq Scan on mc3p_default mc3p_3
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -790,9 +790,9 @@ explain (costs off) select * from mc3p where a = 1 and abs(b) < 1;
 --------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a = 1) AND (abs(b) < 1))
-         ->  Seq Scan on mc3p_default mc3p_1
+         ->  Seq Scan on mc3p_default mc3p_2
                Filter: ((a = 1) AND (abs(b) < 1))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -802,11 +802,11 @@ explain (costs off) select * from mc3p where a = 1 and abs(b) = 1;
 --------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a = 1) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((a = 1) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p_default mc3p_2
+         ->  Seq Scan on mc3p_default mc3p_3
                Filter: ((a = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -816,9 +816,9 @@ explain (costs off) select * from mc3p where a = 1 and abs(b) = 1 and c < 8;
 --------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((c < 8) AND (a = 1) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((c < 8) AND (a = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -828,15 +828,15 @@ explain (costs off) select * from mc3p where a = 10 and abs(b) between 5 and 35;
 -----------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on mc3p1 mc3p
+         ->  Seq Scan on mc3p1 mc3p_1
                Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p2 mc3p_1
+         ->  Seq Scan on mc3p2 mc3p_2
                Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p3 mc3p_2
+         ->  Seq Scan on mc3p3 mc3p_3
                Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p4 mc3p_3
+         ->  Seq Scan on mc3p4 mc3p_4
                Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
-         ->  Seq Scan on mc3p_default mc3p_4
+         ->  Seq Scan on mc3p_default mc3p_5
                Filter: ((a = 10) AND (abs(b) >= 5) AND (abs(b) <= 35))
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -846,13 +846,13 @@ explain (costs off) select * from mc3p where a > 10;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p5 mc3p
+         ->  Seq Scan on mc3p5 mc3p_1
                Filter: (a > 10)
-         ->  Seq Scan on mc3p6 mc3p_1
+         ->  Seq Scan on mc3p6 mc3p_2
                Filter: (a > 10)
-         ->  Seq Scan on mc3p7 mc3p_2
+         ->  Seq Scan on mc3p7 mc3p_3
                Filter: (a > 10)
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (a > 10)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -862,21 +862,21 @@ explain (costs off) select * from mc3p where a >= 10;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p1 mc3p
+         ->  Seq Scan on mc3p1 mc3p_1
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p2 mc3p_1
+         ->  Seq Scan on mc3p2 mc3p_2
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p3 mc3p_2
+         ->  Seq Scan on mc3p3 mc3p_3
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p4 mc3p_3
+         ->  Seq Scan on mc3p4 mc3p_4
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p5 mc3p_4
+         ->  Seq Scan on mc3p5 mc3p_5
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p6 mc3p_5
+         ->  Seq Scan on mc3p6 mc3p_6
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p7 mc3p_6
+         ->  Seq Scan on mc3p7 mc3p_7
                Filter: (a >= 10)
-         ->  Seq Scan on mc3p_default mc3p_7
+         ->  Seq Scan on mc3p_default mc3p_8
                Filter: (a >= 10)
  Optimizer: Postgres query optimizer
 (19 rows)
@@ -886,11 +886,11 @@ explain (costs off) select * from mc3p where a < 10;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (a < 10)
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (a < 10)
-         ->  Seq Scan on mc3p_default mc3p_2
+         ->  Seq Scan on mc3p_default mc3p_3
                Filter: (a < 10)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -900,13 +900,13 @@ explain (costs off) select * from mc3p where a <= 10 and abs(b) < 10;
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a <= 10) AND (abs(b) < 10))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((a <= 10) AND (abs(b) < 10))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: ((a <= 10) AND (abs(b) < 10))
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: ((a <= 10) AND (abs(b) < 10))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -934,9 +934,9 @@ explain (costs off) select * from mc3p where a > 20;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p7 mc3p
+         ->  Seq Scan on mc3p7 mc3p_1
                Filter: (a > 20)
-         ->  Seq Scan on mc3p_default mc3p_1
+         ->  Seq Scan on mc3p_default mc3p_2
                Filter: (a > 20)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -946,13 +946,13 @@ explain (costs off) select * from mc3p where a >= 20;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p5 mc3p
+         ->  Seq Scan on mc3p5 mc3p_1
                Filter: (a >= 20)
-         ->  Seq Scan on mc3p6 mc3p_1
+         ->  Seq Scan on mc3p6 mc3p_2
                Filter: (a >= 20)
-         ->  Seq Scan on mc3p7 mc3p_2
+         ->  Seq Scan on mc3p7 mc3p_3
                Filter: (a >= 20)
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (a >= 20)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -962,13 +962,13 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or
 ---------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p1 mc3p
+         ->  Seq Scan on mc3p1 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-         ->  Seq Scan on mc3p2 mc3p_1
+         ->  Seq Scan on mc3p2 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-         ->  Seq Scan on mc3p5 mc3p_2
+         ->  Seq Scan on mc3p5 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -978,15 +978,15 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or
 --------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p5 mc3p_3
+         ->  Seq Scan on mc3p5 mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
-         ->  Seq Scan on mc3p_default mc3p_4
+         ->  Seq Scan on mc3p_default mc3p_5
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1))
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -996,15 +996,15 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1 and c = 1) or
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p5 mc3p_3
+         ->  Seq Scan on mc3p5 mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
-         ->  Seq Scan on mc3p_default mc3p_4
+         ->  Seq Scan on mc3p_default mc3p_5
                Filter: (((a = 1) AND (abs(b) = 1) AND (c = 1)) OR ((a = 10) AND (abs(b) = 5) AND (c = 10)) OR ((a > 11) AND (a < 20)) OR (a < 1) OR (a = 1))
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -1014,23 +1014,23 @@ explain (costs off) select * from mc3p where a = 1 or abs(b) = 1 or c = 1;
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p3 mc3p_3
+         ->  Seq Scan on mc3p3 mc3p_4
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p4 mc3p_4
+         ->  Seq Scan on mc3p4 mc3p_5
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p5 mc3p_5
+         ->  Seq Scan on mc3p5 mc3p_6
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p6 mc3p_6
+         ->  Seq Scan on mc3p6 mc3p_7
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p7 mc3p_7
+         ->  Seq Scan on mc3p7 mc3p_8
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
-         ->  Seq Scan on mc3p_default mc3p_8
+         ->  Seq Scan on mc3p_default mc3p_9
                Filter: ((a = 1) OR (abs(b) = 1) OR (c = 1))
  Optimizer: Postgres query optimizer
 (21 rows)
@@ -1040,17 +1040,17 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1) or (a = 10 a
 ------------------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p3 mc3p_3
+         ->  Seq Scan on mc3p3 mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p4 mc3p_4
+         ->  Seq Scan on mc3p4 mc3p_5
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
-         ->  Seq Scan on mc3p_default mc3p_5
+         ->  Seq Scan on mc3p_default mc3p_6
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 10)))
  Optimizer: Postgres query optimizer
 (15 rows)
@@ -1060,13 +1060,13 @@ explain (costs off) select * from mc3p where (a = 1 and abs(b) = 1) or (a = 10 a
 -----------------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on mc3p0 mc3p
+         ->  Seq Scan on mc3p0 mc3p_1
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-         ->  Seq Scan on mc3p1 mc3p_1
+         ->  Seq Scan on mc3p1 mc3p_2
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-         ->  Seq Scan on mc3p2 mc3p_2
+         ->  Seq Scan on mc3p2 mc3p_3
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
-         ->  Seq Scan on mc3p_default mc3p_3
+         ->  Seq Scan on mc3p_default mc3p_4
                Filter: (((a = 1) AND (abs(b) = 1)) OR ((a = 10) AND (abs(b) = 9)))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1085,13 +1085,13 @@ explain (costs off) select * from mc2p where a < 2;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc2p0 mc2p
+         ->  Seq Scan on mc2p0 mc2p_1
                Filter: (a < 2)
-         ->  Seq Scan on mc2p1 mc2p_1
+         ->  Seq Scan on mc2p1 mc2p_2
                Filter: (a < 2)
-         ->  Seq Scan on mc2p2 mc2p_2
+         ->  Seq Scan on mc2p2 mc2p_3
                Filter: (a < 2)
-         ->  Seq Scan on mc2p_default mc2p_3
+         ->  Seq Scan on mc2p_default mc2p_4
                Filter: (a < 2)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1110,15 +1110,15 @@ explain (costs off) select * from mc2p where a > 1;
 ---------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on mc2p2 mc2p
+         ->  Seq Scan on mc2p2 mc2p_1
                Filter: (a > 1)
-         ->  Seq Scan on mc2p3 mc2p_1
+         ->  Seq Scan on mc2p3 mc2p_2
                Filter: (a > 1)
-         ->  Seq Scan on mc2p4 mc2p_2
+         ->  Seq Scan on mc2p4 mc2p_3
                Filter: (a > 1)
-         ->  Seq Scan on mc2p5 mc2p_3
+         ->  Seq Scan on mc2p5 mc2p_4
                Filter: (a > 1)
-         ->  Seq Scan on mc2p_default mc2p_4
+         ->  Seq Scan on mc2p_default mc2p_5
                Filter: (a > 1)
  Optimizer: Postgres query optimizer
 (13 rows)
@@ -1437,12 +1437,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM part p(x) ORDER BY x;
          Output: p.x, p.b
          Sort Key: p.x
          ->  Append
-               ->  Seq Scan on public.part_p1 p
-                     Output: p.x, p.b
-               ->  Seq Scan on public.part_rev p_1
+               ->  Seq Scan on public.part_p1 p_1
                      Output: p_1.x, p_1.b
-               ->  Seq Scan on public.part_p2_p1 p_2
+               ->  Seq Scan on public.part_rev p_2
                      Output: p_2.x, p_2.b
+               ->  Seq Scan on public.part_p2_p1 p_3
+                     Output: p_3.x, p_3.b
  Optimizer: Postgres query optimizer
  Settings: plan_cache_mode = 'force_generic_plan'
 (15 rows)
@@ -1460,11 +1460,11 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
  Nested Loop
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Append
-               ->  Seq Scan on mc2p1 t1
+               ->  Seq Scan on mc2p1 t1_1
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p2 t1_1
+               ->  Seq Scan on mc2p2 t1_2
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p_default t1_2
+               ->  Seq Scan on mc2p_default t1_3
                      Filter: (a = 1)
    ->  Materialize
          ->  Aggregate
@@ -1473,23 +1473,23 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                      ->  Materialize
                            ->  Gather Motion 3:1  (slice2; segments: 3)
                                  ->  Append
-                                       ->  Seq Scan on mc3p0 t2
+                                       ->  Seq Scan on mc3p0 t2_1
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p1 t2_1
+                                       ->  Seq Scan on mc3p1 t2_2
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p2 t2_2
+                                       ->  Seq Scan on mc3p2 t2_3
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p3 t2_3
+                                       ->  Seq Scan on mc3p3 t2_4
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p4 t2_4
+                                       ->  Seq Scan on mc3p4 t2_5
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p5 t2_5
+                                       ->  Seq Scan on mc3p5 t2_6
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p6 t2_6
+                                       ->  Seq Scan on mc3p6 t2_7
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p7 t2_7
+                                       ->  Seq Scan on mc3p7 t2_8
                                              Filter: ((c = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p_default t2_8
+                                       ->  Seq Scan on mc3p_default t2_9
                                              Filter: ((c = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (35 rows)
@@ -1502,11 +1502,11 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
  Nested Loop
    ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Append
-               ->  Seq Scan on mc2p1 t1
+               ->  Seq Scan on mc2p1 t1_1
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p2 t1_1
+               ->  Seq Scan on mc2p2 t1_2
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p_default t1_2
+               ->  Seq Scan on mc2p_default t1_3
                      Filter: (a = 1)
    ->  Materialize
          ->  Aggregate
@@ -1515,11 +1515,11 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                      ->  Materialize
                            ->  Gather Motion 1:1  (slice2; segments: 1)
                                  ->  Append
-                                       ->  Seq Scan on mc3p0 t2
+                                       ->  Seq Scan on mc3p0 t2_1
                                              Filter: ((a = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p1 t2_1
+                                       ->  Seq Scan on mc3p1 t2_2
                                              Filter: ((a = 1) AND (abs(b) = 1))
-                                       ->  Seq Scan on mc3p_default t2_2
+                                       ->  Seq Scan on mc3p_default t2_3
                                              Filter: ((a = 1) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (23 rows)
@@ -1537,11 +1537,11 @@ explain (costs off) select * from mc2p t1, lateral (select count(*) from mc3p t2
                            ->  Seq Scan on mc3p1 t2
                                  Filter: ((a = 1) AND (c = 1) AND (abs(b) = 1))
          ->  Append
-               ->  Seq Scan on mc2p1 t1
+               ->  Seq Scan on mc2p1 t1_1
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p2 t1_1
+               ->  Seq Scan on mc2p2 t1_2
                      Filter: (a = 1)
-               ->  Seq Scan on mc2p_default t1_2
+               ->  Seq Scan on mc2p_default t1_3
                      Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (16 rows)
@@ -1612,9 +1612,9 @@ explain (costs off) select * from rlp where a = 15 and b <> 'ab' and b <> 'cd' a
 ------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on rlp3efgh rlp
+         ->  Seq Scan on rlp3efgh rlp_1
                Filter: ((b IS NOT NULL) AND ((b)::text <> 'ab'::text) AND ((b)::text <> 'cd'::text) AND ((b)::text <> 'xy'::text) AND (a = 15))
-         ->  Seq Scan on rlp3_default rlp_1
+         ->  Seq Scan on rlp3_default rlp_2
                Filter: ((b IS NOT NULL) AND ((b)::text <> 'ab'::text) AND ((b)::text <> 'cd'::text) AND ((b)::text <> 'xy'::text) AND (a = 15))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1632,11 +1632,11 @@ explain (costs off) select * from coll_pruning_multi where substr(a, 1) = 'e' co
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi
+         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi_1
                Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_1
+         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_2
                Filter: (substr(a, 1) = 'e'::text COLLATE "C")
-         ->  Seq Scan on coll_pruning_multi3 coll_pruning_multi_2
+         ->  Seq Scan on coll_pruning_multi3 coll_pruning_multi_3
                Filter: (substr(a, 1) = 'e'::text COLLATE "C")
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -1647,9 +1647,9 @@ explain (costs off) select * from coll_pruning_multi where substr(a, 1) = 'a' co
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi
+         ->  Seq Scan on coll_pruning_multi1 coll_pruning_multi_1
                Filter: (substr(a, 1) = 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_1
+         ->  Seq Scan on coll_pruning_multi2 coll_pruning_multi_2
                Filter: (substr(a, 1) = 'a'::text COLLATE "POSIX")
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -1754,13 +1754,13 @@ explain (costs off) select * from hp where a = 1;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (a = 1)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (a = 1)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (a = 1)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1770,13 +1770,13 @@ explain (costs off) select * from hp where b = 'xxx';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (b = 'xxx'::text)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (b = 'xxx'::text)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (b = 'xxx'::text)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (b = 'xxx'::text)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1786,13 +1786,13 @@ explain (costs off) select * from hp where a is null;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (a IS NULL)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (a IS NULL)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (a IS NULL)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (a IS NULL)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1802,13 +1802,13 @@ explain (costs off) select * from hp where b is null;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (b IS NULL)
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: (b IS NULL)
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: (b IS NULL)
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: (b IS NULL)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1818,13 +1818,13 @@ explain (costs off) select * from hp where a < 1 and b = 'xxx';
 -------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: ((a < 1) AND (b = 'xxx'::text))
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: ((a < 1) AND (b = 'xxx'::text))
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: ((a < 1) AND (b = 'xxx'::text))
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: ((a < 1) AND (b = 'xxx'::text))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1834,13 +1834,13 @@ explain (costs off) select * from hp where a <> 1 and b = 'yyy';
 --------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: ((a <> 1) AND (b = 'yyy'::text))
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: ((a <> 1) AND (b = 'yyy'::text))
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: ((a <> 1) AND (b = 'yyy'::text))
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: ((a <> 1) AND (b = 'yyy'::text))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1850,13 +1850,13 @@ explain (costs off) select * from hp where a <> 1 and b <> 'xxx';
 ---------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
-         ->  Seq Scan on hp1 hp_1
+         ->  Seq Scan on hp1 hp_2
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
-         ->  Seq Scan on hp2 hp_2
+         ->  Seq Scan on hp2 hp_3
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
-         ->  Seq Scan on hp3 hp_3
+         ->  Seq Scan on hp3 hp_4
                Filter: ((a <> 1) AND (b <> 'xxx'::text))
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1922,11 +1922,11 @@ explain (costs off) select * from hp where (a = 1 and b = 'abcde') or (a = 2 and
 -------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on hp0 hp
+         ->  Seq Scan on hp0 hp_1
                Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-         ->  Seq Scan on hp2 hp_1
+         ->  Seq Scan on hp2 hp_2
                Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
-         ->  Seq Scan on hp3 hp_2
+         ->  Seq Scan on hp3 hp_3
                Filter: (((a = 1) AND (b = 'abcde'::text)) OR ((a = 2) AND (b = 'xxx'::text)) OR ((a IS NULL) AND (b IS NULL)))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -1960,11 +1960,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2, 3);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 ab_2 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -1975,17 +1975,17 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (1, 2, 3);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 3
-         ->  Seq Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a1_b3 ab_2 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b1 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b2 ab_4 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_5 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
-         ->  Seq Scan on ab_a2_b3 ab_5 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b3 ab_6 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b <= $3))
  Optimizer: Postgres query optimizer
 (16 rows)
@@ -2000,9 +2000,9 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 4
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -2013,13 +2013,13 @@ explain (analyze, costs off, summary off, timing off) execute ab_q1 (2, 4);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b1 ab_2 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b1 ab_3 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
-         ->  Seq Scan on ab_a3_b2 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b2 ab_4 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < 3))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2036,11 +2036,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q2 (2, 2);
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a2_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
-         ->  Seq Scan on ab_a2_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a2_b3 ab_3 (never executed)
                Filter: ((a >= $1) AND (a <= $2) AND (b < $0))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2056,11 +2056,11 @@ explain (analyze, costs off, summary off, timing off) execute ab_q3 (2, 2);
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 6
-         ->  Seq Scan on ab_a1_b2 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-         ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=0 loops=1)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
-         ->  Seq Scan on ab_a3_b2 ab_2 (never executed)
+         ->  Seq Scan on ab_a3_b2 ab_3 (never executed)
                Filter: ((b >= $1) AND (b <= $2) AND (a < $0))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2164,11 +2164,11 @@ select explain_parallel_append('execute ab_q4 (2, 2)');
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a2_b1 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b3 ab_2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2184,11 +2184,11 @@ select explain_parallel_append('execute ab_q5 (1, 1, 1)');
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2201,35 +2201,32 @@ select explain_parallel_append('execute ab_q5 (2, 3, 3)');
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
                      Subplans Removed: 3
-                     ->  Seq Scan on ab_a2_b1 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b1 ab_1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b2 ab_1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b2 ab_2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b3 ab_2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b3 ab_3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b1 ab_3 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b1 ab_4 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b2 ab_4 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b2 ab_5 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b3 ab_5 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b3 ab_6 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
 
 -- Try some params whose values do not belong to any partition.
--- We'll still get a single subplan in this case, but it should not be scanned.
 select explain_parallel_append('execute ab_q5 (33, 44, 55)');
-                            explain_parallel_append                            
--------------------------------------------------------------------------------
+                        explain_parallel_append                         
+------------------------------------------------------------------------
  Finalize Aggregate (actual rows=N loops=N)
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
-                     Subplans Removed: 8
-                     ->  Seq Scan on ab_a1_b1 ab (never executed)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
+                     Subplans Removed: 9
  Optimizer: Postgres query optimizer
-(8 rows)
+(6 rows)
 
 -- Test Parallel Append with PARAM_EXEC Params
 select explain_parallel_append('select count(*) from ab where (a = (select 1) or a = (select 3)) and b = 2');
@@ -2243,11 +2240,11 @@ select explain_parallel_append('select count(*) from ab where (a = (select 1) or
    ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Append (actual rows=N loops=N)
-                     ->  Seq Scan on ab_a1_b2 ab (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a2_b2 ab_1 (never executed)
+                     ->  Seq Scan on ab_a2_b2 ab_2 (never executed)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a3_b2 ab_2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b2 ab_3 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
  Optimizer: Postgres query optimizer
 (15 rows)
@@ -2286,15 +2283,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
@@ -2322,23 +2319,23 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                  Filter: (a = ANY ('{0,0,1}'::integer[]))
                      ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 ab (actual rows=N loops=N)
+                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 ab_3 (never executed)
+                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 ab_4 (never executed)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 ab_4 (never executed)
+                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 ab_5 (never executed)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 ab_5 (never executed)
+                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 ab_6 (never executed)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 ab_6 (never executed)
+                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 ab_7 (never executed)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 ab_7 (never executed)
+                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 ab_8 (never executed)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 ab_8 (never executed)
+                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 ab_9 (never executed)
                                  Index Cond: (a = (a.a + 0))
  Optimizer: Postgres query optimizer
 (28 rows)
@@ -2358,27 +2355,27 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 51kB  Segments: 2  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b1 ab_3 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a3_b1 ab_4 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b2 ab_4 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a3_b2 ab_5 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b3 ab_5 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a3_b3 ab_6 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
@@ -2406,15 +2403,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=N loops=N)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -2443,15 +2440,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
                            ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -2488,47 +2485,47 @@ select * from ab where a = (select max(a) from lprt_a) and b = (select max(a)-1 
                  ->  Partial Aggregate (actual rows=1 loops=1)
                        ->  Seq Scan on lprt_a lprt_a_1 (actual rows=100 loops=1)
    ->  Append (actual rows=0 loops=1)
-         ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+         ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a2_b1 ab_3 (never executed)
+         ->  Bitmap Heap Scan on ab_a2_b1 ab_4 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a2_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a2_b2 ab_4 (never executed)
+         ->  Bitmap Heap Scan on ab_a2_b2 ab_5 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a2_b2_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a2_b3 ab_5 (never executed)
+         ->  Bitmap Heap Scan on ab_a2_b3 ab_6 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a2_b3_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b1 ab_6 (never executed)
+         ->  Bitmap Heap Scan on ab_a3_b1 ab_7 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b1_a_idx (never executed)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b2 ab_7 (actual rows=0 loops=1)
+         ->  Bitmap Heap Scan on ab_a3_b2 ab_8 (actual rows=0 loops=1)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
                      Index Cond: (a = $0)
-         ->  Bitmap Heap Scan on ab_a3_b3 ab_8 (never executed)
+         ->  Bitmap Heap Scan on ab_a3_b3 ab_9 (never executed)
                Recheck Cond: (a = $0)
                Filter: (b = $1)
                ->  Bitmap Index Scan on ab_a3_b3_a_idx (never executed)
@@ -2546,38 +2543,38 @@ select * from (select * from ab where a = 1 union all select * from ab) ab where
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
          ->  Append (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_9 (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_11 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_10 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b2 ab_12 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_11 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b3 ab_13 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
-         ->  Seq Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b2 ab_4 (never executed)
+         ->  Seq Scan on ab_a2_b2 ab_5 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b3 ab_5 (never executed)
+         ->  Seq Scan on ab_a2_b3 ab_6 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 ab_6 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b1 ab_7 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b2 ab_7 (never executed)
+         ->  Seq Scan on ab_a3_b2 ab_8 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b3 ab_8 (never executed)
+         ->  Seq Scan on ab_a3_b3 ab_9 (never executed)
                Filter: (b = $0)
  Optimizer: Postgres query optimizer
 (39 rows)
@@ -2592,42 +2589,42 @@ select * from (select * from ab where a = 1 union all (values(10,5)) union all s
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
          ->  Append (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_9 (actual rows=0 loops=1)
+               ->  Bitmap Heap Scan on ab_a1_b1 ab_11 (actual rows=0 loops=1)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_10 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b2 ab_12 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                            Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_11 (never executed)
+               ->  Bitmap Heap Scan on ab_a1_b3 ab_13 (never executed)
                      Recheck Cond: (a = 1)
                      Filter: (b = $0)
                      ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                            Index Cond: (a = 1)
          ->  Result (actual rows=0 loops=1)
-               One-Time Filter: (gp_execution_segment() = 0)
+               One-Time Filter: (gp_execution_segment() = 1)
                ->  Result (actual rows=0 loops=1)
                      One-Time Filter: (5 = $0)
-         ->  Seq Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b1 ab_3 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a2_b1 ab_4 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b2 ab_4 (never executed)
+         ->  Seq Scan on ab_a2_b2 ab_5 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a2_b3 ab_5 (never executed)
+         ->  Seq Scan on ab_a2_b3 ab_6 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b1 ab_6 (actual rows=0 loops=1)
+         ->  Seq Scan on ab_a3_b1 ab_7 (actual rows=0 loops=1)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b2 ab_7 (never executed)
+         ->  Seq Scan on ab_a3_b2 ab_8 (never executed)
                Filter: (b = $0)
-         ->  Seq Scan on ab_a3_b3 ab_8 (never executed)
+         ->  Seq Scan on ab_a3_b3 ab_9 (never executed)
                Filter: (b = $0)
  Optimizer: Postgres query optimizer
 (43 rows)
@@ -2656,19 +2653,19 @@ explain (analyze, costs off, summary off, timing off) execute ab_q6(1);
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 12
-         ->  Seq Scan on ab_a1_b1 ab (never executed)
+         ->  Seq Scan on ab_a1_b1 ab_1 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b2 ab_1 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_2 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b3 ab_2 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_3 (never executed)
                Filter: ((a = $1) AND (b = $0))
          ->  Seq Scan on xy_1 (actual rows=0 loops=1)
                Filter: ((x = $1) AND (y = $0))
-         ->  Seq Scan on ab_a1_b1 ab_3 (never executed)
+         ->  Seq Scan on ab_a1_b1 ab_4 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b2 ab_4 (never executed)
+         ->  Seq Scan on ab_a1_b2 ab_5 (never executed)
                Filter: ((a = $1) AND (b = $0))
-         ->  Seq Scan on ab_a1_b3 ab_5 (never executed)
+         ->  Seq Scan on ab_a1_b3 ab_6 (never executed)
                Filter: ((a = $1) AND (b = $0))
  Optimizer: Postgres query optimizer
 (20 rows)
@@ -2705,15 +2702,15 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                  Index Cond: (a = 1)
@@ -2724,15 +2721,15 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                      Index Cond: (a = 1)
          ->  Materialize (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab (actual rows=0 loops=1)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (actual rows=1 loops=1)
+                     ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (actual rows=1 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (actual rows=0 loops=1)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (actual rows=0 loops=1)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
@@ -2743,15 +2740,15 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                      Index Cond: (a = 1)
          ->  Materialize (never executed)
                ->  Append (never executed)
-                     ->  Bitmap Heap Scan on ab_a1_b1 ab (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b1 ab_1 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b1_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b2 ab_1 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b2 ab_2 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b2_a_idx (never executed)
                                  Index Cond: (a = 1)
-                     ->  Bitmap Heap Scan on ab_a1_b3 ab_2 (never executed)
+                     ->  Bitmap Heap Scan on ab_a1_b3 ab_3 (never executed)
                            Recheck Cond: (a = 1)
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                  Index Cond: (a = 1)
@@ -3085,7 +3082,7 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,1);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (actual rows=0 loops=1)
+         ->  Seq Scan on listp_1_1 listp_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -3096,23 +3093,20 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (2,2);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_2_1 listp (actual rows=0 loops=1)
+         ->  Seq Scan on listp_2_1 listp_1 (actual rows=0 loops=1)
                Filter: (b = ANY (ARRAY[$1, $2]))
  Optimizer: Postgres query optimizer
 (6 rows)
 
--- Try with no matching partitions. One subplan should remain in this case,
--- but it shouldn't be executed.
+-- Try with no matching partitions.
 explain (analyze, costs off, summary off, timing off)  execute q1 (0,0);
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (never executed)
-               Filter: (b = ANY (ARRAY[$1, $2]))
+         Subplans Removed: 2
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 deallocate q1;
 -- Test more complex cases where a not-equal condition further eliminates partitions.
@@ -3124,23 +3118,20 @@ explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,0);
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (actual rows=0 loops=1)
+         ->  Seq Scan on listp_1_1 listp_1 (actual rows=0 loops=1)
                Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
  Optimizer: Postgres query optimizer
 (6 rows)
 
 -- Both partitions allowed by IN clause, then both excluded again by <> clauses.
--- One subplan will remain in this case, but it should not be executed.
 explain (analyze, costs off, summary off, timing off)  execute q1 (1,2,2,1);
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Append (actual rows=0 loops=1)
-         Subplans Removed: 1
-         ->  Seq Scan on listp_1_1 listp (never executed)
-               Filter: ((b = ANY (ARRAY[$1, $2])) AND ($3 <> b) AND ($4 <> b))
+         Subplans Removed: 2
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 -- Ensure Params that evaluate to NULL properly prune away all partitions
 explain (analyze, costs off, summary off, timing off)
@@ -3151,9 +3142,9 @@ select * from listp where a = (select null::int);
    InitPlan 1 (returns $0)  (slice2)
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=0 loops=1)
-         ->  Seq Scan on listp_1_1 listp (never executed)
+         ->  Seq Scan on listp_1_1 listp_1 (never executed)
                Filter: (a = $0)
-         ->  Seq Scan on listp_2_1 listp_1 (never executed)
+         ->  Seq Scan on listp_2_1 listp_2 (never executed)
                Filter: (a = $0)
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -3298,11 +3289,11 @@ select * from mc3p where a < 3 and abs(b) = 1;
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
    ->  Append (actual rows=2 loops=1)
-         ->  Seq Scan on mc3p0 mc3p (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p0 mc3p_1 (actual rows=1 loops=1)
                Filter: ((a < 3) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p1 mc3p_2 (actual rows=1 loops=1)
                Filter: ((a < 3) AND (abs(b) = 1))
-         ->  Seq Scan on mc3p2 mc3p_2 (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p2 mc3p_3 (actual rows=1 loops=1)
                Filter: ((a < 3) AND (abs(b) = 1))
  Optimizer: Postgres query optimizer
 (9 rows)
@@ -3323,7 +3314,7 @@ execute ps1(1);
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=1 loops=1)
          Subplans Removed: 2
-         ->  Seq Scan on mc3p1 mc3p (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
                Filter: ((a = $1) AND (abs(b) < $0))
  Optimizer: Postgres query optimizer
 (8 rows)
@@ -3340,9 +3331,9 @@ execute ps2(1);
      ->  Result (actual rows=1 loops=1)
    ->  Append (actual rows=2 loops=1)
          Subplans Removed: 1
-         ->  Seq Scan on mc3p0 mc3p (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p0 mc3p_1 (actual rows=1 loops=1)
                Filter: ((a <= $1) AND (abs(b) < $0))
-         ->  Seq Scan on mc3p1 mc3p_1 (actual rows=1 loops=1)
+         ->  Seq Scan on mc3p1 mc3p_2 (actual rows=1 loops=1)
                Filter: ((a <= $1) AND (abs(b) < $0))
  Optimizer: Postgres query optimizer
 (10 rows)
@@ -3436,10 +3427,10 @@ explain (analyze, costs off, summary off, timing off) execute mt_q1(15);
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: ma_test.b
          Subplans Removed: 1
-         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test (actual rows=1 loops=1)
+         ->  Index Scan using ma_test_p2_b_idx on ma_test_p2 ma_test_1 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 1
-         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_1 (actual rows=1 loops=1)
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_2 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 2
  Optimizer: Postgres query optimizer
@@ -3453,14 +3444,14 @@ execute mt_q1(15);
 (2 rows)
 
 explain (analyze, costs off, summary off, timing off) execute mt_q1(25);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=1 loops=1)
    Merge Key: ma_test.b
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: ma_test.b
          Subplans Removed: 2
-         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test (actual rows=1 loops=1)
+         ->  Index Scan using ma_test_p3_b_idx on ma_test_p3 ma_test_1 (actual rows=1 loops=1)
                Filter: ((a >= $1) AND ((a % 10) = 5))
                Rows Removed by Filter: 2
  Optimizer: Postgres query optimizer
@@ -3474,17 +3465,15 @@ execute mt_q1(25);
 
 -- Ensure MergeAppend behaves correctly when no subplans match
 explain (analyze, costs off, summary off, timing off) execute mt_q1(35);
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                            QUERY PLAN                            
+------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    Merge Key: ma_test.b
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: ma_test.b
-         Subplans Removed: 2
-         ->  Index Scan using ma_test_p1_b_idx on ma_test_p1 ma_test (never executed)
-               Filter: ((a >= $1) AND ((a % 10) = 5))
+         Subplans Removed: 3
  Optimizer: Postgres query optimizer
-(8 rows)
+(6 rows)
 
 execute mt_q1(35);
  a 
@@ -3492,6 +3481,26 @@ execute mt_q1(35);
 (0 rows)
 
 deallocate mt_q1;
+prepare mt_q2 (int) as select * from ma_test where a >= $1 order by b limit 1;
+-- Ensure output list looks sane when the MergeAppend has no subplans.
+explain (analyze, verbose, costs off, summary off, timing off) execute mt_q2 (35);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   Output: ma_test.a, ma_test.b
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+         Output: ma_test.a, ma_test.b
+         Merge Key: ma_test.b
+         ->  Limit (actual rows=0 loops=1)
+               Output: ma_test.a, ma_test.b
+               ->  Merge Append (actual rows=0 loops=1)
+                     Sort Key: ma_test.b
+                     Subplans Removed: 3
+ Optimizer: Postgres query optimizer
+ Settings: enable_hashjoin = 'off', enable_indexonlyscan = 'off', enable_seqscan = 'off', enable_sort = 'off', plan_cache_mode = 'force_generic_plan'
+(12 rows)
+
+deallocate mt_q2;
 -- ensure initplan params properly prune partitions
 explain (analyze, costs off, summary off, timing off) select * from ma_test where a >= (select min(b) from ma_test_p2) order by b;
                                            QUERY PLAN                                           
@@ -3621,9 +3630,9 @@ explain (costs off) select * from pph_arrpart where a in ('{4, 5}', '{1}');
 ----------------------------------------------------------------------------
  Gather Motion 2:1  (slice1; segments: 2)
    ->  Append
-         ->  Seq Scan on pph_arrpart1 pph_arrpart
+         ->  Seq Scan on pph_arrpart1 pph_arrpart_1
                Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
-         ->  Seq Scan on pph_arrpart2 pph_arrpart_1
+         ->  Seq Scan on pph_arrpart2 pph_arrpart_2
                Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -3836,9 +3845,9 @@ explain (costs off) select * from inh_lp where a = 1;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Append
-         ->  Seq Scan on inh_lp
+         ->  Seq Scan on inh_lp inh_lp_1
                Filter: (a = 1)
-         ->  Seq Scan on inh_lp1 inh_lp_1
+         ->  Seq Scan on inh_lp1 inh_lp_2
                Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (7 rows)

--- a/src/test/regress/expected/rowsecurity.out
+++ b/src/test/regress/expected/rowsecurity.out
@@ -684,31 +684,18 @@ SELECT * FROM t1;
 (5 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM t1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: ((a % 2) = 0)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: ((a % 2) = 0)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: ((a % 2) = 0)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-          QUERY PLAN           
--------------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: ((a % 2) = 0)
-   ->  Seq Scan on t2 t1_2
-         Filter: ((a % 2) = 0)
-   ->  Seq Scan on t3 t1_3
-         Filter: ((a % 2) = 0)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 SELECT * FROM t1 WHERE f_leak(b);
 NOTICE:  f_leak => bbb
@@ -726,31 +713,18 @@ NOTICE:  f_leak => yyy
 (5 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
-<<<<<<< HEAD
                      QUERY PLAN                      
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: (((a % 2) = 0) AND f_leak(b))
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: (((a % 2) = 0) AND f_leak(b))
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: (((a % 2) = 0) AND f_leak(b))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                  QUERY PLAN                   
------------------------------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  Seq Scan on t2 t1_2
-         Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  Seq Scan on t3 t1_3
-         Filter: (((a % 2) = 0) AND f_leak(b))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- reference to system column
 SELECT tableoid::regclass, * FROM t1;
@@ -764,30 +738,17 @@ SELECT tableoid::regclass, * FROM t1;
 (5 rows)
 
 EXPLAIN (COSTS OFF) SELECT *, t1 FROM t1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: ((a % 2) = 0)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: ((a % 2) = 0)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: ((a % 2) = 0)
 (9 rows)
-=======
-          QUERY PLAN           
--------------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: ((a % 2) = 0)
-   ->  Seq Scan on t2 t1_2
-         Filter: ((a % 2) = 0)
-   ->  Seq Scan on t3 t1_3
-         Filter: ((a % 2) = 0)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- reference to whole-row reference
 SELECT *, t1 FROM t1;
@@ -801,31 +762,18 @@ SELECT *, t1 FROM t1;
 (5 rows)
 
 EXPLAIN (COSTS OFF) SELECT *, t1 FROM t1;
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: ((a % 2) = 0)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: ((a % 2) = 0)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: ((a % 2) = 0)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-          QUERY PLAN           
--------------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: ((a % 2) = 0)
-   ->  Seq Scan on t2 t1_2
-         Filter: ((a % 2) = 0)
-   ->  Seq Scan on t3 t1_3
-         Filter: ((a % 2) = 0)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- for share/update lock
 SELECT * FROM t1 FOR SHARE;
@@ -934,31 +882,18 @@ NOTICE:  f_leak => zzz
 (11 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: f_leak(b)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: f_leak(b)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: f_leak(b)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-        QUERY PLAN         
----------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: f_leak(b)
-   ->  Seq Scan on t2 t1_2
-         Filter: f_leak(b)
-   ->  Seq Scan on t3 t1_3
-         Filter: f_leak(b)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- non-superuser with bypass privilege can bypass RLS policy when disabled
 SET SESSION AUTHORIZATION regress_rls_exempt_user;
@@ -991,31 +926,18 @@ NOTICE:  f_leak => zzz
 (11 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: f_leak(b)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: f_leak(b)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: f_leak(b)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-        QUERY PLAN         
----------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: f_leak(b)
-   ->  Seq Scan on t2 t1_2
-         Filter: f_leak(b)
-   ->  Seq Scan on t3 t1_3
-         Filter: f_leak(b)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- Partitioned Tables
@@ -1103,7 +1025,6 @@ NOTICE:  f_leak => my first satire
 (4 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1112,29 +1033,14 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
            ->  Seq Scan on uaccount
                  Filter: (pguser = 'regress_rls_bob'::name)
    ->  Append
-         ->  Seq Scan on part_document_fiction part_document
+         ->  Seq Scan on part_document_fiction part_document_1
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_satire part_document_1
+         ->  Seq Scan on part_document_satire part_document_2
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_nonfiction part_document_2
+         ->  Seq Scan on part_document_nonfiction part_document_3
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   InitPlan 1 (returns $0)
-     ->  Index Scan using uaccount_pkey on uaccount
-           Index Cond: (pguser = CURRENT_USER)
-   ->  Seq Scan on part_document_fiction part_document_1
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_satire part_document_2
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_nonfiction part_document_3
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- viewpoint from regress_rls_carol
 SET SESSION AUTHORIZATION regress_rls_carol;
@@ -1164,7 +1070,6 @@ NOTICE:  f_leak => awesome technology book
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1173,29 +1078,14 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
            ->  Seq Scan on uaccount
                  Filter: (pguser = 'regress_rls_carol'::name)
    ->  Append
-         ->  Seq Scan on part_document_fiction part_document
+         ->  Seq Scan on part_document_fiction part_document_1
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_satire part_document_1
+         ->  Seq Scan on part_document_satire part_document_2
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_nonfiction part_document_2
+         ->  Seq Scan on part_document_nonfiction part_document_3
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   InitPlan 1 (returns $0)
-     ->  Index Scan using uaccount_pkey on uaccount
-           Index Cond: (pguser = CURRENT_USER)
-   ->  Seq Scan on part_document_fiction part_document_1
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_satire part_document_2
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_nonfiction part_document_3
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- viewpoint from regress_rls_dave
 SET SESSION AUTHORIZATION regress_rls_dave;
@@ -1336,7 +1226,6 @@ NOTICE:  f_leak => awesome technology book
 (11 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
-<<<<<<< HEAD
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -1345,29 +1234,14 @@ EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
            ->  Seq Scan on uaccount
                  Filter: (pguser = 'regress_rls_carol'::name)
    ->  Append
-         ->  Seq Scan on part_document_fiction part_document
+         ->  Seq Scan on part_document_fiction part_document_1
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_satire part_document_1
+         ->  Seq Scan on part_document_satire part_document_2
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_nonfiction part_document_2
+         ->  Seq Scan on part_document_nonfiction part_document_3
                Filter: ((dlevel <= $0) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   InitPlan 1 (returns $0)
-     ->  Index Scan using uaccount_pkey on uaccount
-           Index Cond: (pguser = CURRENT_USER)
-   ->  Seq Scan on part_document_fiction part_document_1
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_satire part_document_2
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_nonfiction part_document_3
-         Filter: ((dlevel <= $0) AND f_leak(dtitle))
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- only owner can change policies
 ALTER POLICY pp1 ON part_document USING (true);    --fail
@@ -1407,31 +1281,18 @@ NOTICE:  f_leak => great technology book
 (3 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM part_document WHERE f_leak(dtitle);
-<<<<<<< HEAD
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on part_document_fiction part_document
+         ->  Seq Scan on part_document_fiction part_document_1
                Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_satire part_document_1
+         ->  Seq Scan on part_document_satire part_document_2
                Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
-         ->  Seq Scan on part_document_nonfiction part_document_2
+         ->  Seq Scan on part_document_nonfiction part_document_3
                Filter: ((dauthor = 'regress_rls_carol'::name) AND f_leak(dtitle))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                          QUERY PLAN                           
----------------------------------------------------------------
- Append
-   ->  Seq Scan on part_document_fiction part_document_1
-         Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_satire part_document_2
-         Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-   ->  Seq Scan on part_document_nonfiction part_document_3
-         Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- database superuser does bypass RLS policy when enabled
 RESET SESSION AUTHORIZATION;
@@ -1717,31 +1578,18 @@ EXECUTE p1(2);
 (3 rows)
 
 EXPLAIN (COSTS OFF) EXECUTE p1(2);
-<<<<<<< HEAD
                      QUERY PLAN                     
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: ((a <= 2) AND ((a % 2) = 0))
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: ((a <= 2) AND ((a % 2) = 0))
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: ((a <= 2) AND ((a % 2) = 0))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                  QUERY PLAN                  
-----------------------------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: ((a <= 2) AND ((a % 2) = 0))
-   ->  Seq Scan on t2 t1_2
-         Filter: ((a <= 2) AND ((a % 2) = 0))
-   ->  Seq Scan on t3 t1_3
-         Filter: ((a <= 2) AND ((a % 2) = 0))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- superuser is allowed to bypass RLS checks
 RESET SESSION AUTHORIZATION;
@@ -1774,31 +1622,18 @@ NOTICE:  f_leak => zzz
 (11 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: f_leak(b)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: f_leak(b)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: f_leak(b)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-        QUERY PLAN         
----------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: f_leak(b)
-   ->  Seq Scan on t2 t1_2
-         Filter: f_leak(b)
-   ->  Seq Scan on t3 t1_3
-         Filter: f_leak(b)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- plan cache should be invalidated
 EXECUTE p1(2);
@@ -1813,31 +1648,18 @@ EXECUTE p1(2);
 (6 rows)
 
 EXPLAIN (COSTS OFF) EXECUTE p1(2);
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: (a <= 2)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: (a <= 2)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: (a <= 2)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-        QUERY PLAN         
----------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: (a <= 2)
-   ->  Seq Scan on t2 t1_2
-         Filter: (a <= 2)
-   ->  Seq Scan on t3 t1_3
-         Filter: (a <= 2)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 PREPARE p2(int) AS SELECT * FROM t1 WHERE a = $1;
 EXECUTE p2(2);
@@ -1849,31 +1671,18 @@ EXECUTE p2(2);
 (3 rows)
 
 EXPLAIN (COSTS OFF) EXECUTE p2(2);
-<<<<<<< HEAD
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: (a = 2)
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: (a = 2)
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: (a = 2)
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-        QUERY PLAN         
----------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: (a = 2)
-   ->  Seq Scan on t2 t1_2
-         Filter: (a = 2)
-   ->  Seq Scan on t3 t1_3
-         Filter: (a = 2)
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 -- also, case when privilege switch from superuser
 SET SESSION AUTHORIZATION regress_rls_bob;
@@ -1887,31 +1696,18 @@ EXECUTE p2(2);
 (3 rows)
 
 EXPLAIN (COSTS OFF) EXECUTE p2(2);
-<<<<<<< HEAD
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Seq Scan on t1
+         ->  Seq Scan on t1 t1_1
                Filter: ((a = 2) AND ((a % 2) = 0))
-         ->  Seq Scan on t2 t1_1
+         ->  Seq Scan on t2 t1_2
                Filter: ((a = 2) AND ((a % 2) = 0))
-         ->  Seq Scan on t3 t1_2
+         ->  Seq Scan on t3 t1_3
                Filter: ((a = 2) AND ((a % 2) = 0))
  Optimizer: Postgres query optimizer
 (9 rows)
-=======
-                 QUERY PLAN                  
----------------------------------------------
- Append
-   ->  Seq Scan on t1 t1_1
-         Filter: ((a = 2) AND ((a % 2) = 0))
-   ->  Seq Scan on t2 t1_2
-         Filter: ((a = 2) AND ((a % 2) = 0))
-   ->  Seq Scan on t3 t1_3
-         Filter: ((a = 2) AND ((a % 2) = 0))
-(7 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 --
 -- UPDATE / DELETE and Row-level security
@@ -2052,28 +1848,17 @@ WHERE t1.a = 3 and t2.a = 3 AND f_leak(t1.b) AND f_leak(t2.b);
    ->  Nested Loop
          ->  Seq Scan on t2
                Filter: ((a = 3) AND ((a % 2) = 1) AND f_leak(b))
-<<<<<<< HEAD
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Append
-                           ->  Seq Scan on t1
+                           ->  Seq Scan on t1 t1_1
                                  Filter: ((a = 3) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t2 t1_1
+                           ->  Seq Scan on t2 t1_2
                                  Filter: ((a = 3) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t3 t1_2
+                           ->  Seq Scan on t3 t1_3
                                  Filter: ((a = 3) AND ((a % 2) = 0) AND f_leak(b))
  Optimizer: Postgres query optimizer
 (14 rows)
-=======
-         ->  Append
-               ->  Seq Scan on t1 t1_1
-                     Filter: ((a = 3) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t2 t1_2
-                     Filter: ((a = 3) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t3 t1_3
-                     Filter: ((a = 3) AND ((a % 2) = 0) AND f_leak(b))
-(11 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 UPDATE t2 SET b=t2.b FROM t1
 WHERE t1.a = 3 and t2.a = 3 AND f_leak(t1.b) AND f_leak(t2.b);
@@ -2111,7 +1896,6 @@ NOTICE:  f_leak => cde
 EXPLAIN (COSTS OFF) UPDATE t1 t1_1 SET b = t1_2.b FROM t1 t1_2
 WHERE t1_1.a = 4 AND t1_2.a = t1_1.a AND t1_2.b = t1_1.b
 AND f_leak(t1_1.b) AND f_leak(t1_2.b) RETURNING *, t1_1, t1_2;
-<<<<<<< HEAD
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -2123,11 +1907,11 @@ AND f_leak(t1_1.b) AND f_leak(t1_2.b) RETURNING *, t1_1, t1_2;
                ->  Hash Join
                      Hash Cond: (t1_2.b = t1_1.b)
                      ->  Append
-                           ->  Seq Scan on t1 t1_2
+                           ->  Seq Scan on t1 t1_2_1
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t2 t1_2_1
+                           ->  Seq Scan on t2 t1_2_2
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t3 t1_2_2
+                           ->  Seq Scan on t3 t1_2_3
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice3; segments: 3)
@@ -2137,11 +1921,11 @@ AND f_leak(t1_1.b) AND f_leak(t1_2.b) RETURNING *, t1_1, t1_2;
                ->  Hash Join
                      Hash Cond: (t1_2.b = t1_1_1.b)
                      ->  Append
-                           ->  Seq Scan on t1 t1_2
+                           ->  Seq Scan on t1 t1_2_1
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t2 t1_2_1
+                           ->  Seq Scan on t2 t1_2_2
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t3 t1_2_2
+                           ->  Seq Scan on t3 t1_2_3
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice5; segments: 3)
@@ -2151,11 +1935,11 @@ AND f_leak(t1_1.b) AND f_leak(t1_2.b) RETURNING *, t1_1, t1_2;
                ->  Hash Join
                      Hash Cond: (t1_2.b = t1_1_2.b)
                      ->  Append
-                           ->  Seq Scan on t1 t1_2
+                           ->  Seq Scan on t1 t1_2_1
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t2 t1_2_1
+                           ->  Seq Scan on t2 t1_2_2
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-                           ->  Seq Scan on t3 t1_2_2
+                           ->  Seq Scan on t3 t1_2_3
                                  Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice7; segments: 3)
@@ -2163,48 +1947,6 @@ AND f_leak(t1_1.b) AND f_leak(t1_2.b) RETURNING *, t1_1, t1_2;
                                        Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
  Optimizer: Postgres query optimizer
 (48 rows)
-=======
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Update on t1 t1_1
-   Update on t1 t1_1
-   Update on t2 t1_1_1
-   Update on t3 t1_1_2
-   ->  Nested Loop
-         Join Filter: (t1_1.b = t1_2.b)
-         ->  Seq Scan on t1 t1_1
-               Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-         ->  Append
-               ->  Seq Scan on t1 t1_2_1
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t2 t1_2_2
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t3 t1_2_3
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-   ->  Nested Loop
-         Join Filter: (t1_1_1.b = t1_2.b)
-         ->  Seq Scan on t2 t1_1_1
-               Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-         ->  Append
-               ->  Seq Scan on t1 t1_2_1
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t2 t1_2_2
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t3 t1_2_3
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-   ->  Nested Loop
-         Join Filter: (t1_1_2.b = t1_2.b)
-         ->  Seq Scan on t3 t1_1_2
-               Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-         ->  Append
-               ->  Seq Scan on t1 t1_2_1
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t2 t1_2_2
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on t3 t1_2_3
-                     Filter: ((a = 4) AND ((a % 2) = 0) AND f_leak(b))
-(37 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 UPDATE t1 t1_1 SET b = t1_2.b FROM t1 t1_2
 WHERE t1_1.a = 4 AND t1_2.a = t1_1.a AND t1_2.b = t1_1.b

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -23,24 +23,14 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-<<<<<<< HEAD
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
+                     ->  Seq Scan on c_star a_star_3
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
  Optimizer: Postgres query optimizer
-=======
-               ->  Parallel Append
-                     ->  Parallel Seq Scan on d_star a_star_4
-                     ->  Parallel Seq Scan on f_star a_star_6
-                     ->  Parallel Seq Scan on e_star a_star_5
-                     ->  Parallel Seq Scan on b_star a_star_2
-                     ->  Parallel Seq Scan on c_star a_star_3
-                     ->  Parallel Seq Scan on a_star a_star_1
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (11 rows)
 
 select round(avg(aa)), sum(aa) from a_star a1;
@@ -59,24 +49,14 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-<<<<<<< HEAD
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
- Optimizer: Postgres query optimizer
-=======
-               ->  Parallel Append
-                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
                      ->  Seq Scan on c_star a_star_3
-                     ->  Parallel Seq Scan on f_star a_star_6
-                     ->  Parallel Seq Scan on e_star a_star_5
-                     ->  Parallel Seq Scan on b_star a_star_2
-                     ->  Parallel Seq Scan on a_star a_star_1
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
+ Optimizer: Postgres query optimizer
 (11 rows)
 
 select round(avg(aa)), sum(aa) from a_star a2;
@@ -97,24 +77,14 @@ explain (costs off)
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-<<<<<<< HEAD
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
- Optimizer: Postgres query optimizer
-=======
-               ->  Parallel Append
-                     ->  Seq Scan on d_star a_star_4
-                     ->  Seq Scan on f_star a_star_6
-                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
                      ->  Seq Scan on b_star a_star_2
                      ->  Seq Scan on c_star a_star_3
-                     ->  Seq Scan on a_star a_star_1
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
+ Optimizer: Postgres query optimizer
 (11 rows)
 
 select round(avg(aa)), sum(aa) from a_star a3;
@@ -139,22 +109,13 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-<<<<<<< HEAD
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
+                     ->  Seq Scan on c_star a_star_3
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
  Optimizer: Postgres query optimizer
-=======
-                     ->  Parallel Seq Scan on a_star a_star_1
-                     ->  Parallel Seq Scan on b_star a_star_2
-                     ->  Parallel Seq Scan on c_star a_star_3
-                     ->  Parallel Seq Scan on d_star a_star_4
-                     ->  Parallel Seq Scan on e_star a_star_5
-                     ->  Parallel Seq Scan on f_star a_star_6
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 (11 rows)
 
 select round(avg(aa)), sum(aa) from a_star a4;
@@ -182,7 +143,6 @@ create table part_pa_test_p2 partition of part_pa_test for values from (0) to (m
 explain (costs off)
 	select (select max((select pa1.b from part_pa_test pa1 where pa1.a = pa2.a)))
 	from part_pa_test pa2;
-<<<<<<< HEAD
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Finalize Aggregate
@@ -203,25 +163,6 @@ explain (costs off)
      ->  Result
  Optimizer: Postgres query optimizer
 (17 rows)
-=======
-                          QUERY PLAN                          
---------------------------------------------------------------
- Aggregate
-   ->  Gather
-         Workers Planned: 3
-         ->  Parallel Append
-               ->  Parallel Seq Scan on part_pa_test_p1 pa2_1
-               ->  Parallel Seq Scan on part_pa_test_p2 pa2_2
-   SubPlan 2
-     ->  Result
-   SubPlan 1
-     ->  Append
-           ->  Seq Scan on part_pa_test_p1 pa1_1
-                 Filter: (a = pa2.a)
-           ->  Seq Scan on part_pa_test_p2 pa1_2
-                 Filter: (a = pa2.a)
-(14 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table part_pa_test;
 -- test with leader participation disabled

--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -149,16 +149,16 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Seq Scan on part_pa_test_p1 pa2
-                     ->  Seq Scan on part_pa_test_p2 pa2_1
+                     ->  Seq Scan on part_pa_test_p1 pa2_1
+                     ->  Seq Scan on part_pa_test_p2 pa2_2
                SubPlan 1
                  ->  Result
                        Filter: (pa1.a = pa2.a)
                        ->  Materialize
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                    ->  Append
-                                         ->  Seq Scan on part_pa_test_p1 pa1
-                                         ->  Seq Scan on part_pa_test_p2 pa1_1
+                                         ->  Seq Scan on part_pa_test_p1 pa1_1
+                                         ->  Seq Scan on part_pa_test_p2 pa1_2
    SubPlan 2
      ->  Result
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -24,12 +24,12 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
+                     ->  Seq Scan on c_star a_star_3
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -50,12 +50,12 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
+                     ->  Seq Scan on c_star a_star_3
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -78,12 +78,12 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
+                     ->  Seq Scan on c_star a_star_3
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -109,12 +109,12 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Seq Scan on a_star
-                     ->  Seq Scan on b_star a_star_1
-                     ->  Seq Scan on c_star a_star_2
-                     ->  Seq Scan on d_star a_star_3
-                     ->  Seq Scan on e_star a_star_4
-                     ->  Seq Scan on f_star a_star_5
+                     ->  Seq Scan on a_star a_star_1
+                     ->  Seq Scan on b_star a_star_2
+                     ->  Seq Scan on c_star a_star_3
+                     ->  Seq Scan on d_star a_star_4
+                     ->  Seq Scan on e_star a_star_5
+                     ->  Seq Scan on f_star a_star_6
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -149,16 +149,16 @@ explain (costs off)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Seq Scan on part_pa_test_p1 pa2
-                     ->  Seq Scan on part_pa_test_p2 pa2_1
+                     ->  Seq Scan on part_pa_test_p1 pa2_1
+                     ->  Seq Scan on part_pa_test_p2 pa2_2
                SubPlan 1
                  ->  Result
                        Filter: (pa1.a = pa2.a)
                        ->  Materialize
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                    ->  Append
-                                         ->  Seq Scan on part_pa_test_p1 pa1
-                                         ->  Seq Scan on part_pa_test_p2 pa1_1
+                                         ->  Seq Scan on part_pa_test_p1 pa1_1
+                                         ->  Seq Scan on part_pa_test_p2 pa1_2
    SubPlan 2
      ->  Result
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/tablesample.out
+++ b/src/test/regress/expected/tablesample.out
@@ -256,38 +256,22 @@ EXPLAIN (COSTS OFF)
 -- check inheritance behavior
 explain (costs off)
   select count(*) from person tablesample bernoulli (100);
-<<<<<<< HEAD
                          QUERY PLAN                          
 -------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Append
-                     ->  Sample Scan on person
+                     ->  Sample Scan on person person_1
                            Sampling: bernoulli ('100'::real)
-                     ->  Sample Scan on emp person_1
+                     ->  Sample Scan on emp person_2
                            Sampling: bernoulli ('100'::real)
-                     ->  Sample Scan on student person_2
+                     ->  Sample Scan on student person_3
                            Sampling: bernoulli ('100'::real)
-                     ->  Sample Scan on stud_emp person_3
+                     ->  Sample Scan on stud_emp person_4
                            Sampling: bernoulli ('100'::real)
  Optimizer: Postgres query optimizer
 (13 rows)
-=======
-                   QUERY PLAN                    
--------------------------------------------------
- Aggregate
-   ->  Append
-         ->  Sample Scan on person person_1
-               Sampling: bernoulli ('100'::real)
-         ->  Sample Scan on emp person_2
-               Sampling: bernoulli ('100'::real)
-         ->  Sample Scan on student person_3
-               Sampling: bernoulli ('100'::real)
-         ->  Sample Scan on stud_emp person_4
-               Sampling: bernoulli ('100'::real)
-(10 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 select count(*) from person tablesample bernoulli (100);
  count 
@@ -494,26 +478,15 @@ create table parted_sample_1 partition of parted_sample for values in (1);
 create table parted_sample_2 partition of parted_sample for values in (2);
 explain (costs off)
   select * from parted_sample tablesample bernoulli (100);
-<<<<<<< HEAD
-                         QUERY PLAN                         
-------------------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
-         ->  Sample Scan on parted_sample_1 parted_sample
+         ->  Sample Scan on parted_sample_1
                Sampling: bernoulli ('100'::real)
-         ->  Sample Scan on parted_sample_2 parted_sample_1
+         ->  Sample Scan on parted_sample_2
                Sampling: bernoulli ('100'::real)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                QUERY PLAN                 
--------------------------------------------
- Append
-   ->  Sample Scan on parted_sample_1
-         Sampling: bernoulli ('100'::real)
-   ->  Sample Scan on parted_sample_2
-         Sampling: bernoulli ('100'::real)
-(5 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 drop table parted_sample, parted_sample_1, parted_sample_2;

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -1579,7 +1579,6 @@ ANALYZE other_tbl_parent;
 ANALYZE other_tbl_child;
 EXPLAIN (costs off)
 UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
-<<<<<<< HEAD
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Update on base_tbl_parent
@@ -1605,31 +1604,6 @@ UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
                            ->  Seq Scan on base_tbl_child base_tbl_parent_1
  Optimizer: Postgres query optimizer
 (22 rows)
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Update on base_tbl_parent
-   Update on base_tbl_parent
-   Update on base_tbl_child base_tbl_parent_1
-   ->  Hash Join
-         Hash Cond: (other_tbl_parent.id = base_tbl_parent.a)
-         ->  Append
-               ->  Seq Scan on other_tbl_parent other_tbl_parent_1
-               ->  Seq Scan on other_tbl_child other_tbl_parent_2
-         ->  Hash
-               ->  Seq Scan on base_tbl_parent
-   ->  Merge Join
-         Merge Cond: (base_tbl_parent_1.a = other_tbl_parent.id)
-         ->  Sort
-               Sort Key: base_tbl_parent_1.a
-               ->  Seq Scan on base_tbl_child base_tbl_parent_1
-         ->  Sort
-               Sort Key: other_tbl_parent.id
-               ->  Append
-                     ->  Seq Scan on other_tbl_parent other_tbl_parent_1
-                     ->  Seq Scan on other_tbl_child other_tbl_parent_2
-(20 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
 SELECT * FROM ONLY base_tbl_parent ORDER BY a;
@@ -2383,7 +2357,6 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
    Update on public.t11 t1_1
    Update on public.t12 t1_2
    Update on public.t111 t1_3
-<<<<<<< HEAD
    ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id, (DMLAction)
          ->  Split
@@ -2495,37 +2468,6 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on', optimizer = 'off'
 (115 rows)
-=======
-   ->  Index Scan using t1_a_idx on public.t1
-         Output: 100, t1.b, t1.c, t1.ctid
-         Index Cond: ((t1.a > 5) AND (t1.a < 7))
-         Filter: ((t1.a <> 6) AND (alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1.a) AND leakproof(t1.a))
-         SubPlan 1
-           ->  Append
-                 ->  Seq Scan on public.t12 t12_1
-                       Filter: (t12_1.a = t1.a)
-                 ->  Seq Scan on public.t111 t12_2
-                       Filter: (t12_2.a = t1.a)
-         SubPlan 2
-           ->  Append
-                 ->  Seq Scan on public.t12 t12_4
-                       Output: t12_4.a
-                 ->  Seq Scan on public.t111 t12_5
-                       Output: t12_5.a
-   ->  Index Scan using t11_a_idx on public.t11 t1_1
-         Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid
-         Index Cond: ((t1_1.a > 5) AND (t1_1.a < 7))
-         Filter: ((t1_1.a <> 6) AND (alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1_1.a) AND leakproof(t1_1.a))
-   ->  Index Scan using t12_a_idx on public.t12 t1_2
-         Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid
-         Index Cond: ((t1_2.a > 5) AND (t1_2.a < 7))
-         Filter: ((t1_2.a <> 6) AND (alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-   ->  Index Scan using t111_a_idx on public.t111 t1_3
-         Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid
-         Index Cond: ((t1_3.a > 5) AND (t1_3.a < 7))
-         Filter: ((t1_3.a <> 6) AND (alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1_3.a) AND leakproof(t1_3.a))
-(33 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
 SELECT * FROM v1 WHERE a=100; -- Nothing should have been changed to 100
@@ -2547,7 +2489,6 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
    Update on public.t11 t1_1
    Update on public.t12 t1_2
    Update on public.t111 t1_3
-<<<<<<< HEAD
    ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)
          Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, (DMLAction)
          ->  Split
@@ -2659,37 +2600,6 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on', optimizer = 'off'
 (115 rows)
-=======
-   ->  Index Scan using t1_a_idx on public.t1
-         Output: (t1.a + 1), t1.b, t1.c, t1.ctid
-         Index Cond: ((t1.a > 5) AND (t1.a = 8))
-         Filter: ((alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1.a) AND leakproof(t1.a))
-         SubPlan 1
-           ->  Append
-                 ->  Seq Scan on public.t12 t12_1
-                       Filter: (t12_1.a = t1.a)
-                 ->  Seq Scan on public.t111 t12_2
-                       Filter: (t12_2.a = t1.a)
-         SubPlan 2
-           ->  Append
-                 ->  Seq Scan on public.t12 t12_4
-                       Output: t12_4.a
-                 ->  Seq Scan on public.t111 t12_5
-                       Output: t12_5.a
-   ->  Index Scan using t11_a_idx on public.t11 t1_1
-         Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid
-         Index Cond: ((t1_1.a > 5) AND (t1_1.a = 8))
-         Filter: ((alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1_1.a) AND leakproof(t1_1.a))
-   ->  Index Scan using t12_a_idx on public.t12 t1_2
-         Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid
-         Index Cond: ((t1_2.a > 5) AND (t1_2.a = 8))
-         Filter: ((alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-   ->  Index Scan using t111_a_idx on public.t111 t1_3
-         Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid
-         Index Cond: ((t1_3.a > 5) AND (t1_3.a = 8))
-         Filter: ((alternatives: SubPlan 1 or hashed SubPlan 2) AND snoop(t1_3.a) AND leakproof(t1_3.a))
-(33 rows)
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
 NOTICE:  snooped value: 8  (seg0 slice4 127.0.0.1:40000 pid=26920)

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -1579,8 +1579,8 @@ ANALYZE other_tbl_parent;
 ANALYZE other_tbl_child;
 EXPLAIN (costs off)
 UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Update on base_tbl_parent
    Update on base_tbl_parent
    Update on base_tbl_child base_tbl_parent_1
@@ -1589,8 +1589,8 @@ UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
                ->  Hash Join
                      Hash Cond: (other_tbl_parent.id = base_tbl_parent.a)
                      ->  Append
-                           ->  Seq Scan on other_tbl_parent
-                           ->  Seq Scan on other_tbl_child other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_parent other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_child other_tbl_parent_2
                      ->  Hash
                            ->  Seq Scan on base_tbl_parent
    ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
@@ -1598,8 +1598,8 @@ UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
                ->  Hash Join
                      Hash Cond: (other_tbl_parent.id = base_tbl_parent_1.a)
                      ->  Append
-                           ->  Seq Scan on other_tbl_parent
-                           ->  Seq Scan on other_tbl_child other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_parent other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_child other_tbl_parent_2
                      ->  Hash
                            ->  Seq Scan on base_tbl_child base_tbl_parent_1
  Optimizer: Postgres query optimizer
@@ -2366,24 +2366,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1.a > 5) AND (t1.a < 7) AND (t1.a <> 6) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
-                             Filter: (t12.a = t1.a)
+                             Filter: (t12_1.a = t1.a)
                              ->  Materialize
-                                   Output: t12.a
+                                   Output: t12_1.a
                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                         Output: t12.a
+                                         Output: t12_1.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12
-                                                     Output: t12.a
-                                               ->  Seq Scan on public.t111 t12_1
+                                               ->  Seq Scan on public.t12 t12_1
                                                      Output: t12_1.a
+                                               ->  Seq Scan on public.t111 t12_2
+                                                     Output: t12_2.a
                      SubPlan 2 (copy 12)
                        ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                             Output: t12_2.a
+                             Output: t12_4.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_2
-                                         Output: t12_2.a
-                                   ->  Seq Scan on public.t111 t12_3
-                                         Output: t12_3.a
+                                   ->  Seq Scan on public.t12 t12_4
+                                         Output: t12_4.a
+                                   ->  Seq Scan on public.t111 t12_5
+                                         Output: t12_5.a
    ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)
          Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
@@ -2393,24 +2393,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1_1.a > 5) AND (t1_1.a < 7) AND (t1_1.a <> 6) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_4.a = t1_1.a)
+                             Filter: (t12_7.a = t1_1.a)
                              ->  Materialize
-                                   Output: t12_4.a
+                                   Output: t12_7.a
                                    ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                         Output: t12_4.a
+                                         Output: t12_7.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_4
-                                                     Output: t12_4.a
-                                               ->  Seq Scan on public.t111 t12_5
-                                                     Output: t12_5.a
+                                               ->  Seq Scan on public.t12 t12_7
+                                                     Output: t12_7.a
+                                               ->  Seq Scan on public.t111 t12_8
+                                                     Output: t12_8.a
                      SubPlan 2 (copy 14)
                        ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                             Output: t12_6.a
+                             Output: t12_10.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_6
-                                         Output: t12_6.a
-                                   ->  Seq Scan on public.t111 t12_7
-                                         Output: t12_7.a
+                                   ->  Seq Scan on public.t12 t12_10
+                                         Output: t12_10.a
+                                   ->  Seq Scan on public.t111 t12_11
+                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
          Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          ->  Split
@@ -2420,24 +2420,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1_2.a > 5) AND (t1_2.a < 7) AND (t1_2.a <> 6) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
                      SubPlan 1 (copy 15)
                        ->  Result
-                             Filter: (t12_8.a = t1_2.a)
+                             Filter: (t12_13.a = t1_2.a)
                              ->  Materialize
-                                   Output: t12_8.a
+                                   Output: t12_13.a
                                    ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                                         Output: t12_8.a
+                                         Output: t12_13.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_8
-                                                     Output: t12_8.a
-                                               ->  Seq Scan on public.t111 t12_9
-                                                     Output: t12_9.a
+                                               ->  Seq Scan on public.t12 t12_13
+                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t111 t12_14
+                                                     Output: t12_14.a
                      SubPlan 2 (copy 16)
                        ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                             Output: t12_10.a
+                             Output: t12_16.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
+                                   ->  Seq Scan on public.t12 t12_16
+                                         Output: t12_16.a
+                                   ->  Seq Scan on public.t111 t12_17
+                                         Output: t12_17.a
    ->  Explicit Redistribute Motion 3:3  (slice10; segments: 3)
          Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
@@ -2447,24 +2447,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1_3.a > 5) AND (t1_3.a < 7) AND (t1_3.a <> 6) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_12.a = t1_3.a)
+                             Filter: (t12_19.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_12.a
+                                   Output: t12_19.a
                                    ->  Broadcast Motion 3:3  (slice11; segments: 3)
-                                         Output: t12_12.a
+                                         Output: t12_19.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_12
-                                                     Output: t12_12.a
-                                               ->  Seq Scan on public.t111 t12_13
-                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t12 t12_19
+                                                     Output: t12_19.a
+                                               ->  Seq Scan on public.t111 t12_20
+                                                     Output: t12_20.a
                      SubPlan 2 (copy 18)
                        ->  Broadcast Motion 3:3  (slice12; segments: 3)
-                             Output: t12_14.a
+                             Output: t12_22.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_14
-                                         Output: t12_14.a
-                                   ->  Seq Scan on public.t111 t12_15
-                                         Output: t12_15.a
+                                   ->  Seq Scan on public.t12 t12_22
+                                         Output: t12_22.a
+                                   ->  Seq Scan on public.t111 t12_23
+                                         Output: t12_23.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on', optimizer = 'off'
 (115 rows)
@@ -2498,24 +2498,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1.a > 5) AND (t1.a = 8) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
-                             Filter: (t12.a = t1.a)
+                             Filter: (t12_1.a = t1.a)
                              ->  Materialize
-                                   Output: t12.a
+                                   Output: t12_1.a
                                    ->  Broadcast Motion 3:1  (slice2; segments: 3)
-                                         Output: t12.a
+                                         Output: t12_1.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12
-                                                     Output: t12.a
-                                               ->  Seq Scan on public.t111 t12_1
+                                               ->  Seq Scan on public.t12 t12_1
                                                      Output: t12_1.a
+                                               ->  Seq Scan on public.t111 t12_2
+                                                     Output: t12_2.a
                      SubPlan 2 (copy 12)
                        ->  Broadcast Motion 3:1  (slice3; segments: 3)
-                             Output: t12_2.a
+                             Output: t12_4.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_2
-                                         Output: t12_2.a
-                                   ->  Seq Scan on public.t111 t12_3
-                                         Output: t12_3.a
+                                   ->  Seq Scan on public.t12 t12_4
+                                         Output: t12_4.a
+                                   ->  Seq Scan on public.t111 t12_5
+                                         Output: t12_5.a
    ->  Explicit Redistribute Motion 1:3  (slice4; segments: 1)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
@@ -2525,24 +2525,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1_1.a > 5) AND (t1_1.a = 8) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_4.a = t1_1.a)
+                             Filter: (t12_7.a = t1_1.a)
                              ->  Materialize
-                                   Output: t12_4.a
+                                   Output: t12_7.a
                                    ->  Broadcast Motion 3:1  (slice5; segments: 3)
-                                         Output: t12_4.a
+                                         Output: t12_7.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_4
-                                                     Output: t12_4.a
-                                               ->  Seq Scan on public.t111 t12_5
-                                                     Output: t12_5.a
+                                               ->  Seq Scan on public.t12 t12_7
+                                                     Output: t12_7.a
+                                               ->  Seq Scan on public.t111 t12_8
+                                                     Output: t12_8.a
                      SubPlan 2 (copy 14)
                        ->  Broadcast Motion 3:1  (slice6; segments: 3)
-                             Output: t12_6.a
+                             Output: t12_10.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_6
-                                         Output: t12_6.a
-                                   ->  Seq Scan on public.t111 t12_7
-                                         Output: t12_7.a
+                                   ->  Seq Scan on public.t12 t12_10
+                                         Output: t12_10.a
+                                   ->  Seq Scan on public.t111 t12_11
+                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 1:3  (slice7; segments: 1)
          Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          ->  Split
@@ -2552,24 +2552,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1_2.a > 5) AND (t1_2.a = 8) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
                      SubPlan 1 (copy 15)
                        ->  Result
-                             Filter: (t12_8.a = t1_2.a)
+                             Filter: (t12_13.a = t1_2.a)
                              ->  Materialize
-                                   Output: t12_8.a
+                                   Output: t12_13.a
                                    ->  Broadcast Motion 3:1  (slice8; segments: 3)
-                                         Output: t12_8.a
+                                         Output: t12_13.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_8
-                                                     Output: t12_8.a
-                                               ->  Seq Scan on public.t111 t12_9
-                                                     Output: t12_9.a
+                                               ->  Seq Scan on public.t12 t12_13
+                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t111 t12_14
+                                                     Output: t12_14.a
                      SubPlan 2 (copy 16)
                        ->  Broadcast Motion 3:1  (slice9; segments: 3)
-                             Output: t12_10.a
+                             Output: t12_16.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
+                                   ->  Seq Scan on public.t12 t12_16
+                                         Output: t12_16.a
+                                   ->  Seq Scan on public.t111 t12_17
+                                         Output: t12_17.a
    ->  Explicit Redistribute Motion 1:3  (slice10; segments: 1)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
@@ -2579,24 +2579,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1_3.a > 5) AND (t1_3.a = 8) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_12.a = t1_3.a)
+                             Filter: (t12_19.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_12.a
+                                   Output: t12_19.a
                                    ->  Broadcast Motion 3:1  (slice11; segments: 3)
-                                         Output: t12_12.a
+                                         Output: t12_19.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_12
-                                                     Output: t12_12.a
-                                               ->  Seq Scan on public.t111 t12_13
-                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t12 t12_19
+                                                     Output: t12_19.a
+                                               ->  Seq Scan on public.t111 t12_20
+                                                     Output: t12_20.a
                      SubPlan 2 (copy 18)
                        ->  Broadcast Motion 3:1  (slice12; segments: 3)
-                             Output: t12_14.a
+                             Output: t12_22.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_14
-                                         Output: t12_14.a
-                                   ->  Seq Scan on public.t111 t12_15
-                                         Output: t12_15.a
+                                   ->  Seq Scan on public.t12 t12_22
+                                         Output: t12_22.a
+                                   ->  Seq Scan on public.t111 t12_23
+                                         Output: t12_23.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on', optimizer = 'off'
 (115 rows)

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -334,6 +334,27 @@ UPDATE ro_view20 SET b=upper(b);
 ERROR:  cannot update view "ro_view20"
 DETAIL:  Views that return set-returning functions are not automatically updatable.
 HINT:  To enable updating the view, provide an INSTEAD OF UPDATE trigger or an unconditional ON UPDATE DO INSTEAD rule.
+-- A view with a conditional INSTEAD rule but no unconditional INSTEAD rules
+-- or INSTEAD OF triggers should be non-updatable and generate useful error
+-- messages with appropriate detail
+CREATE RULE rw_view16_ins_rule AS ON INSERT TO rw_view16
+  WHERE NEW.a > 0 DO INSTEAD INSERT INTO base_tbl VALUES (NEW.a, NEW.b);
+CREATE RULE rw_view16_upd_rule AS ON UPDATE TO rw_view16
+  WHERE OLD.a > 0 DO INSTEAD UPDATE base_tbl SET b=NEW.b WHERE a=OLD.a;
+CREATE RULE rw_view16_del_rule AS ON DELETE TO rw_view16
+  WHERE OLD.a > 0 DO INSTEAD DELETE FROM base_tbl WHERE a=OLD.a;
+INSERT INTO rw_view16 (a, b) VALUES (3, 'Row 3'); -- should fail
+ERROR:  cannot insert into view "rw_view16"
+DETAIL:  Views with conditional DO INSTEAD rules are not automatically updatable.
+HINT:  To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.
+UPDATE rw_view16 SET b='ROW 2' WHERE a=2; -- should fail
+ERROR:  cannot update view "rw_view16"
+DETAIL:  Views with conditional DO INSTEAD rules are not automatically updatable.
+HINT:  To enable updating the view, provide an INSTEAD OF UPDATE trigger or an unconditional ON UPDATE DO INSTEAD rule.
+DELETE FROM rw_view16 WHERE a=2; -- should fail
+ERROR:  cannot delete from view "rw_view16"
+DETAIL:  Views with conditional DO INSTEAD rules are not automatically updatable.
+HINT:  To enable deleting from the view, provide an INSTEAD OF DELETE trigger or an unconditional ON DELETE DO INSTEAD rule.
 DROP TABLE base_tbl CASCADE;
 NOTICE:  drop cascades to 16 other objects
 DETAIL:  drop cascades to view ro_view1
@@ -1568,8 +1589,8 @@ ANALYZE other_tbl_parent;
 ANALYZE other_tbl_child;
 EXPLAIN (costs off)
 UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Update on base_tbl_parent
    Update on base_tbl_parent
    Update on base_tbl_child base_tbl_parent_1
@@ -1578,8 +1599,8 @@ UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
                ->  Hash Join
                      Hash Cond: (other_tbl_parent.id = base_tbl_parent.a)
                      ->  Append
-                           ->  Seq Scan on other_tbl_parent
-                           ->  Seq Scan on other_tbl_child other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_parent other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_child other_tbl_parent_2
                      ->  Hash
                            ->  Seq Scan on base_tbl_parent
    ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
@@ -1587,8 +1608,8 @@ UPDATE rw_view1 SET a = a + 1000 FROM other_tbl_parent WHERE a = id;
                ->  Hash Join
                      Hash Cond: (other_tbl_parent.id = base_tbl_parent_1.a)
                      ->  Append
-                           ->  Seq Scan on other_tbl_parent
-                           ->  Seq Scan on other_tbl_child other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_parent other_tbl_parent_1
+                           ->  Seq Scan on other_tbl_child other_tbl_parent_2
                      ->  Hash
                            ->  Seq Scan on base_tbl_child base_tbl_parent_1
  Optimizer: Postgres query optimizer
@@ -2371,24 +2392,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1.a > 5) AND (t1.a < 7) AND (t1.a <> 6) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
-                             Filter: (t12.a = t1.a)
+                             Filter: (t12_1.a = t1.a)
                              ->  Materialize
-                                   Output: t12.a
+                                   Output: t12_1.a
                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                         Output: t12.a
+                                         Output: t12_1.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12
-                                                     Output: t12.a
-                                               ->  Seq Scan on public.t111 t12_1
+                                               ->  Seq Scan on public.t12 t12_1
                                                      Output: t12_1.a
+                                               ->  Seq Scan on public.t111 t12_2
+                                                     Output: t12_2.a
                      SubPlan 2 (copy 12)
                        ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                             Output: t12_2.a
+                             Output: t12_4.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_2
-                                         Output: t12_2.a
-                                   ->  Seq Scan on public.t111 t12_3
-                                         Output: t12_3.a
+                                   ->  Seq Scan on public.t12 t12_4
+                                         Output: t12_4.a
+                                   ->  Seq Scan on public.t111 t12_5
+                                         Output: t12_5.a
    ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)
          Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
@@ -2398,24 +2419,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1_1.a > 5) AND (t1_1.a < 7) AND (t1_1.a <> 6) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_4.a = t1_1.a)
+                             Filter: (t12_7.a = t1_1.a)
                              ->  Materialize
-                                   Output: t12_4.a
+                                   Output: t12_7.a
                                    ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                         Output: t12_4.a
+                                         Output: t12_7.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_4
-                                                     Output: t12_4.a
-                                               ->  Seq Scan on public.t111 t12_5
-                                                     Output: t12_5.a
+                                               ->  Seq Scan on public.t12 t12_7
+                                                     Output: t12_7.a
+                                               ->  Seq Scan on public.t111 t12_8
+                                                     Output: t12_8.a
                      SubPlan 2 (copy 14)
                        ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                             Output: t12_6.a
+                             Output: t12_10.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_6
-                                         Output: t12_6.a
-                                   ->  Seq Scan on public.t111 t12_7
-                                         Output: t12_7.a
+                                   ->  Seq Scan on public.t12 t12_10
+                                         Output: t12_10.a
+                                   ->  Seq Scan on public.t111 t12_11
+                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
          Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          ->  Split
@@ -2425,24 +2446,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1_2.a > 5) AND (t1_2.a < 7) AND (t1_2.a <> 6) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
                      SubPlan 1 (copy 15)
                        ->  Result
-                             Filter: (t12_8.a = t1_2.a)
+                             Filter: (t12_13.a = t1_2.a)
                              ->  Materialize
-                                   Output: t12_8.a
+                                   Output: t12_13.a
                                    ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                                         Output: t12_8.a
+                                         Output: t12_13.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_8
-                                                     Output: t12_8.a
-                                               ->  Seq Scan on public.t111 t12_9
-                                                     Output: t12_9.a
+                                               ->  Seq Scan on public.t12 t12_13
+                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t111 t12_14
+                                                     Output: t12_14.a
                      SubPlan 2 (copy 16)
                        ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                             Output: t12_10.a
+                             Output: t12_16.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
+                                   ->  Seq Scan on public.t12 t12_16
+                                         Output: t12_16.a
+                                   ->  Seq Scan on public.t111 t12_17
+                                         Output: t12_17.a
    ->  Explicit Redistribute Motion 3:3  (slice10; segments: 3)
          Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
@@ -2452,24 +2473,24 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                      Filter: ((t1_3.a > 5) AND (t1_3.a < 7) AND (t1_3.a <> 6) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_12.a = t1_3.a)
+                             Filter: (t12_19.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_12.a
+                                   Output: t12_19.a
                                    ->  Broadcast Motion 3:3  (slice11; segments: 3)
-                                         Output: t12_12.a
+                                         Output: t12_19.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_12
-                                                     Output: t12_12.a
-                                               ->  Seq Scan on public.t111 t12_13
-                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t12 t12_19
+                                                     Output: t12_19.a
+                                               ->  Seq Scan on public.t111 t12_20
+                                                     Output: t12_20.a
                      SubPlan 2 (copy 18)
                        ->  Broadcast Motion 3:3  (slice12; segments: 3)
-                             Output: t12_14.a
+                             Output: t12_22.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_14
-                                         Output: t12_14.a
-                                   ->  Seq Scan on public.t111 t12_15
-                                         Output: t12_15.a
+                                   ->  Seq Scan on public.t12 t12_22
+                                         Output: t12_22.a
+                                   ->  Seq Scan on public.t111 t12_23
+                                         Output: t12_23.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on'
 (115 rows)
@@ -2503,24 +2524,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1.a > 5) AND (t1.a = 8) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
-                             Filter: (t12.a = t1.a)
+                             Filter: (t12_1.a = t1.a)
                              ->  Materialize
-                                   Output: t12.a
+                                   Output: t12_1.a
                                    ->  Broadcast Motion 3:1  (slice2; segments: 3)
-                                         Output: t12.a
+                                         Output: t12_1.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12
-                                                     Output: t12.a
-                                               ->  Seq Scan on public.t111 t12_1
+                                               ->  Seq Scan on public.t12 t12_1
                                                      Output: t12_1.a
+                                               ->  Seq Scan on public.t111 t12_2
+                                                     Output: t12_2.a
                      SubPlan 2 (copy 12)
                        ->  Broadcast Motion 3:1  (slice3; segments: 3)
-                             Output: t12_2.a
+                             Output: t12_4.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_2
-                                         Output: t12_2.a
-                                   ->  Seq Scan on public.t111 t12_3
-                                         Output: t12_3.a
+                                   ->  Seq Scan on public.t12 t12_4
+                                         Output: t12_4.a
+                                   ->  Seq Scan on public.t111 t12_5
+                                         Output: t12_5.a
    ->  Explicit Redistribute Motion 1:3  (slice4; segments: 1)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
@@ -2530,24 +2551,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1_1.a > 5) AND (t1_1.a = 8) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_4.a = t1_1.a)
+                             Filter: (t12_7.a = t1_1.a)
                              ->  Materialize
-                                   Output: t12_4.a
+                                   Output: t12_7.a
                                    ->  Broadcast Motion 3:1  (slice5; segments: 3)
-                                         Output: t12_4.a
+                                         Output: t12_7.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_4
-                                                     Output: t12_4.a
-                                               ->  Seq Scan on public.t111 t12_5
-                                                     Output: t12_5.a
+                                               ->  Seq Scan on public.t12 t12_7
+                                                     Output: t12_7.a
+                                               ->  Seq Scan on public.t111 t12_8
+                                                     Output: t12_8.a
                      SubPlan 2 (copy 14)
                        ->  Broadcast Motion 3:1  (slice6; segments: 3)
-                             Output: t12_6.a
+                             Output: t12_10.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_6
-                                         Output: t12_6.a
-                                   ->  Seq Scan on public.t111 t12_7
-                                         Output: t12_7.a
+                                   ->  Seq Scan on public.t12 t12_10
+                                         Output: t12_10.a
+                                   ->  Seq Scan on public.t111 t12_11
+                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 1:3  (slice7; segments: 1)
          Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
          ->  Split
@@ -2557,24 +2578,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1_2.a > 5) AND (t1_2.a = 8) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
                      SubPlan 1 (copy 15)
                        ->  Result
-                             Filter: (t12_8.a = t1_2.a)
+                             Filter: (t12_13.a = t1_2.a)
                              ->  Materialize
-                                   Output: t12_8.a
+                                   Output: t12_13.a
                                    ->  Broadcast Motion 3:1  (slice8; segments: 3)
-                                         Output: t12_8.a
+                                         Output: t12_13.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_8
-                                                     Output: t12_8.a
-                                               ->  Seq Scan on public.t111 t12_9
-                                                     Output: t12_9.a
+                                               ->  Seq Scan on public.t12 t12_13
+                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t111 t12_14
+                                                     Output: t12_14.a
                      SubPlan 2 (copy 16)
                        ->  Broadcast Motion 3:1  (slice9; segments: 3)
-                             Output: t12_10.a
+                             Output: t12_16.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
+                                   ->  Seq Scan on public.t12 t12_16
+                                         Output: t12_16.a
+                                   ->  Seq Scan on public.t111 t12_17
+                                         Output: t12_17.a
    ->  Explicit Redistribute Motion 1:3  (slice10; segments: 1)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
@@ -2584,24 +2605,24 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                      Filter: ((t1_3.a > 5) AND (t1_3.a = 8) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_12.a = t1_3.a)
+                             Filter: (t12_19.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_12.a
+                                   Output: t12_19.a
                                    ->  Broadcast Motion 3:1  (slice11; segments: 3)
-                                         Output: t12_12.a
+                                         Output: t12_19.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_12
-                                                     Output: t12_12.a
-                                               ->  Seq Scan on public.t111 t12_13
-                                                     Output: t12_13.a
+                                               ->  Seq Scan on public.t12 t12_19
+                                                     Output: t12_19.a
+                                               ->  Seq Scan on public.t111 t12_20
+                                                     Output: t12_20.a
                      SubPlan 2 (copy 18)
                        ->  Broadcast Motion 3:1  (slice12; segments: 3)
-                             Output: t12_14.a
+                             Output: t12_22.a
                              ->  Append
-                                   ->  Seq Scan on public.t12 t12_14
-                                         Output: t12_14.a
-                                   ->  Seq Scan on public.t111 t12_15
-                                         Output: t12_15.a
+                                   ->  Seq Scan on public.t12 t12_22
+                                         Output: t12_22.a
+                                   ->  Seq Scan on public.t111 t12_23
+                                         Output: t12_23.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on'
 (115 rows)

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -2288,7 +2288,7 @@ ALTER TABLE ataddindex
 \d ataddindex
 DROP TABLE ataddindex;
 
-CREATE TABLE ataddindex(f1 VARCHAR(10));
+CREATE TABLE ataddindex(f1 VARCHAR(10)) DISTRIBUTED REPLICATED;
 INSERT INTO ataddindex(f1) VALUES ('foo'), ('a');
 ALTER TABLE ataddindex
   ALTER f1 SET DATA TYPE TEXT,


### PR DESCRIPTION
Resolve conflicts in tests caused by fixing aliases

1) Commit 6ef77cf fixed alias output in EXPLAIN in
src/test/regress/expected/aggregates.out,
src/test/regress/expected/alter_table.out,
src/test/regress/expected/inherit.out,
src/test/regress/expected/partition_aggregate.out,
src/test/regress/expected/partition_join.out,
src/test/regress/expected/partition_prune.out,
src/test/regress/expected/rowsecurity.out,
src/test/regress/expected/select_parallel.out,
src/test/regress/expected/tablesample.out,
src/test/regress/expected/updatable_views.out,
we need to fix it in GPDB-specific output and ORCA output.

2) Commit 823e739 added new tests to src/test/regress/sql/aggregates.sql, we
need to add them to ORCA output.

3) Commit 1281a5c changed tests in src/test/regress/sql/alter_table.sql, while
earlier commit 6b0e52b already added GPDB-specific output in the same place.
Also, adding a column with a primary key or unique constraint is not supported
in GPDB.

4) Commit 93765bd added new tests to src/test/regress/sql/alter_table.sql, and
commit ae5cae5 changed them.

5) Commit 22864f6 added new tests to src/test/regress/sql/partition_prune.sql,
we need to adapt their output for GPDB and add it to ORCA.

6) Commit d751ba5 added new tests to src/test/regress/sql/updatable_views.sql,
we need to add their output to ORCA.