### PR TITLE
Change gpstop -rai to gpstop -arf to install GUC during gp_toolkit tests

### DIFF
--- a/gpcontrib/gp_toolkit/expected/resource_manager_restore_to_none.out
+++ b/gpcontrib/gp_toolkit/expected/resource_manager_restore_to_none.out
@@ -5,17 +5,17 @@
 \! echo $?
 0
 -- start_ignore
-\! gpstop -rai
-20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -rai
+\! gpstop -arf
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -arf
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16142.g1f3e5a0825 build dev'
-20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='fast'
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
 20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20230110:23:11:34:400128 gpstop:ubuntu:gpadmin-[INFO]:-Stopping coordinator standby host ubuntu mode=immediate
+20230110:23:11:34:400128 gpstop:ubuntu:gpadmin-[INFO]:-Stopping coordinator standby host ubuntu mode=fast
 20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown standby process on ubuntu
 20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
 20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...

--- a/gpcontrib/gp_toolkit/expected/resource_manager_switch_to_queue.out
+++ b/gpcontrib/gp_toolkit/expected/resource_manager_switch_to_queue.out
@@ -5,13 +5,13 @@
 \! echo $?
 0
 -- start_ignore
-\! gpstop -rai
-20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -rai
+\! gpstop -arf
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -arf
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16117.g367b82d8d9 build dev'
-20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='fast'
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
 20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1

--- a/gpcontrib/gp_toolkit/sql/resource_manager_restore_to_none.sql
+++ b/gpcontrib/gp_toolkit/sql/resource_manager_restore_to_none.sql
@@ -5,7 +5,7 @@
 \! echo $?
 
 -- start_ignore
-\! gpstop -rai
+\! gpstop -arf
 -- end_ignore
 
 \! echo $?

--- a/gpcontrib/gp_toolkit/sql/resource_manager_switch_to_queue.sql
+++ b/gpcontrib/gp_toolkit/sql/resource_manager_switch_to_queue.sql
@@ -5,7 +5,7 @@
 \! echo $?
 
 -- start_ignore
-\! gpstop -rai
+\! gpstop -arf
 -- end_ignore
 
 \! echo $?


### PR DESCRIPTION
Rework gpstop -rai usage in some gp_toolkit tests to avoid cluster crashes if
the tablespace directory is removed. Reproduce problem:
CREATE TABLESPACE ts_test LOCATION '/home/gpadmin/.data/test';
DROP TABLESPACE ts_test;
rm -rf /home/gpadmin/.data/test
gpstop -rai

Cluster fails with FATAL: "/home/gpadmin/.data/test" does not exist. Occurs
when running tests multiple times.

Replace -rai with -arf because scripts apply config changes after gpconfig,
so -arf is safe.

See ticket: ADBDEV-7996