### PR TITLE
ADBDEV-8057: Fix pg_rewind leaving replica on old timeline

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -375,16 +375,9 @@ main(int argc, char **argv)
 		 * in the target that needs rewinding.
 		 */
 		if (target_wal_endrec > divergerec)
-		{
 			rewind_needed = true;
-		}
 		else
-		{
-			/* the last common checkpoint record must be part of target WAL */
-			Assert(target_wal_endrec == divergerec);
-
 			rewind_needed = false;
-		}
 	}
 
 	if (!rewind_needed)

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -390,8 +390,16 @@ main(int argc, char **argv)
 			rewind_needed = false;
 
 			memcpy(&ControlFile_new, &ControlFile_target, sizeof(ControlFileData));
+
+			/*
+			 * minRecoveryPoint is the minimum end of WAL that is considered
+			 * valid. In some cases checkpoint might be the first WAL record
+			 * on the new timeline, so to ensure minRecoveryPoint includes
+			 * records after the switch, we have to set minRecoveryPoint to
+			 * some point *after* the checkpoint, for example checkPoint + 1.
+			 */
 			ControlFile_new.minRecoveryPoint = Max(ControlFile_source.minRecoveryPoint,
-												   ControlFile_source.checkPoint);
+												   ControlFile_source.checkPoint + 1);
 			ControlFile_new.minRecoveryPointTLI = ControlFile_source.checkPointCopy.ThisTimeLineID;
 			pg_log_info("no rewind required, updating target to source's timeline");
 			if (!dry_run)

--- a/src/bin/pg_rewind/t/010_target_is_ancestor.pl
+++ b/src/bin/pg_rewind/t/010_target_is_ancestor.pl
@@ -1,0 +1,124 @@
+
+# Copyright (c) 2021-2024, PostgreSQL Global Development Group
+
+# Test cases where the target is a direct ancestor of the source.
+#
+# We set up two timelines like this:
+#
+#            -------------- TLI 2 (source)
+#           /
+#  ---A----B-------C------- TLI 1
+#
+#
+# On TLI 1, we take a backup on points A, B and C. We use a server
+# restored from each of those points as the target, and a primary
+# server running on TLI 2 as the source.
+#
+# - A is a direct ancestor of the source, so no rewind is required
+# - B is also a direct ancestor of the source, at exactly the point
+#     where the timelines diverged. No rewind is required.
+# - C is not a direct ancestor, so rewind is required. (This case is
+#   not the focus of these tests, it's here just for completeness.)
+
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+use File::Copy;
+use File::Path qw(rmtree);
+
+my $tmp_folder = PostgreSQL::Test::Utils::tempdir;
+
+my $orig_node = PostgreSQL::Test::Cluster->new('orig_node');
+$orig_node->init(allows_streaming => 1);
+$orig_node->append_conf(
+	'postgresql.conf', qq(
+wal_log_hints = on
+));
+$orig_node->start;
+$orig_node->safe_psql('postgres', 'CREATE TABLE test_tab (t TEXT)');
+$orig_node->safe_psql('postgres',
+	"INSERT INTO test_tab VALUES ('at the beginning')");
+$orig_node->stop;
+$orig_node->backup_fs_cold('backup_A');
+
+$orig_node->start;
+$orig_node->safe_psql('postgres',
+	"INSERT INTO test_tab VALUES ('after backup A')");
+$orig_node->stop;
+$orig_node->backup_fs_cold('backup_B');
+
+# Restore backup B to create Timeline 2
+my $node_2 = PostgreSQL::Test::Cluster->new('node_2');
+$node_2->init_from_backup($orig_node, 'backup_B', has_streaming => 1);
+$node_2->start;
+$node_2->promote;
+$node_2->safe_psql('postgres', "INSERT INTO test_tab VALUES ('in node')");
+
+$orig_node->start;
+$orig_node->safe_psql('postgres',
+	"INSERT INTO test_tab VALUES ('this will be lost on rewind')");
+$orig_node->stop;
+$orig_node->backup_fs_cold('backup_C');
+
+# Create a new node from a backup, and run pg_rewind to rewind it as a
+# follower of $source_node
+sub rewind_from_backup
+{
+	my ($backup, $expected_stderr, $source_node) = @_;
+
+	my $source_pgdata = $source_node->data_dir;
+	my $source_connstr = $source_node->connstr();
+
+	my $target_node = PostgreSQL::Test::Cluster->new('restored_' . $backup . '_' . $source_node->name);
+	$target_node->init_from_backup($orig_node, $backup, has_streaming => 1);
+	my $target_pgdata = $target_node->data_dir;
+
+	# Keep a temporary postgresql.conf or it would be overwritten during the rewind.
+	copy("$target_pgdata/postgresql.conf", "$tmp_folder/postgresql.conf.tmp");
+
+	command_checks_all(
+		[
+			'pg_rewind',
+			"--debug",
+			"--no-sync",
+			"--source-server=$source_connstr",
+			"--target-pgdata=$target_pgdata"
+		],
+		0,
+		[],
+		$expected_stderr,
+		"pg_rewind on node restored from $backup");
+
+	# Now move back postgresql.conf with old settings
+	move("$tmp_folder/postgresql.conf.tmp", "$target_pgdata/postgresql.conf");
+
+	# Configure it to connect to the new primary
+	$target_node->append_conf(
+		'postgresql.conf', qq(
+primary_conninfo = '$source_connstr'
+));
+	$target_node->set_standby_mode();
+	$target_node->start;
+
+	$source_node->wait_for_catchup($target_node->name);
+	my $result =
+	  $target_node->safe_psql('postgres', "SELECT * FROM test_tab");
+	is( $result, qq(at the beginning
+after backup A
+in node),
+		"check query after rewind from $backup");
+	$target_node->stop;
+}
+
+rewind_from_backup('backup_C',
+	[qr/pg_rewind: rewinding from last common checkpoint at .* on timeline 1/],
+	$node_2);
+rewind_from_backup('backup_B', [qr/pg_rewind: no rewind required/], $node_2);
+rewind_from_backup('backup_A', [qr/pg_rewind: no rewind required/], $node_2);
+
+$node_2->stop;
+
+done_testing();

--- a/src/bin/pg_rewind/t/010_target_is_ancestor.pl
+++ b/src/bin/pg_rewind/t/010_target_is_ancestor.pl
@@ -95,6 +95,13 @@ sub rewind_from_backup
 	# Now move back postgresql.conf with old settings
 	move("$tmp_folder/postgresql.conf.tmp", "$target_pgdata/postgresql.conf");
 
+	# Make the more recent WAL from timeline 1 available to the
+	# restored server.  It doesn't need it, the point of this is to
+	# test that the server ignores this extra WAL.
+	copy($orig_node->data_dir . "/pg_wal/000000010000000000000001",
+	  $target_node->data_dir . "/pg_wal/000000010000000000000001")
+	  || die "copying 000000010000000000000001: $!";
+
 	# Configure it to connect to the new primary
 	$target_node->append_conf(
 		'postgresql.conf', qq(

--- a/src/bin/pg_rewind/t/107_empty_conf.pl
+++ b/src/bin/pg_rewind/t/107_empty_conf.pl
@@ -31,6 +31,10 @@ sub run_test
 
 	RewindTest::run_pg_rewind($test_mode, do_not_start_primary => 1);
 
+	# Append new file to the old one to preserve primary_conninfo
+	my $new_file_data = slurp_file("$master_pgdata/postgresql.conf");
+	append_to_file("$tmp_folder/master-postgresql-full.conf.tmp", $new_file_data);
+
 	copy(
 		"$tmp_folder/master-postgresql-full.conf.tmp",
 		"$master_pgdata/postgresql.conf");


### PR DESCRIPTION
Remove bogus assertion in pg_rewind

It's entirely possible that the calculated "point of divergence" is
before the end of WAL on the target, because when we calculate the
point of divergence, we assume that the target's WAL extends to
infinity on its current timeline. It might be more clear to calculate
the end of WAL first, and if the target is a direct ancestor of the
source, consider the end of target WAL as the point of
divergence. However, it doesn't change the result: the target is a
direct ancestor of the source, and doesn't need to be rewound.

Add tests to cover the "no rewind required" cases, both when the
target's end of WAL is exactly at the point of divergence, which is
what the removed assertion assumed (case B in the test), and the case
where the assertion failed (case A).

Changes from original patch: test was made more general to prepare for more
detailed tests in the next commits. In particular, we pg_rewind from a
running source node, not from a stopped one, and the source node is passed as
an argument. This doesn't affect the test validity for this patch.

Discussion: https://www.postgresql.org/message-id/18575-1b9b3b60e2a480de@postgresql.org

---

Alternatively, perhaps just copying the history file would be enough?

Changes from original patch:
- Move sourceHistfile initialization to before rewind_parseTimeLineHistory,
  since rewind_parseTimeLineHistory actually modifies it.
- Don't copy timeline history file when dry_run is specified. Dry run
  shouldn't make changes that can potentially break the target server when
  applied incorrectly.
- Fix 107_empty_conf.pl test to preserve primary_conninfo setting.

---

Fix pg_rewind edge case when checkpoint is at switchpoint

In one specific edge case, when the source server makes a checkpoint exactly
after switching to a new timeline, switchpoint LSN exactly matches latest
checkpoint LSN. This can happen, for example, if the source has just performed
archive recovery. Then setting minRecoveryPoint to the checkpoint LSN in
pg_rewind is illegal and causes an error at startup, since minRecoveryPoint
actually means the minimum allowed end of WAL, and we want that to be after
the switch occurs, not at the end of the previous timeline.

As a fix, add +1 to the checkpoint LSN when setting minRecoveryPoint, which
now correctly handles this case. Also add a test scenario for the source node
that has performed recovery.

---

Note: Do not squash to preserve authorship