### PR TITLE
ADBDEV-7581: Fix lost executor error messages after query cancellation [7X]

### DIFF
--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -190,6 +190,7 @@ proc_exit_prepare(int code)
 	InterruptPending = false;
 	ProcDiePending = false;
 	QueryCancelPending = false;
+	QueryCancelCleanup = false;
 	InterruptHoldoffCount = 1;
 	CritSectionCount = 0;
 

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -36,6 +36,10 @@ volatile sig_atomic_t IdleInTransactionSessionTimeoutPending = false;
 volatile sig_atomic_t InterruptPending = false;
 volatile sig_atomic_t LogMemoryContextPending = false;
 volatile sig_atomic_t ProcDiePending = false;
+/*
+ * GPDB: true if the query was cancelled and cleanup shall be done, suppressing
+ * the error.
+ */
 volatile sig_atomic_t QueryCancelCleanup = false;
 volatile sig_atomic_t QueryCancelPending = false;
 volatile sig_atomic_t QueryFinishPending = false;

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -63,3 +63,4 @@
 /external_table_union_all_optimizer.out
 /external_table_optimizer.out
 /external_table_persistent_error_log_optimizer.out
+/cancel_cleanup.out

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -363,4 +363,6 @@ test: hba_conf
 
 test: gp_query_id
 
+test: cancel_cleanup
+
 # end of tests

--- a/src/test/regress/input/cancel_cleanup.source
+++ b/src/test/regress/input/cancel_cleanup.source
@@ -1,0 +1,62 @@
+-- start_ignore
+CREATE EXTENSION plpython3u;
+CREATE EXTENSION gp_inject_fault;
+
+CREATE OR REPLACE FUNCTION install_hook()
+  RETURNS SETOF BOOL
+  AS '@abs_builddir@/regress@DLSUFFIX@',
+     'gp_install_mock_query_info_collect_hook'
+  LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION uninstall_hook()
+  RETURNS SETOF BOOL
+  AS '@abs_builddir@/regress@DLSUFFIX@',
+     'gp_uninstall_mock_query_info_collect_hook'
+  LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION raise_sigint()
+  RETURNS SETOF BOOL
+  AS '@abs_builddir@/regress@DLSUFFIX@',
+     'gp_raise_sigint'
+  LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION send_sigint_to_segment_backend(content_id INT)
+  RETURNS SETOF TEXT AS $$
+    import os, signal, plpy
+
+    row = plpy.execute(f"SELECT PID FROM gp_stat_activity WHERE backend_type = 'client backend' AND gp_segment_id = {content_id}", 1)
+    pid = row[0]['pid']
+    assert pid != None
+    os.kill(pid, signal.SIGINT)
+
+    return [f"seg{content_id}"]
+  $$ LANGUAGE plpython3u STRICT SECURITY DEFINER EXECUTE ON COORDINATOR;
+-- end_ignore
+
+-- Create a table with a unique constraint which enables us to trigger an error
+-- directly on the segment.
+CREATE TABLE t1(i INT UNIQUE);
+INSERT INTO t1 SELECT 1;
+
+-- Install the hook only on the seg1.
+SELECT install_hook() FROM t1;
+
+-- Send SIGINT to seg1 outside a transaction.
+SELECT send_sigint_to_segment_backend(1);
+
+-- QueryCancelCleanup should not be set. We should see QUERY_ERROR instead of
+-- QUERY_CANCELED.
+INSERT INTO t1 SELECT 1;
+
+-- Cancel the query normally. seg1 should set QueryCancelCleanup = 1 upon 
+-- raising the signal.
+SELECT raise_sigint() FROM t1;
+
+SELECT uninstall_hook() FROM t1;
+
+-- start_ignore
+DROP FUNCTION install_hook();
+DROP FUNCTION uninstall_hook();
+DROP FUNCTION raise_sigint();
+DROP FUNCTION send_sigint_to_segment_backend(int);
+-- end_ignore

--- a/src/test/regress/output/cancel_cleanup.source
+++ b/src/test/regress/output/cancel_cleanup.source
@@ -1,0 +1,71 @@
+-- Create a table with a unique constraint which enables us to trigger an error
+-- directly on the segment.
+CREATE TABLE t1(i INT UNIQUE);
+INSERT INTO t1 SELECT 1;
+-- Install the hook only on the seg1.
+SELECT install_hook() FROM t1;
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, QUERY_DONE, QueryCancelCleanup = 0
+ install_hook 
+--------------
+ t
+(1 row)
+
+-- Send SIGINT to seg1 outside a transaction.
+SELECT send_sigint_to_segment_backend(1);
+NOTICE:  seg1 slice1, QUERY_SUBMIT, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, QUERY_START, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_INITIALIZE, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_FINISHED, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, INNER_QUERY_DONE, QueryCancelCleanup = 0
+ send_sigint_to_segment_backend 
+--------------------------------
+ seg1
+(1 row)
+
+-- QueryCancelCleanup should not be set. We should see QUERY_ERROR instead of
+-- QUERY_CANCELED.
+INSERT INTO t1 SELECT 1;
+NOTICE:  seg1 slice0, QUERY_SUBMIT, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, QUERY_START, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, PLAN_NODE_INITIALIZE, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice0, QUERY_ERROR, QueryCancelCleanup = 0
+ERROR:  duplicate key value violates unique constraint "t1_i_key"
+DETAIL:  Key (i)=(1) already exists.
+-- Cancel the query normally. seg1 should set QueryCancelCleanup = 1 upon 
+-- raising the signal.
+SELECT raise_sigint() FROM t1;
+NOTICE:  seg1 slice1, QUERY_SUBMIT, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, QUERY_START, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_INITIALIZE, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, QUERY_CANCELING, QueryCancelCleanup = 1
+NOTICE:  seg1 slice1, QUERY_CANCELED, QueryCancelCleanup = 1
+ERROR:  canceling MPP operation
+SELECT uninstall_hook() FROM t1;
+NOTICE:  seg1 slice1, QUERY_SUBMIT, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, QUERY_START, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_INITIALIZE, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+NOTICE:  seg1 slice1, PLAN_NODE_EXECUTING, QueryCancelCleanup = 0
+ uninstall_hook 
+----------------
+ t
+(1 row)
+

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -58,3 +58,4 @@
 /workfile_mgr_test.sql
 /external_table_persistent_error_log.sql
 /external_table_union_all.sql
+/cancel_cleanup.sql


### PR DESCRIPTION
This is a cherry-pick of 3b526c2e from 6X.

The original patch is expanded upon: `QueryCancelCleanup` is additionaly cleared in the top-level error handling block as well as in `proc_exit_prepare()` in `proc_exit()`.

A new set of tests was made from ground up.

The PR should be merged by rebasing to preserve authorship.