### PR TITLE
Fix appendRelations list

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -401,6 +401,9 @@ set_plan_references(PlannerInfo *root, Plan *plan)
 	{
 		AppendRelInfo *appinfo = lfirst_node(AppendRelInfo, lc);
 
+		if (list_member_ptr(glob->appendRelations, appinfo))
+			continue;
+
 		/* adjust RT indexes */
 		appinfo->parent_relid += rtoffset;
 		appinfo->child_relid += rtoffset;


### PR DESCRIPTION
Fix appendRelations list

Commit 6ef77cf added a new appendRelations field to the PlannerGlobal and
PlannedStmt structures and populated it in the set_plan_references function,
while the earlier commit 19cd1cf added a GPDB-specific copy of sub-plans at the
end of the adjust_appendrel_attrs_mutator function, which caused the
set_plan_references function to put multiple copies of appinfo into the
glob->appendRelations list. This patch adds only unique appinfos to this list.