### PR TITLE
Fix segfault after processing OOM

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3427,7 +3427,7 @@ AbortTransaction(void)
 	 * so that all mem/resource will be freed
 	 */
 	if (elog_geterrcode() == ERRCODE_GP_MEMPROT_KILL)
-		DisconnectAndDestroyAllGangs(true);
+		DestroyAllGangs(true);
 
 	/* Release resource group slot at the end of a transaction */
 	if (ShouldUnassignResGroup())

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -920,8 +920,18 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 	cdbinfo = segdbDesc->segment_database_info;
 	isWriter = segdbDesc->isWriter;
 
-	/* update num of active QEs */
-	DECR_COUNT(cdbinfo, numActiveQEs);
+	/*
+	 * update num of active QEs
+	 * Flag forceDestroy says, that it may be the second call for this segdbDesc,
+	 * because there was error and now we destroy all at AbortTransaction.
+	 * In this case numActiveQEs counter may be zero and no need to be
+	 * decremented.
+	 */
+	if ((cdbinfo->numActiveQEs > 0 && cdbinfo->cdbs->numActiveQEs > 0) ||
+		!forceDestroy)
+	{
+		DECR_COUNT(cdbinfo, numActiveQEs);
+	}
 
 	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
 
@@ -957,8 +967,18 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 			 lastWriter = cell, cell = lnext(cell)) ;
 
 		if (lastWriter)
+		{
+#ifdef FAULT_INJECTOR
+			if (SIMPLE_FAULT_INJECTOR("emulate_allocation_error") == FaultInjectorTypeSkip)
+			{
+				ereport(ERROR, (errcode(ERRCODE_GP_MEMPROT_KILL),
+						errmsg("Out of memory was emulated")
+				));
+			}
+#endif
 			lappend_cell(segdbDesc->segment_database_info->freelist,
 						 lastWriter, segdbDesc);
+		}
 		else
 			segdbDesc->segment_database_info->freelist =
 				lcons(segdbDesc, segdbDesc->segment_database_info->freelist);

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -920,19 +920,6 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 	cdbinfo = segdbDesc->segment_database_info;
 	isWriter = segdbDesc->isWriter;
 
-	/*
-	 * update num of active QEs
-	 * Flag forceDestroy says, that it may be the second call for this segdbDesc,
-	 * because there was error and now we destroy all at AbortTransaction.
-	 * In this case numActiveQEs counter may be zero and no need to be
-	 * decremented.
-	 */
-	if ((cdbinfo->numActiveQEs > 0 && cdbinfo->cdbs->numActiveQEs > 0) ||
-		!forceDestroy)
-	{
-		DECR_COUNT(cdbinfo, numActiveQEs);
-	}
-
 	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
 
 	if (forceDestroy || !cleanupQE(segdbDesc))
@@ -969,7 +956,7 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 		if (lastWriter)
 		{
 #ifdef FAULT_INJECTOR
-			if (SIMPLE_FAULT_INJECTOR("emulate_allocation_error") == FaultInjectorTypeSkip)
+			if (SIMPLE_FAULT_INJECTOR("cdb_freelist_append_oom") == FaultInjectorTypeSkip)
 			{
 				ereport(ERROR, (errcode(ERRCODE_GP_MEMPROT_KILL),
 						errmsg("Out of memory was emulated")
@@ -984,6 +971,9 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 				lcons(segdbDesc, segdbDesc->segment_database_info->freelist);
 	}
 
+
+	/* update num of active and idle QEs */
+	DECR_COUNT(cdbinfo, numActiveQEs);
 	INCR_COUNT(cdbinfo, numIdleQEs);
 
 	MemoryContextSwitchTo(oldContext);
@@ -998,6 +988,8 @@ destroy_segdb:
 	{
 		markCurrentGxactWriterGangLost();
 	}
+
+	DECR_COUNT(cdbinfo, numActiveQEs);
 
 	MemoryContextSwitchTo(oldContext);
 }

--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -309,6 +309,9 @@ cdbconn_doConnectComplete(SegmentDatabaseDescriptor *segdbDesc)
 static void
 cdbconn_disconnect(SegmentDatabaseDescriptor *segdbDesc)
 {
+	if (segdbDesc->conn == NULL)
+		return;
+
 	if (PQstatus(segdbDesc->conn) != CONNECTION_BAD)
 	{
 		PGTransactionStatusType status = PQtransactionStatus(segdbDesc->conn);

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -554,7 +554,10 @@ AtAbort_DispatcherState(void)
 	 * Cleanup all outbound dispatcher states belong to
 	 * current resource owner and its children
 	 */
-	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_destroyDispatcherHandle);
+	if (ERRCODE_TO_CATEGORY(elog_geterrcode()) != ERRCODE_INSUFFICIENT_RESOURCES)
+		CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_cleanupDispatcherHandle);
+	else
+		CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_destroyDispatcherHandle);
 
 	Assert(open_dispatcher_handles == NULL);
 

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -36,6 +36,7 @@ static int numNonExtendedDispatcherState = 0;
 
 dispatcher_handle_t *open_dispatcher_handles;
 static void cleanup_dispatcher_handle(dispatcher_handle_t *h);
+static void destroy_dispatcher_state_and_handle(dispatcher_handle_t *h);
 
 static dispatcher_handle_t *find_dispatcher_handle(CdbDispatcherState *ds);
 static dispatcher_handle_t *allocate_dispatcher_handle(void);
@@ -365,8 +366,8 @@ cdbdisp_destroyDispatcherState(CdbDispatcherState *ds)
 	if (!ds)
 		return;
 #ifdef USE_ASSERT_CHECKING
-	/* Disallow reentrance. */
-	Assert (!ds->isGangDestroying);
+	/* Disallow re-entrance. It may be in case of AbortTransaction after error. */
+	Assert (!ds->isGangDestroying || elog_geterrcode() != 0);
 	ds->isGangDestroying = true;
 #endif
 
@@ -520,6 +521,19 @@ cleanup_dispatcher_handle(dispatcher_handle_t *h)
 	cdbdisp_destroyDispatcherState(h->dispatcherState);
 }
 
+static void
+destroy_dispatcher_state_and_handle(dispatcher_handle_t *h)
+{
+	if (h->dispatcherState == NULL)
+	{
+		destroy_dispatcher_handle(h);
+		return;
+	}
+
+	h->dispatcherState->forceDestroyGang = true;
+	cdbdisp_destroyDispatcherState(h->dispatcherState);
+}
+
 /*
  * Cleanup all dispatcher state that belong to
  * current resource owner and its childrens
@@ -540,7 +554,7 @@ AtAbort_DispatcherState(void)
 	 * Cleanup all outbound dispatcher states belong to
 	 * current resource owner and its children
 	 */
-	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_cleanupDispatcherHandle);
+	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_destroyDispatcherHandle);
 
 	Assert(open_dispatcher_handles == NULL);
 
@@ -550,7 +564,7 @@ AtAbort_DispatcherState(void)
 	 */
 	if (currentGxactWriterGangLost())
 	{
-		DisconnectAndDestroyAllGangs(true);
+		DestroyAllGangs(true);
 		CheckForResetSession();
 	}
 }
@@ -585,6 +599,25 @@ cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData *owner)
 		if (curr->owner == owner)
 		{
 			cleanup_dispatcher_handle(curr);
+		}
+	}
+}
+
+void
+cdbdisp_destroyDispatcherHandle(const struct ResourceOwnerData *owner)
+{
+	dispatcher_handle_t *curr;
+	dispatcher_handle_t *next;
+
+	next = open_dispatcher_handles;
+	while (next)
+	{
+		curr = next;
+		next = curr->next;
+
+		if (curr->owner == owner)
+		{
+			destroy_dispatcher_state_and_handle(curr);
 		}
 	}
 }

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -715,6 +715,34 @@ getCdbProcessesForQD(int isPrimary)
 }
 
 /*
+ * This function is used for case when we should just free memory (without any
+ * additional allocations).
+ */
+void
+DestroyAllGangs(bool resetSession)
+{
+	if (Gp_role == GP_ROLE_UTILITY)
+		return;
+
+	ELOG_DISPATCHER_DEBUG("DestroyAllGangs");
+
+	/* Destroy CurrentGangCreating before GangContext is reset */
+	if (CurrentGangCreating != NULL)
+	{
+		RecycleGang(CurrentGangCreating, true);
+		CurrentGangCreating = NULL;
+	}
+
+	/* destroy cdb_component_dbs, disconnect all connections with QEs */
+	cdbcomponent_destroyCdbComponents();
+
+	if (resetSession)
+		resetSessionForPrimaryGangLoss();
+
+	ELOG_DISPATCHER_DEBUG("DestroyAllGangs done");
+}
+
+/*
  * This function should not be used in the context of named portals
  * as it destroys the CdbComponentsContext, which is accessed later
  * during named portal cleanup.
@@ -735,7 +763,7 @@ DisconnectAndDestroyAllGangs(bool resetSession)
     }
 
 	/* cleanup all out bound dispatcher state */
-	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_cleanupDispatcherHandle);
+	CdbResourceOwnerWalker(CurrentResourceOwner, cdbdisp_destroyDispatcherHandle);
 	
 	/* destroy cdb_component_dbs, disconnect all connections with QEs */
 	cdbcomponent_destroyCdbComponents();

--- a/src/include/cdb/cdbdisp.h
+++ b/src/include/cdb/cdbdisp.h
@@ -205,6 +205,7 @@ bool cdbdisp_checkForCancel(CdbDispatcherState * ds);
 int cdbdisp_getWaitSocketFd(CdbDispatcherState *ds);
 
 void cdbdisp_cleanupDispatcherHandle(const struct ResourceOwnerData * owner);
+void cdbdisp_destroyDispatcherHandle(const struct ResourceOwnerData * owner);
 
 void AtAbort_DispatcherState(void);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -74,6 +74,7 @@ extern List *getCdbProcessesForQD(int isPrimary);
 extern Gang *AllocateGang(struct CdbDispatcherState *ds, enum GangType type, List *segments);
 extern void RecycleGang(Gang *gp, bool forceDestroy);
 extern void DisconnectAndDestroyAllGangs(bool resetSession);
+extern void DestroyAllGangs(bool resetSession);
 extern void DisconnectAndDestroyUnusedQEs(void);
 
 extern void CheckForResetSession(void);

--- a/src/test/regress/expected/bfv_OOM.out
+++ b/src/test/regress/expected/bfv_OOM.out
@@ -1,0 +1,45 @@
+-- Test for correct processing AbortTransaction after getting OOM at
+-- cdbcomponent_recycleIdleQE and re-entering here from AbortTransaction.
+create table test_table (f1 text, f2 text, f3 text, f4 text)
+distributed by (f1);
+create function test_function() returns setof test_table as
+$$
+declare
+	rec1 record;
+begin
+	for rec1 in select * from test_table
+	loop
+		return next rec1;
+	end loop;
+end;
+$$
+language plpgsql;
+create view test_view as select t.* from test_function() t;
+select gp_inject_fault('emulate_allocation_error', 'skip', dbid)
+from gp_segment_configuration
+where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from test_view;
+ERROR:  Out of memory was emulated
+CONTEXT:  PL/pgSQL function test_function() line 5 at FOR over SELECT rows
+select gp_inject_fault('emulate_allocation_error', 'reset', dbid)
+from gp_segment_configuration
+where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select * from test_view;
+ f1 | f2 | f3 | f4 
+----+----+----+----
+(0 rows)
+
+-- Cleanup
+drop view test_view;
+drop function test_function();
+drop table test_table;

--- a/src/test/regress/expected/bfv_OOM.out
+++ b/src/test/regress/expected/bfv_OOM.out
@@ -15,7 +15,7 @@ end;
 $$
 language plpgsql;
 create view test_view as select t.* from test_function() t;
-select gp_inject_fault('emulate_allocation_error', 'skip', dbid)
+select gp_inject_fault('cdb_freelist_append_oom', 'skip', dbid)
 from gp_segment_configuration
 where role = 'p' and content = -1;
  gp_inject_fault 
@@ -26,7 +26,7 @@ where role = 'p' and content = -1;
 select * from test_view;
 ERROR:  Out of memory was emulated
 CONTEXT:  PL/pgSQL function test_function() line 5 at FOR over SELECT rows
-select gp_inject_fault('emulate_allocation_error', 'reset', dbid)
+select gp_inject_fault('cdb_freelist_append_oom', 'reset', dbid)
 from gp_segment_configuration
 where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -195,6 +195,7 @@ test: rpt rpt_joins rpt_tpch rpt_returning bfv_dml_rpt
 # other sessions. Therefore the other tests in this group mustn't create
 # temp tables
 test: bfv_cte bfv_joins bfv_planner bfv_subquery bfv_legacy bfv_temp bfv_dml
+test: bfv_OOM
 
 test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_dml_oids trigger_sets_oid qp_skew qp_select
 

--- a/src/test/regress/sql/bfv_OOM.sql
+++ b/src/test/regress/sql/bfv_OOM.sql
@@ -1,0 +1,44 @@
+-- Test for correct processing AbortTransaction after getting OOM at
+-- cdbcomponent_recycleIdleQE and re-entering here from AbortTransaction.
+
+--start_ignore
+create extension if not exists gp_inject_fault;
+drop view if exists view;
+drop function if exists test_function();
+drop table if exists test_table;
+--end_ignore
+
+create table test_table (f1 text, f2 text, f3 text, f4 text)
+distributed by (f1);
+
+create function test_function() returns setof test_table as
+$$
+declare
+	rec1 record;
+begin
+	for rec1 in select * from test_table
+	loop
+		return next rec1;
+	end loop;
+end;
+$$
+language plpgsql;
+
+create view test_view as select t.* from test_function() t;
+
+select gp_inject_fault('emulate_allocation_error', 'skip', dbid)
+from gp_segment_configuration
+where role = 'p' and content = -1;
+
+select * from test_view;
+
+select gp_inject_fault('emulate_allocation_error', 'reset', dbid)
+from gp_segment_configuration
+where role = 'p' and content = -1;
+
+select * from test_view;
+
+-- Cleanup
+drop view test_view;
+drop function test_function();
+drop table test_table;

--- a/src/test/regress/sql/bfv_OOM.sql
+++ b/src/test/regress/sql/bfv_OOM.sql
@@ -26,13 +26,13 @@ language plpgsql;
 
 create view test_view as select t.* from test_function() t;
 
-select gp_inject_fault('emulate_allocation_error', 'skip', dbid)
+select gp_inject_fault('cdb_freelist_append_oom', 'skip', dbid)
 from gp_segment_configuration
 where role = 'p' and content = -1;
 
 select * from test_view;
 
-select gp_inject_fault('emulate_allocation_error', 'reset', dbid)
+select gp_inject_fault('cdb_freelist_append_oom', 'reset', dbid)
 from gp_segment_configuration
 where role = 'p' and content = -1;
 


### PR DESCRIPTION
Fix segfault after processing OOM

When OOM is received at the cdbcomponent_recycleIdleQE, it will lead to
re-entrance to the cdbcomponent_recycleIdleQE for segdbDesc, which was processed
before OOM. Such case may lead to segfault, because part of resources was clean
earlier, but will be cleaned again.

Also, there are counters: numActiveQEs and numIdleQEs, which are used for
checking for more than zero. numActiveQEs may be less than zero in case of
re-entrance to the cdbcomponent_recycleIdleQE, which may lead to assertion
failed.

This patch modifies cleaning cdb_component_dbs. When AbortTransaction is
processed, cdb_component_dbs should be cleaned without additional allocating
memory and without tries to reusing components.