### PR TITLE
ADBDEV-8107: Move private declarations back to public in cdbendpoint.h

### DIFF
--- a/src/backend/cdb/endpoint/cdbendpoint_private.h
+++ b/src/backend/cdb/endpoint/cdbendpoint_private.h
@@ -17,7 +17,6 @@
 #define CDBENDPOINTINTERNAL_H
 
 #define MAX_ENDPOINT_SIZE				1024
-#define ENDPOINT_TOKEN_ARR_LEN			16
 #define ENDPOINT_TOKEN_STR_LEN			(ENDPOINT_TOKEN_ARR_LEN<<1)
 #define InvalidEndpointSessionId		(-1)	/* follows invalid
 												 * gp_session_id */
@@ -49,7 +48,6 @@ extern int	get_session_id_from_token(Oid userID, const int8 *token);
 /* utility functions in "cdbendpointutilities.c" */
 extern bool endpoint_token_hex_equals(const int8 *token1, const int8 *token2);
 extern bool endpoint_name_equals(const char *name1, const char *name2);
-extern void endpoint_token_str2arr(const char *tokenStr, int8 *token);
 extern void endpoint_token_arr2str(const int8 *token, char *tokenStr);
 extern char *state_enum_to_string(EndpointState state);
 

--- a/src/include/cdb/cdbendpoint.h
+++ b/src/include/cdb/cdbendpoint.h
@@ -52,6 +52,8 @@ enum EndPointExecPosition
 #define ENDPOINT_READY_ACK_MSG			"ENDPOINT_READY"
 #define ENDPOINT_FINISHED_ACK_MSG		"ENDPOINT_FINISHED"
 
+#define ENDPOINT_TOKEN_ARR_LEN			16
+
 /*
  * Endpoint attach status, used by parallel retrieve cursor.
  */
@@ -157,5 +159,8 @@ extern bool AuthEndpoint(Oid userID, const char *tokenStr);
 extern TupleDesc GetRetrieveStmtTupleDesc(const RetrieveStmt *stmt);
 extern void ExecRetrieveStmt(const RetrieveStmt *stmt, DestReceiver *dest);
 extern void generate_endpoint_name(char *name, const char *cursorName);
+
+/* utility functions in "cdbendpointutilities.c" */
+extern void endpoint_token_str2arr(const char *tokenStr, int8 *token);
 
 #endif   /* CDBENDPOINT_H */


### PR DESCRIPTION
Move private declarations back to public in cdbendpoint.h

In GPDB 6, declarations for endpoint_token_str2arr and ENDPOINT_TOKEN_ARR_LEN
were in cdb/cdbendpoint.h, but were moved to
cdb/endpoint/cdbendpoint_private.h by commit
7a1ce379c12a56a4708568c94bbe8a053a4074ce in GPDB 7. However, we still need
those as public for adb_fdw, so we should move them back.