### PR TITLE
Fix tests in src/test/regress/expected/create_index.out

### DIFF
--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -1353,14 +1353,14 @@ INSERT INTO func_index_heap VALUES('QWERTY');
  f1     | text |           |          | 
  f2     | text |           |          | 
 Indexes:
-    "func_index_index" UNIQUE, btree (textcat(f1, f2))
+    "func_index_index" btree (textcat(f1, f2))
 
 \d func_index_index
      Index "public.func_index_index"
  Column  | Type | Key? |   Definition    
 ---------+------+------+-----------------
  textcat | text | yes  | textcat(f1, f2)
-unique, btree, for table "public.func_index_heap"
+btree, for table "public.func_index_heap"
 
 --
 -- Same test, expressional index
@@ -1383,14 +1383,14 @@ INSERT INTO func_index_heap VALUES('QWERTY');
  f1     | text |           |          | 
  f2     | text |           |          | 
 Indexes:
-    "func_index_index" UNIQUE, btree ((f1 || f2))
+    "func_index_index" btree ((f1 || f2))
 
 \d func_index_index
   Index "public.func_index_index"
  Column | Type | Key? | Definition 
 --------+------+------+------------
  expr   | text | yes  | (f1 || f2)
-unique, btree, for table "public.func_index_heap"
+btree, for table "public.func_index_heap"
 
 -- this should fail because of unsafe column type (anonymous record)
 create index on func_index_heap ((f1 || f2), (row(f1, f2)));
@@ -1617,11 +1617,12 @@ LINE 1: ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq3_idx;
                                  ^
 DETAIL:  Cannot create a primary key or unique constraint using such an index.
 CREATE UNIQUE INDEX cwi_uniq4_idx ON cwi_test(b collate "POSIX");
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "a" is not included in the constraint.
 ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq4_idx;  -- fail
-ERROR:  index "cwi_uniq4_idx" column number 1 does not have default sorting behavior
+ERROR:  index "cwi_uniq4_idx" does not exist
 LINE 1: ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq4_idx;
                                  ^
-DETAIL:  Cannot create a primary key or unique constraint using such an index.
 DROP TABLE cwi_test;
 -- ADD CONSTRAINT USING INDEX is forbidden on partitioned tables
 CREATE TABLE cwi_test(a int) PARTITION BY hash (a);

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -1364,6 +1364,24 @@ INSERT INTO func_index_heap VALUES('QWE','RTY');
 INSERT INTO func_index_heap VALUES('ABCD', 'EF');
 -- but this shouldn't:
 INSERT INTO func_index_heap VALUES('QWERTY');
+-- while we're here, see that the metadata looks sane
+\d func_index_heap
+         Table "public.func_index_heap"
+ Column | Type | Collation | Nullable | Default 
+--------+------+-----------+----------+---------
+ f1     | text |           |          | 
+ f2     | text |           |          | 
+Indexes:
+    "func_index_index" btree (textcat(f1, f2))
+Distributed by: (f1)
+
+\d func_index_index
+     Index "public.func_index_index"
+ Column  | Type | Key? |   Definition    
+---------+------+------+-----------------
+ textcat | text | yes  | textcat(f1, f2)
+btree, for table "public.func_index_heap"
+
 --
 -- Same test, expressional index
 --
@@ -1377,6 +1395,27 @@ INSERT INTO func_index_heap VALUES('QWE','RTY');
 INSERT INTO func_index_heap VALUES('ABCD', 'EF');
 -- but this shouldn't:
 INSERT INTO func_index_heap VALUES('QWERTY');
+-- while we're here, see that the metadata looks sane
+\d func_index_heap
+         Table "public.func_index_heap"
+ Column | Type | Collation | Nullable | Default 
+--------+------+-----------+----------+---------
+ f1     | text |           |          | 
+ f2     | text |           |          | 
+Indexes:
+    "func_index_index" btree ((f1 || f2))
+Distributed by: (f1)
+
+\d func_index_index
+  Index "public.func_index_index"
+ Column | Type | Key? | Definition 
+--------+------+------+------------
+ expr   | text | yes  | (f1 || f2)
+btree, for table "public.func_index_heap"
+
+-- this should fail because of unsafe column type (anonymous record)
+create index on func_index_heap ((f1 || f2), (row(f1, f2)));
+ERROR:  column "row" has pseudo-type record
 --
 -- Test unique index with included columns
 --
@@ -1589,6 +1628,20 @@ primary key, btree, for table "public.cwi_test"
 DROP INDEX cwi_replaced_pkey;	-- Should fail; a constraint depends on it
 ERROR:  cannot drop index cwi_replaced_pkey because constraint cwi_replaced_pkey on table cwi_test requires it
 HINT:  You can drop constraint cwi_replaced_pkey on table cwi_test instead.
+-- Check that non-default index options are rejected
+CREATE UNIQUE INDEX cwi_uniq3_idx ON cwi_test(a desc);
+ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq3_idx;  -- fail
+ERROR:  index "cwi_uniq3_idx" column number 1 does not have default sorting behavior
+LINE 1: ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq3_idx;
+                                 ^
+DETAIL:  Cannot create a primary key or unique constraint using such an index.
+CREATE UNIQUE INDEX cwi_uniq4_idx ON cwi_test(b collate "POSIX");
+ERROR:  UNIQUE index must contain all columns in the table's distribution key
+DETAIL:  Distribution key column "a" is not included in the constraint.
+ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq4_idx;  -- fail
+ERROR:  index "cwi_uniq4_idx" does not exist
+LINE 1: ALTER TABLE cwi_test ADD UNIQUE USING INDEX cwi_uniq4_idx;
+                                 ^
 DROP TABLE cwi_test;
 -- ADD CONSTRAINT USING INDEX is forbidden on partitioned tables
 CREATE TABLE cwi_test(a int) PARTITION BY hash (a);


### PR DESCRIPTION
Fix tests in src/test/regress/expected/create_index.out

Commits 2acab05 and fbbf680 added new tests to
src/test/regress/sql/create_index.sql, we need to adapt their output for GPDB
and add them to ORCA.