### PR TITLE
Fix tests in src/test/regress/expected/tuplesort_optimizer.out

### DIFF
--- a/src/test/regress/expected/tuplesort_optimizer.out
+++ b/src/test/regress/expected/tuplesort_optimizer.out
@@ -5,9 +5,7 @@ SET max_parallel_workers = 0;
 -- key aborts. One easy way to achieve that is to use uuids that all
 -- have the same prefix, as abbreviated keys for uuids just use the
 -- first sizeof(Datum) bytes.
-DROP TABLE IF EXISTS abbrev_abort_uuids;
-NOTICE:  table "abbrev_abort_uuids" does not exist, skipping
-CREATE TABLE abbrev_abort_uuids (
+CREATE TEMP TABLE abbrev_abort_uuids (
     id serial not null,
     abort_increasing uuid,
     abort_decreasing uuid,
@@ -568,7 +566,7 @@ ROLLBACK;
 ----
 -- test tuplesort mark/restore
 ---
-CREATE TABLE test_mark_restore(col1 int, col2 int, col12 int);
+CREATE TEMP TABLE test_mark_restore(col1 int, col2 int, col12 int);
 -- need a few duplicates for mark/restore to matter
 INSERT INTO test_mark_restore(col1, col2, col12)
    SELECT a.i, b.i, a.i * b.i FROM generate_series(1, 500) a(i), generate_series(1, 5) b(i);
@@ -675,6 +673,3 @@ EXPLAIN (COSTS OFF) :qry;
 (10 rows)
 
 COMMIT;
--- cleanup
-DROP TABLE IF EXISTS abbrev_abort_uuids;
-DROP TABLE IF EXISTS test_mark_restore;


### PR DESCRIPTION
Fix tests in src/test/regress/expected/tuplesort_optimizer.out

Commit baa32ce changed tests in src/test/regress/sql/tuplesort.sql, we need to
change their output in ORCA.