### PR TITLE
Use correct way to detect SPI inner query

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1534,19 +1534,12 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	cplan = GetCachedPlan(plansource, paramLI, false, _SPI_current->queryEnv, NULL);
 	stmt_list = cplan->stmt_list;
 
-	/*
-	 * GPDB: Mark all queries as SPI inner queries for extension usage. But
-	 * make sure that SPI is not top level itself.
-	 */
-	if (already_under_executor_run())
+	/* GPDB: Mark all queries as SPI inner queries for extension usage */
+	foreach(lc, stmt_list)
 	{
-		foreach(lc, stmt_list)
-		{
-			Node	   *stmt = (Node *) lfirst(lc);
-
-			if (IsA(stmt, PlannedStmt))
-				((PlannedStmt *) stmt)->metricsQueryType = SPI_INNER_QUERY;
-		}
+		Node *stmt = (Node *) lfirst(lc);
+		if (IsA(stmt, PlannedStmt))
+			((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
 	}
 
 	if (!plan->saved)
@@ -2492,12 +2485,8 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			_SPI_current->processed = 0;
 			_SPI_current->tuptable = NULL;
 
-			/*
-			 * GPDB: Mark all queries as SPI inner query for extension usage
-			 * But make sure that SPI is not top level itself.
-			 */
-			if (already_under_executor_run())
-				stmt->metricsQueryType = SPI_INNER_QUERY;
+			/* GPDB: Mark all queries as SPI inner query for extension usage */
+			stmt->metricsQueryType = SPI_INNER_QUERY;
 
 			/* Check for unsupported cases. */
 			if (stmt->utilityStmt)


### PR DESCRIPTION
Use correct way to detect SPI inner query.

Port fix for detection of SPI inner nodes from adb 6.x Previously we used 
already_under_executor_run() to detect if the current node belongs to inner
query. This function does not work for SPI exclusively, so some other nodes,
like function called from the extension, were incorrectly marked as
SPI_INNER_QUERY instead of being TOP_LEVEL_QUERY, which resulted in wrong
metrics collection.

This patch uses _SPI_connected counter to check the level of SPI, but marks all 
queries using SPI from interactive session as SPI_INNER_QUERY (f.e. queries
using SPI from functions).

This is a port of commit dadbffb for adb-6.

Co-Authored-By: Denis Kovalev <d.kovalev@arenadata.io>

