### PR TITLE
Fix tests in src/test/regress/expected/replication_slots.out

### DIFF
--- a/src/test/regress/expected/replication_slots.out
+++ b/src/test/regress/expected/replication_slots.out
@@ -10,10 +10,10 @@ HINT:  Creating replication slots on a single segment is not advised.  Replicati
 (1 row)
 
 -- And I should see that my replication slot exists
-select pg_get_replication_slots();
-          pg_get_replication_slots           
----------------------------------------------
- (some_replication_slot,,physical,,f,f,,,,,)
+select * from pg_get_replication_slots() where not active;
+       slot_name       | plugin | slot_type | datoid | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn 
+-----------------------+--------+-----------+--------+-----------+--------+------------+------+--------------+-------------+---------------------
+ some_replication_slot |        | physical  |        | f         | f      |            |      |              |             | 
 (1 row)
 
 -- Cleanup:

--- a/src/test/regress/sql/replication_slots.sql
+++ b/src/test/regress/sql/replication_slots.sql
@@ -4,7 +4,7 @@
 select pg_create_physical_replication_slot('some_replication_slot');
 
 -- And I should see that my replication slot exists
-select pg_get_replication_slots();
+select * from pg_get_replication_slots() where not active;
 
 -- Cleanup:
 select pg_drop_replication_slot('some_replication_slot');


### PR DESCRIPTION
Fix tests in src/test/regress/expected/replication_slots.out

Commit ea22aff added new tests to src/test/regress/sql/replication_slots.sql,
we need to adapt their output for GPDB, where the cluster already has one
active slot for a replica, which is not interesting for the test.