### PR TITLE
Implement cleanup and rollback options for the cluster shrink

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -14,6 +14,7 @@ try:
     from gppylib.system.environment import GpCoordinatorEnvironment
     from gppylib.system import configurationInterface, configurationImplGpdb
     from gprebalance_modules.shrink import GGShrink, DBNAME
+    from gprebalance_modules.planner import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -51,8 +52,12 @@ def parseargs():
                       help='Max number of workers at a time. Valid values are 1-%d.' % MAX_PARALLEL_WORKERS)
     parser.add_option('-c', '--clean', action='store_true', dest="clean_required",
                       help='remove the rebalance schema.')
+    parser.add_option('-r', '--rollback', action='store_true', dest="rollback_required",
+                      help='performs rebalance rollback if possible.')
     parser.add_option('-h', '-?', '--help', action='help',
                       help='show this help message and exit.')
+    parser.add_option('-y', '--non-interactive-mode', dest="interactive", action='store_false', default=True,
+                         help="non-interactive mode, do not require user input for confirmations, use defaults.")
 
     parser.set_defaults(verbose=False)
 
@@ -86,6 +91,15 @@ def validate_options(options, args, parser):
     if options.parallel < 1 or options.parallel > MAX_PARALLEL_WORKERS:
         logger.error(
             'Invalid argument.  parallel value must be >= 1 and <= %d' % MAX_PARALLEL_WORKERS)
+        parser.exit(1)
+
+    if options.clean_required and options.rollback_required:
+        logger.error("Can't use together options '--clean' and '--rollback'")
+        parser.exit(1)
+
+    if ((options.clean_required or options.rollback_required) and
+        options.target_segment_count != None):
+        logger.error("Can't use '--target-segment-count' together option '--clean' or '--rollback'")
         parser.exit(1)
 
     return options, args
@@ -192,17 +206,20 @@ def main(options, args, parser):
             logger.error(f"{str(ex)}")
             sys.exit(1)
 
-        # the equality case is considered by shrink internally
-        if options.target_segment_count != None and gparray.get_segment_count() < options.target_segment_count:
-            logger.error('Target segment count (%s) > current segment count (%s).\n'
-                         'Currently only shrink is supported (target segment count < current segment count).'
-                          % (options.target_segment_count, gparray.get_segment_count()))
-            sys.exit(1)
-        else:
-            global gg_shrink
-            gg_shrink = GGShrink(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
-            gg_shrink.run()
-       
+        global gg_shrink
+        gg_shrink = GGShrink(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
+
+        # Note: the plan for a shrink later will be provided by the planner component.
+        # But for now we simply create a Plan object from the options directly.
+        # We'll keep this stub till planner is ready.
+        # If shrink_plan is None, we assume that we need to continue previous operation
+        shrink_plan = None
+        if options.target_segment_count != None:
+            shrink_plan = Plan()
+            shrink_plan.setTargetSegmentCount(options.target_segment_count)
+
+        gg_shrink.run(shrink_plan)
+
         sys.exit(0)
     except Exception as e:
         if options and options.verbose:

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -453,7 +453,7 @@ class SegmentIsShutDown(Command):
     def is_shutdown(self):
         for key, value in self.results.split_stdout():
             if key == 'Database cluster state':
-                return value.strip() == 'shut down'
+                return value.strip() == 'shut down' or value.strip() == 'shut down in recovery'
         return False
 
     @staticmethod

--- a/gpMgmt/bin/gprebalance_modules/Makefile
+++ b/gpMgmt/bin/gprebalance_modules/Makefile
@@ -3,7 +3,7 @@
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-PROGRAMS= __init__.py rebalance_validator.py rebalance.py rebalance_plan.py rebalance_executor.py rebalance_status.py shrink.py
+PROGRAMS= __init__.py rebalance_validator.py rebalance.py rebalance_plan.py rebalance_executor.py rebalance_status.py shrink.py planner.py rebalance_commons.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/gprebalance_modules'

--- a/gpMgmt/bin/gprebalance_modules/planner.py
+++ b/gpMgmt/bin/gprebalance_modules/planner.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import pickle
+
+class Plan:
+    def __init__(self):
+        self.target_segment_count = 0
+
+    def getTargetSegmentCount(self) -> int:
+        return self.target_segment_count
+
+    def setTargetSegmentCount(self, target_segment_count: int) -> None:
+        self.target_segment_count = target_segment_count
+
+    def serializePlan(self) -> bytes:
+        return pickle.dumps(self)
+
+def deserializePlan(input: bytes) -> Plan:
+    return pickle.loads(input)

--- a/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import psycopg2
+from psycopg2.extensions import cursor
+from gppylib.db import dbconn
+from gprebalance_modules import planner
+
+def get_table_distr_segment_count(conn: dbconn.Connection, schema_name: str, table_name: str) -> int:
+    row = dbconn.queryRow(conn,
+                          f'''SELECT p.numsegments
+                          FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+                          JOIN gp_distribution_policy p ON c.oid = p.localoid
+                          WHERE n.nspname='{schema_name}' AND c.relname='{table_name}';''')
+    return int(row[0])
+
+class RebalanceSchema:
+    def __init__(self, conn: dbconn.Connection):
+        self.schema_name = 'ggrebalance'
+        self.rebalance_status = 'rebalance_status'
+        self.table_rebalance_status_detail = 'table_rebalance_status_detail'
+        self.saved_plan = 'saved_plan'
+        self.conn = conn
+
+    def createSchema(self, plan: planner.Plan) -> None:
+        dbconn.execSQL(self.conn, 'BEGIN')
+        dbconn.execSQL(self.conn, f'CREATE SCHEMA {self.schema_name}')
+        dbconn.execSQL(self.conn,
+                       f'''CREATE TABLE {self.schema_name}.{self.rebalance_status}
+                       (status TEXT, updated TIMESTAMP WITH TIME ZONE)
+                       DISTRIBUTED REPLICATED''')
+        dbconn.execSQL(self.conn,
+                       f'''CREATE TABLE {self.schema_name}.{self.table_rebalance_status_detail}
+                       (db_name TEXT, schema_name TEXT, rel_name TEXT, status TEXT,
+                       CONSTRAINT unique_fqn UNIQUE (db_name, schema_name, rel_name))
+                       DISTRIBUTED REPLICATED''')
+        dbconn.execSQL(self.conn,
+                       f'''CREATE TABLE {self.schema_name}.{self.saved_plan}
+                       (plan BYTEA)
+                       DISTRIBUTED REPLICATED''')
+
+        self.savePlan(plan)
+
+        dbconn.execSQL(self.conn, 'COMMIT')
+
+    def dropSchema(self) -> None:
+        dbconn.execSQL(self.conn, f'DROP SCHEMA {self.schema_name} CASCADE')
+
+    def getSchemaName(self) -> str:
+        return self.schema_name
+
+    def savePlan(self, plan: planner.Plan) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''INSERT INTO {self.schema_name}.{self.saved_plan}
+                       VALUES ('\\x{plan.serializePlan().hex()}')''')
+
+    def retrieveSavedPlan(self) -> planner.Plan:
+        if not self.schemaExists():
+            return None
+
+        row = dbconn.queryRow(self.conn, f'SELECT count(1) FROM {self.schema_name}.{self.saved_plan}')
+        plan_count = int(row[0])
+        if plan_count > 1:
+            raise Exception(f'Number of saved plans ({plan_count}) is > 1')
+        if plan_count == 0:
+            return None
+
+        row = dbconn.queryRow(self.conn, f'SELECT plan FROM {self.schema_name}.{self.saved_plan} LIMIT 1')
+        return planner.deserializePlan(row[0])
+
+    def schemaExists(self) -> bool:
+        row = dbconn.queryRow(self.conn, f"SELECT COUNT(1) FROM pg_namespace WHERE nspname = '{self.schema_name}'")
+        return int(row[0]) == 1
+
+    def getStateFromPreviousRun(self) -> str:
+        cursor = dbconn.query(self.conn, f'SELECT status FROM {self.schema_name}.{self.rebalance_status} ORDER BY updated DESC LIMIT 1')
+        if cursor.rowcount > 0:
+            return str(cursor.fetchone()[0])
+        return 'not defined'
+
+    def rebalanceSchema(self, target_segment_count: int) -> None:
+        # Before rebalancing check if the tables are already rebalanced
+        # (in case we re-enter after interruption that happened after COMMIT but before new state)
+        if get_table_distr_segment_count(self.conn, self.schema_name, self.rebalance_status) > target_segment_count:
+            dbconn.execSQL(self.conn,
+                           f'''ALTER TABLE "{self.schema_name}"."{self.rebalance_status}"
+                           REBALANCE {target_segment_count}''')
+
+        if get_table_distr_segment_count(self.conn, self.schema_name, self.table_rebalance_status_detail) > target_segment_count:
+            dbconn.execSQL(self.conn,
+                           f'''ALTER TABLE "{self.schema_name}"."{self.table_rebalance_status_detail}"
+                           REBALANCE {target_segment_count}''')
+
+        if get_table_distr_segment_count(self.conn, self.schema_name, self.saved_plan) > target_segment_count:
+            dbconn.execSQL(self.conn,
+                           f'''ALTER TABLE "{self.schema_name}"."{self.saved_plan}"
+                           REBALANCE {target_segment_count}''')
+
+    def storeState(self, state: str) -> None:
+        if self.schemaExists():
+            dbconn.execSQL(self.conn,
+                           f'''INSERT INTO {self.schema_name}.{self.rebalance_status}
+                           VALUES ('{state}', NOW())''')
+
+    def clearTablesToRebalanceWithStatus(self, status: str) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''DELETE FROM {self.schema_name}.{self.table_rebalance_status_detail}
+                       WHERE (status <> '{status}')''')
+
+    def addTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''INSERT INTO {self.schema_name}.{self.table_rebalance_status_detail}
+                       VALUES ('{db}', '{schema_name}', '{rel_name}', '{status}')''')
+
+    def setStatusForTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''UPDATE {self.schema_name}.{self.table_rebalance_status_detail} SET status = '{status}'
+                       WHERE db_name = '{db}' AND schema_name = '{schema_name}' AND rel_name = '{rel_name}';''')
+
+    def getTablesToRebalanceWithStatus(self, status: str) -> cursor:
+        return dbconn.query(self.conn, f"""SELECT db_name, schema_name, rel_name FROM
+                            {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = '{status}'""")

--- a/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
@@ -104,7 +104,7 @@ class RebalanceSchema:
     def clearTablesToRebalanceWithStatus(self, status: str) -> None:
         dbconn.execSQL(self.conn,
                        f'''DELETE FROM {self.schema_name}.{self.table_rebalance_status_detail}
-                       WHERE (status <> '{status}')''')
+                       WHERE (status = '{status}')''')
 
     def addTableToRebalance(self, db: str, schema_name: str, rel_name: str, status: str) -> None:
         dbconn.execSQL(self.conn,

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -773,12 +773,9 @@ class GGShrink:
         return False
 
     def is_gp_segment_configuration_shrinked(self) -> bool:
-        # TODO
-        if not os.path.exists(self.gparray_dump_file):
+        if self.dumped_gparray is None:
             return False
-        gparray_from_file = GpArray.initFromFile(self.gparray_dump_file)
-        gparray_from_catalog = GpArray.initFromCatalog(self.dburl, utility=True)
-        return gparray_from_file.get_segment_count() != gparray_from_catalog.get_segment_count()
+        return self.dumped_gparray.get_segment_count() != self.gparray.get_segment_count()
 
     def shutdown(self) -> None:
         if self.workers_for_tables_rebalance != None:

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -317,6 +317,12 @@ class GGShrink:
                 return
 
             else:
+                self.shrink_plan = self.rebalance_schema.retrieveSavedPlan()
+                if self.shrink_plan == None:
+                    self.logger.error('No saved plan found. Try to execute cleanup.')
+                    self.trigger('move_to_STATE_ERROR')
+                    return
+
                 if state_from_prev_run in self.states_rollback_flow:
                     self.logger.info('Continue interrupted rollback operation...')
                     self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
@@ -332,12 +338,6 @@ class GGShrink:
                         return
 
                     self.logger.info('Continue interrupted operation...')
-                    self.shrink_plan = self.rebalance_schema.retrieveSavedPlan()
-                    if self.shrink_plan == None:
-                        self.logger.error('No saved plan found. Try to execute cleanup.')
-                        self.trigger('move_to_STATE_ERROR')
-                        return
-
                     self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
                     try:
                         next_state = self.get_state_after_interrupt(state_from_prev_run)
@@ -397,38 +397,7 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED(self) -> None:
-        # collect databases and tables that require 'ALTER TABLE REBALANCE'
-        # and store in 'table_rebalance_status_detail' table
-
-        dbconn.execSQL(self.conn, 'BEGIN')
-
-        # cleanup list of tables that require rebalance
-        # for the case we re-enter this state after we were interrupted right after it
-        self.rebalance_schema.clearTablesToRebalanceWithStatus('done')
-
-        cursor = dbconn.query(self.conn, 'SELECT datname FROM pg_database')
-        databases_to_process = []
-        for record in cursor:
-            database_name = record[0]
-            if database_name != 'template0':
-                databases_to_process.append(database_name)
-
-        for db in databases_to_process:
-            dburl = dbconn.DbURL(dbname=db, port=self.gpEnv.getCoordinatorPort())
-            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
-                cursor = dbconn.query(conn,
-                                      f'''SELECT n.nspname, c.relname
-                                      FROM pg_class c
-                                      JOIN pg_namespace n ON c.relnamespace = n.oid
-                                      JOIN gp_distribution_policy p ON c.oid = p.localoid
-                                      WHERE c.relkind IN ('r', 'p') AND c.relispartition = FALSE AND
-                                      p.numsegments > {self.shrink_plan.getTargetSegmentCount()} AND
-                                      n.nspname NOT IN ('pg_catalog', 'information_schema', '{self.rebalance_schema.getSchemaName()}')''')
-                for schema_name, rel_name in cursor:
-                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, 'none')
-
-        dbconn.execSQL(self.conn, 'COMMIT')
-
+        self.prepare_shrink_schema(False)
         self.trigger('move_to_STATE_PREPARE_SHRINK_SCHEMA_DONE')
 
     @wrap_state_func_with_faults
@@ -598,8 +567,7 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START(self) -> None:
-        # TODO: fill the tables that could be created after interruption
-
+        self.prepare_shrink_schema(True)
         self.trigger('move_to_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE')
 
     @wrap_state_func_with_faults
@@ -715,6 +683,39 @@ class GGShrink:
                 dbconn.execSQL(conn, 'COMMIT')
             self.shrink.logger.info(f'Complete table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}"')
             self.set_results(CommandResult(0, b'', b'', True, False))
+
+    def prepare_shrink_schema(self, is_rollback: bool) -> None:
+        status = 'done' if is_rollback else 'none'
+        cmp = '<=' if is_rollback else '>'
+
+        dbconn.execSQL(self.conn, 'BEGIN')
+
+        # cleanup list of tables that require rebalance
+        # for the case we re-enter this state after we were interrupted right after it
+        self.rebalance_schema.clearTablesToRebalanceWithStatus(status)
+
+        cursor = dbconn.query(self.conn, 'SELECT datname FROM pg_database')
+        databases_to_process = []
+        for record in cursor:
+            database_name = record[0]
+            if database_name != 'template0':
+                databases_to_process.append(database_name)
+
+        for db in databases_to_process:
+            dburl = dbconn.DbURL(dbname=db, port=self.gpEnv.getCoordinatorPort())
+            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+                cursor = dbconn.query(conn,
+                                      f'''SELECT n.nspname, c.relname
+                                      FROM pg_class c
+                                      JOIN pg_namespace n ON c.relnamespace = n.oid
+                                      JOIN gp_distribution_policy p ON c.oid = p.localoid
+                                      WHERE c.relkind IN ('r', 'p') AND c.relispartition = FALSE AND
+                                      p.numsegments {cmp} {self.shrink_plan.getTargetSegmentCount()} AND
+                                      n.nspname NOT IN ('pg_catalog', 'information_schema', '{self.rebalance_schema.getSchemaName()}')''')
+                for schema_name, rel_name in cursor:
+                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, status)
+
+        dbconn.execSQL(self.conn, 'COMMIT')
 
     def rebalance_tables(self, original_status: str, target_status: str, target_segment_count: int) -> None:
         cursor = self.rebalance_schema.getTablesToRebalanceWithStatus(original_status)

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -293,7 +293,7 @@ class GGShrink:
     def on_every_state(self) -> None:
         if self.shutdown_requested:
             self.logger.info('Shrink was interrupted')
-            sys.exit(1)
+            raise Exception('Shrink was interrupted')
 
         assert self.state in self.states + self.states_main_shrink_flow + self.states_rollback_flow
 
@@ -626,7 +626,7 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:
-        sys.exit(1)
+        raise Exception('Shrink entered STATE_ERROR')
 
     # state callbacks end here
 

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -9,11 +9,15 @@ try:
     from gppylib.commands.gp import *
     from gppylib.gplog import *
     from gppylib.db import dbconn
+    from gppylib import userinput
+    from gppylib.gparray import GpArray, Segment
     from gppylib.fault_injection import *
     from gppylib.userinput import *
     from gppylib.commands import base
     from gppylib.commands.gp import SEGMENT_STOP_TIMEOUT_DEFAULT, SegmentStop
     from gppylib.system.environment import *
+    from gprebalance_modules.planner import *
+    from gprebalance_modules.rebalance_commons import RebalanceSchema
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -46,10 +50,6 @@ class GGShrink:
     timeout = SEGMENT_STOP_TIMEOUT_DEFAULT
     stop_mode = 'fast'
 
-    rebalance_schema_name = 'ggrebalance'
-    rebalance_status = 'rebalance_status'
-    table_rebalance_status_detail = 'table_rebalance_status_detail'
-
     states = [
         'STATE_START',
         'STATE_OPTIONS_VALIDATION',
@@ -57,7 +57,8 @@ class GGShrink:
         'STATE_END',
         'STATE_CLEANUP',
         'STATE_ERROR',
-        'STATE_ROLLBACK'
+        'STATE_ROLLBACK',
+        'STATE_END_FROM_ROLLBACK'
     ]
 
     # Note: order of states in the list below is important,
@@ -82,6 +83,21 @@ class GGShrink:
         'STATE_SHRINK_DONE'
     ]
 
+    # Note: order of states in the list below is important,
+    # as we rely on it when recover from an interrupted state.
+    # These states are separated from 'states' and 'states_main_shrink_flow'
+    # above in order to support re-enter the interrupted state of rollback.
+    states_rollback_flow = [
+        'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START',
+        'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE',
+        'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START',
+        'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE',
+        'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START',
+        'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE',
+        'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START',
+        'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE'
+    ]
+
     transitions = [
         {
             'trigger': 'start',
@@ -94,8 +110,13 @@ class GGShrink:
             'dest': 'STATE_CLEANUP'
         },
         {
-            'trigger': 'move_to_STATE_CHECK_PREVIOUS_RUN',
+            'trigger': 'move_to_STATE_ROLLBACK',
             'source': 'STATE_OPTIONS_VALIDATION',
+            'dest': 'STATE_ROLLBACK'
+        },
+        {
+            'trigger': 'move_to_STATE_CHECK_PREVIOUS_RUN',
+            'source': ['STATE_OPTIONS_VALIDATION', 'STATE_ROLLBACK'],
             'dest': 'STATE_CHECK_PREVIOUS_RUN'
         },
         {
@@ -165,8 +186,53 @@ class GGShrink:
         },
         {
             'trigger': 'move_to_STATE_END',
-            'source': ['STATE_SHRINK_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP'],
+            'source': ['STATE_SHRINK_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_END_FROM_ROLLBACK'],
             'dest': 'STATE_END'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START',
+            'source': 'STATE_CHECK_PREVIOUS_RUN',
+            'dest': 'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE',
+            'source': 'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START',
+            'dest': 'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START',
+            'source': 'STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE',
+            'dest': 'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE',
+            'source': 'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START',
+            'dest': 'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START',
+            'source': 'STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE',
+            'dest': 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE',
+            'source': 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START',
+            'dest': 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START',
+            'source': 'STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE',
+            'dest': 'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE',
+            'source': 'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START',
+            'dest': 'STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_END_FROM_ROLLBACK',
+            'source': ['STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE', 'STATE_ROLLBACK', 'STATE_CHECK_PREVIOUS_RUN'],
+            'dest': 'STATE_END_FROM_ROLLBACK'
         },
         {
             'trigger': 'move_to_STATE_ERROR',
@@ -187,75 +253,41 @@ class GGShrink:
         self.workers_for_segment_stop = None
         self.gparray = gpArray
         self.gparray_dump_file = gpArrayDumpFilename
+        self.rebalance_schema = RebalanceSchema(self.conn)
+        self.shrink_plan = None
         self.needs_repopulate = False
         self.dumped_gparray = gparray.GpArray.initFromFile(self.gparray_dump_file) if os.path.exists(self.gparray_dump_file) else None
 
         self.machine = Machine(model = self,
                                queued=True,
-                               states = self.states + self.states_main_shrink_flow,
+                               states = self.states + self.states_main_shrink_flow + self.states_rollback_flow,
                                transitions = self.transitions,
                                initial = 'STATE_START',
                                before_state_change = 'on_every_state')
 
-    def run(self) -> None:
+    def run(self, shrinkPlan: Plan) -> None:
+        self.shrink_plan = shrinkPlan
         self.trigger('start')
-
-    def ggrebalance_schema_exists(self) -> bool:
-        row = dbconn.queryRow(self.conn, f"SELECT COUNT(1) FROM pg_namespace WHERE nspname = '{self.rebalance_schema_name}'")
-        return int(row[0]) == 1
-
-    def get_state_from_previous_run(self) -> str:
-        cursor = dbconn.query(self.conn, f'SELECT status FROM {self.rebalance_schema_name}.{self.rebalance_status} ORDER BY updated DESC LIMIT 1')
-        if cursor.rowcount > 0:
-            return str(cursor.fetchone()[0])
-        return 'not defined'
-    
-    def get_state_after_interrupt(self, prev_state) -> str:
-        prev_idx = self.states_main_shrink_flow.index(prev_state)
-        lower = self.states_main_shrink_flow.index('STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
-        upper = self.states_main_shrink_flow.index('STATE_SHRINK_TABLES_DONE')
-        if prev_idx >= lower and prev_idx <= upper:
-
-            #if shrink is interrupted after catalog update and before the state is logged
-            if prev_state == 'STATE_SHRINK_TABLES_DONE' and \
-                self.dumped_gparray is not None \
-                and self.gparray.get_segment_count() + self.options.target_segment_count == self.dumped_gparray.get_segment_count():
-                return 'STATE_SHRINK_CATALOG_DONE'
-
-            row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set();')
-            # means that target rebalance numsegments is reset, and new tables are created at old segment count
-            if bool(row[0]) is False:
-                self.logger.info("Cluster restarted after previous run, trying to repopulate the relation queue")
-                self.needs_repopulate = True
-                return 'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED'
-        
-        return self.states_main_shrink_flow[prev_idx + 1]
 
     def on_every_state(self) -> None:
         if self.shutdown_requested:
             self.logger.info('Shrink was interrupted')
             sys.exit(1)
 
-        assert self.state in self.states + self.states_main_shrink_flow
+        assert self.state in self.states + self.states_main_shrink_flow + self.states_rollback_flow
 
-        # insert status if the schema already exists
-        if self.state in self.states_main_shrink_flow:
-            if self.ggrebalance_schema_exists():
-                dbconn.execSQL(self.conn,
-                               f'''INSERT INTO {self.rebalance_schema_name}.{self.rebalance_status}
-                               VALUES ('{self.state}', NOW())''')
+        if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
+            self.rebalance_schema.storeState(self.state)
+
+    # decorator to inject a fault before or after the given 'on_enter_' state callback
 
     # state callbacks start here
     @wrap_state_func_with_faults
     def on_enter_STATE_OPTIONS_VALIDATION(self) -> None:
         if self.options.clean_required:
             self.trigger('move_to_STATE_CLEANUP')
-        elif not self.ggrebalance_schema_exists() and \
-            self.gparray.get_segment_count() == self.options.target_segment_count:
-            self.logger.error('Target segment count (%s) = current segment count (%s).\n'
-                         'Currently only shrink is supported (target segment count < current segment count).'
-                          % (self.options.target_segment_count, self.gparray.get_segment_count()))
-            raise ValueError("Wrong target segment count")
+        elif self.options.rollback_required:
+            self.trigger('move_to_STATE_ROLLBACK')
         else:
             self.trigger('move_to_STATE_CHECK_PREVIOUS_RUN')
 
@@ -264,81 +296,95 @@ class GGShrink:
         # check if rebalance schema exists
         # and whether we can get the state where we stopped in previous run
         # in order to proceed from the same point
-        if self.ggrebalance_schema_exists():
-            self.logger.info('Rebalance schema already exists')
-            state_from_prev_run = self.get_state_from_previous_run()
+        if self.rebalance_schema.schemaExists():
+            self.logger.info('Rebalance schema exists')
+            state_from_prev_run = self.rebalance_schema.getStateFromPreviousRun()
             # check maybe the state is the final one
             if state_from_prev_run == self.states_main_shrink_flow[-1]:
-                self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
-                self.trigger('move_to_STATE_END')
+                if self.options.rollback_required:
+                    self.logger.info(f"Previous run was completed successfully. Can't perform rollback.")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                else:
+                    self.logger.error('Previous run was completed successfully. Please execute cleanup before a new run.')
+                    self.trigger('move_to_STATE_END')
+                return
+
+            elif self.shrink_plan != None:
+                self.logger.error("Can't start a new operation, because the previous one was interrupted. "
+                                  "Please try to launch again without a plan to continue from the interrupted state, "
+                                  "or use '--rollback' or '--cleanup' options.")
+                self.trigger('move_to_STATE_ERROR')
+                return
+
             else:
-                self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
-                try:
-                    next_state = self.get_state_after_interrupt(state_from_prev_run)
-                except:
-                    self.logger.error("Can't determine next state")
-                    self.trigger('move_to_STATE_ERROR')
-                    return
+                if state_from_prev_run in self.states_rollback_flow:
+                    self.logger.info('Continue interrupted rollback operation...')
+                    self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
+                    try:
+                        next_state = self.states_rollback_flow[ self.states_rollback_flow.index(state_from_prev_run) + 1 ]
+                    except:
+                        self.logger.error("Can't determine next rollback state")
+                        self.trigger('move_to_STATE_ERROR')
+                        return
+                else:
+                    if self.options.rollback_required:
+                        self.trigger('move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START')
+                        return
+
+                    self.logger.info('Continue interrupted operation...')
+                    self.shrink_plan = self.rebalance_schema.retrieveSavedPlan()
+                    if self.shrink_plan == None:
+                        self.logger.error('No saved plan found. Try to execute cleanup.')
+                        self.trigger('move_to_STATE_ERROR')
+                        return
+
+                    self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
+                    try:
+                        next_state = self.get_state_after_interrupt(state_from_prev_run)
+                    except:
+                        self.logger.error("Can't determine next state. Try to execute cleanup.")
+                        self.trigger('move_to_STATE_ERROR')
+                        return
+
                 # use auto to_«state» method to recover
                 self.trigger(f'to_{next_state}')
         else:
+            if self.shrink_plan == None:
+                self.logger.error("Rebalance schema doesn't exists and no shrink plan is supplied. Please specify shrink plan.")
+                self.trigger('move_to_STATE_ERROR')
+                return
+            if self.gparray.get_segment_count() <= self.shrink_plan.target_segment_count:
+                logger.error('Target segment count (%s) >= current segment count (%s).\n'
+                             'Currently only shrink is supported (target segment count < current segment count).'
+                              % (self.shrink_plan.target_segment_count, self.gparray.get_segment_count()))
+                self.trigger('move_to_STATE_ERROR')
+                return
+
             self.trigger('move_to_STATE_SETUP_SHRINK_SCHEMA_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED(self) -> None:
-        # Create schema and status tables
-        dbconn.execSQL(self.conn, 'BEGIN')
-        dbconn.execSQL(self.conn, f'DROP SCHEMA IF EXISTS {self.rebalance_schema_name} CASCADE')
-        dbconn.execSQL(self.conn, f'CREATE SCHEMA {self.rebalance_schema_name}')
-        dbconn.execSQL(self.conn,
-                       f'''CREATE TABLE {self.rebalance_schema_name}.{self.rebalance_status}
-                       (status TEXT, updated TIMESTAMP WITH TIME ZONE)
-                       DISTRIBUTED REPLICATED''')
-        dbconn.execSQL(self.conn,
-                       f'''CREATE TABLE {self.rebalance_schema_name}.{self.table_rebalance_status_detail}
-                       (db_name TEXT, schema_name TEXT, rel_name TEXT, status TEXT,
-                       CONSTRAINT unique_fqn UNIQUE (db_name, schema_name, rel_name))
-                       DISTRIBUTED REPLICATED''')
-        dbconn.execSQL(self.conn, 'COMMIT')
-
+        # Create schema and status tables.
+        # It will also save plan in order to use it for recovering after interruption
+        self.rebalance_schema.createSchema(self.shrink_plan)
         self.trigger('move_to_STATE_SETUP_SHRINK_SCHEMA_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE(self) -> None:
-        self.logger.info(f'Created shrink schema {self.rebalance_schema_name}')
+        self.logger.info('Created rebalance schema')
         self.trigger('move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
-
-    def get_table_distr_segment_count(self, schema_name, table_name) -> int:
-        row = dbconn.queryRow(self.conn,
-                              f'''SELECT p.numsegments
-                              FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
-                              JOIN gp_distribution_policy p ON c.oid = p.localoid
-                              WHERE n.nspname='{schema_name}' AND c.relname='{table_name}';''')
-        return int(row[0])
 
     @wrap_state_func_with_faults
     def on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED(self) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
         dbconn.execSQL(self.conn, 'CHECKPOINT')
-        dbconn.execSQL(self.conn, f'SELECT gp_toolkit.gp_set_rebalance_numsegments({self.options.target_segment_count})')
+        dbconn.execSQL(self.conn, f'SELECT gp_toolkit.gp_set_rebalance_numsegments({self.shrink_plan.getTargetSegmentCount()})')
 
         self.gparray.dumpToFile(self.gparray_dump_file)
 
         # Rebalance the status tables we've created previously right here before we start to rebalance all other tables.
-        # Before that check if the tables are already rebalanced
-        # (in case we re-enter after interruption that happened after COMMIT but before new state)
-        if self.get_table_distr_segment_count(self.rebalance_schema_name,
-                                              self.rebalance_status) > self.options.target_segment_count:
-            dbconn.execSQL(self.conn,
-                           f'''ALTER TABLE "{self.rebalance_schema_name}"."{self.rebalance_status}"
-                           REBALANCE {self.options.target_segment_count}''')
-
-        if self.get_table_distr_segment_count(self.rebalance_schema_name,
-                                              self.table_rebalance_status_detail) > self.options.target_segment_count:
-            dbconn.execSQL(self.conn,
-                           f'''ALTER TABLE "{self.rebalance_schema_name}"."{self.table_rebalance_status_detail}"
-                           REBALANCE {self.options.target_segment_count}''')
+        self.rebalance_schema.rebalanceSchema(self.shrink_plan.getTargetSegmentCount())
 
         dbconn.execSQL(self.conn, 'COMMIT')
 
@@ -346,7 +392,7 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE(self) -> None:
-        self.logger.info(f'Updated target segment count to {self.options.target_segment_count}')
+        self.logger.info(f'Updated target segment count to {self.shrink_plan.getTargetSegmentCount()}')
         self.trigger('move_to_STATE_PREPARE_SHRINK_SCHEMA_STARTED')
 
     @wrap_state_func_with_faults
@@ -356,10 +402,9 @@ class GGShrink:
 
         dbconn.execSQL(self.conn, 'BEGIN')
 
-        # cleanup table_rebalance_status_detail for the case we re-enter this state after we were interrupted
-        dbconn.execSQL(self.conn,
-                       f'''DELETE FROM {self.rebalance_schema_name}.{self.table_rebalance_status_detail}
-                       WHERE (status <> 'done')''')
+        # cleanup list of tables that require rebalance
+        # for the case we re-enter this state after we were interrupted right after it
+        self.rebalance_schema.clearTablesToRebalanceWithStatus('done')
 
         cursor = dbconn.query(self.conn, 'SELECT datname FROM pg_database')
         databases_to_process = []
@@ -377,12 +422,10 @@ class GGShrink:
                                       JOIN pg_namespace n ON c.relnamespace = n.oid
                                       JOIN gp_distribution_policy p ON c.oid = p.localoid
                                       WHERE c.relkind IN ('r', 'p') AND c.relispartition = FALSE AND
-                                      p.numsegments > {self.options.target_segment_count} AND
-                                      n.nspname NOT IN ('pg_catalog', 'information_schema', '{self.rebalance_schema_name}')''')
+                                      p.numsegments > {self.shrink_plan.getTargetSegmentCount()} AND
+                                      n.nspname NOT IN ('pg_catalog', 'information_schema', '{self.rebalance_schema.getSchemaName()}')''')
                 for schema_name, rel_name in cursor:
-                    dbconn.execSQL(self.conn,
-                                   f'''INSERT INTO {self.rebalance_schema_name}.{self.table_rebalance_status_detail}
-                                   VALUES ('{db}', '{schema_name}', '{rel_name}', 'none')''')
+                    self.rebalance_schema.addTableToRebalance(db, schema_name, rel_name, 'none')
 
         dbconn.execSQL(self.conn, 'COMMIT')
 
@@ -390,65 +433,14 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE(self) -> None:
-        self.logger.info(f'Initiated {self.rebalance_schema_name}.{self.table_rebalance_status_detail}')
+        self.logger.info(f'Initiated list of tables to rebalance')
         self.trigger('move_to_STATE_SHRINK_TABLES_STARTED')
-
-    class TableRebalanceTask(SQLCommand):
-        def __init__(self,
-                     shrink: 'GGShrink',
-                     db_name: str,
-                     schema_name: str,
-                     rel_name: str) -> None:
-            self.shrink = shrink
-            self.db_name = db_name
-            self.schema_name = schema_name
-            self.rel_name = rel_name
-            SQLCommand.__init__(self, f'task rebalance for {self.db_name}.{self.schema_name}.{self.rel_name}')
-
-        def run(self) -> None:
-            dburl = dbconn.DbURL(dbname=self.db_name, port=self.shrink.gpEnv.getCoordinatorPort())
-            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
-                dbconn.execSQL(conn, 'BEGIN')
-                dbconn.execSQL(conn,
-                               f'''ALTER TABLE "{self.schema_name}"."{self.rel_name}"
-                               REBALANCE {self.shrink.options.target_segment_count}''')
-                dbconn.execSQL(self.shrink.conn,
-                               f'''UPDATE {self.shrink.rebalance_schema_name}.{self.shrink.table_rebalance_status_detail} SET status = 'done'
-                               WHERE db_name = '{self.db_name}' AND schema_name = '{self.schema_name}' AND rel_name = '{self.rel_name}';''')
-                dbconn.execSQL(conn, 'COMMIT')
-            self.set_results(CommandResult(0, b'', b'', True, False))
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SHRINK_TABLES_STARTED(self) -> None:
-        self.logger.info('Start tables rebalance')
-
+        self.logger.info('Start tables rebalance for shrink')
         # perform 'ALTER TABLE REBALANCE' for all not yet processed tables
-        cursor = dbconn.query(self.conn,
-                              f"SELECT db_name, schema_name, rel_name FROM {self.rebalance_schema_name}.{self.table_rebalance_status_detail} WHERE status = 'none'")
-
-        self.logger.info(f'Tables to process {cursor.rowcount}')
-
-        if cursor.rowcount > 0:
-            self.workers_for_tables_rebalance = WorkerPool(numWorkers=min(cursor.rowcount, self.options.parallel))
-
-            for db_name, schema_name, rel_name in cursor:
-                task = self.TableRebalanceTask(self,
-                                               db_name,
-                                               schema_name,
-                                               rel_name)
-                self.workers_for_tables_rebalance.addCommand(task)
-
-            print_progress(self.workers_for_tables_rebalance, interval=1)
-
-            self.workers_for_tables_rebalance.haltWork()
-            self.workers_for_tables_rebalance.joinWorkers()
-
-            for task in self.workers_for_tables_rebalance.getCompletedItems():
-                if not task.was_successful():
-                    raise Exception(f'Failed to do ALTER REBALANCE: {task.get_results().stderr}')
-
-            self.workers_for_tables_rebalance = None
-
+        self.rebalance_tables('none', 'done', self.shrink_plan.getTargetSegmentCount())
         self.trigger('move_to_STATE_SHRINK_TABLES_DONE')
 
     @wrap_state_func_with_faults
@@ -462,11 +454,11 @@ class GGShrink:
 
         ## Shrink catalog
         dbconn.execSQL(self.conn, 'BEGIN')
-        cursor = dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
-        dbconn.execSQL(self.conn, f'DELETE FROM gp_segment_configuration WHERE content >= {self.options.target_segment_count}')
+        dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+        dbconn.execSQL(self.conn, f'DELETE FROM gp_segment_configuration WHERE content >= {self.shrink_plan.getTargetSegmentCount()}')
         dbconn.execSQL(self.conn, 'CHECKPOINT')
         dbconn.execSQL(self.conn, 'SELECT gp_expand_bump_version()')
-        cursor = dbconn.query(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
+        dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
         dbconn.execSQL(self.conn, 'COMMIT')
 
         self.trigger('move_to_STATE_SHRINK_CATALOG_DONE')
@@ -485,30 +477,20 @@ class GGShrink:
         if gp_array is None:
             gp_array = self.gparray
         
-        segments_to_stop = gp_array.get_segment_count() - self.options.target_segment_count
+        segments_to_stop = gp_array.get_segment_count() - self.shrink_plan.getTargetSegmentCount()
         segments_to_stop = segments_to_stop * 2 # consider mirrors
         self.workers_for_segment_stop = WorkerPool(numWorkers=min(segments_to_stop, self.options.batch_size))
 
         for seg_pair in gp_array.getSegmentList():
             primary_seg = seg_pair.primaryDB
-            mirror_seq = seg_pair.mirrorDB
-            if primary_seg.getSegmentContentId() >= self.options.target_segment_count:
+            mirror_seg = seg_pair.mirrorDB
+            if primary_seg.getSegmentContentId() >= self.shrink_plan.getTargetSegmentCount():
                 if primary_seg.isSegmentUp():
-                    cmd = SegmentStop(f'stop primary (content {primary_seg.getSegmentContentId()}, dbid {primary_seg.getSegmentDbId()})',
-                                       primary_seg.getSegmentDataDirectory(),
-                                       mode=self.stop_mode,
-                                       timeout=self.timeout,
-                                       ctxt=base.REMOTE,
-                                       remoteHost=primary_seg.getSegmentHostName())
+                    cmd = self.SegmentStopAfterShrink(self, primary_seg)
                     self.workers_for_segment_stop.addCommand(cmd)
 
-                if mirror_seq != None and mirror_seq.isSegmentUp():
-                    cmd = SegmentStop(f'stop mirror (content {mirror_seq.getSegmentContentId()}, dbid {mirror_seq.getSegmentDbId()})',
-                                       mirror_seq.getSegmentDataDirectory(),
-                                       mode=self.stop_mode,
-                                       timeout=self.timeout,
-                                       ctxt=base.REMOTE,
-                                       remoteHost=mirror_seq.getSegmentHostName())
+                if mirror_seg != None and mirror_seg.isSegmentUp():
+                    cmd = self.SegmentStopAfterShrink(self, mirror_seg)
                     self.workers_for_segment_stop.addCommand(cmd)
 
         print_progress(self.workers_for_segment_stop, interval=1)
@@ -537,18 +519,265 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_CLEANUP(self) -> None:
-        dbconn.execSQL(self.conn, f'DROP SCHEMA {self.rebalance_schema_name} CASCADE')
-        self.logger.info('Cleanup is complete')
+        if not self.rebalance_schema.schemaExists():
+            self.logger.info(f"Rebalance schema doesn't exist. Cleanup is not required.")
+        else:
+            state_from_prev_run = self.rebalance_schema.getStateFromPreviousRun()
+            if state_from_prev_run != self.states_main_shrink_flow[-1]:
+                self.logger.warning("ggrebalance hasn't finished shrink process properly. Previous run was interrupted. "
+                                    "Some unbalanced tables can still exist.")
+
+                # get default num segments
+                dbconn.execSQL(self.conn, 'BEGIN')
+                dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+                row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_get_rebalance_numsegments()')
+                current_num_segments = int(row[0])
+                dbconn.execSQL(self.conn, 'END')
+
+                if current_num_segments != 0x7FFFFFFF:
+                    self.logger.warning(f'Current numsegments {current_num_segments} is not equal to default value.')
+                    self.logger.info('Suggestion: explicitly reset the value before cleanup. Note: cluster restart will implicitly reset the value.')
+
+                if (self.options.interactive and
+                    not userinput.ask_yesno(None, "\nContinue with cleanup?", 'Y')):
+                    self.logger.info('Cleanup was interrupted...')
+                    self.trigger('move_to_STATE_END')
+                    return
+                # TODO: use new api to avoid 0x7FFFFFFF
+                if (current_num_segments != 0x7FFFFFFF and
+                    (not self.options.interactive or userinput.ask_yesno(None, "\nReset numsegments to default?", 'Y'))):
+                    dbconn.execSQL(self.conn, 'BEGIN')
+                    dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+                    dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
+                    dbconn.execSQL(self.conn, 'COMMIT')
+                    self.logger.info('Reset numsegments to default is done.')
+
+            if os.path.exists(self.gparray_dump_file):
+                os.remove(self.gparray_dump_file)
+            self.rebalance_schema.dropSchema()
+            self.logger.info('Cleanup is complete')
+        self.trigger('move_to_STATE_END')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_ROLLBACK(self) -> None:
+        if not self.rebalance_schema.schemaExists():
+            self.logger.info("Rebalance schema doesn't exist. Can't perform rollback.")
+            self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+            return
+        else:
+            state_from_prev_run = self.rebalance_schema.getStateFromPreviousRun()
+            if state_from_prev_run != 'not defined':
+                # check maybe the state is the final one
+                if state_from_prev_run == self.states_main_shrink_flow[-1]:
+                    self.logger.info("Previous run was completed successfully. Can't perform rollback.")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                    return
+
+                if not self.state_can_rollback(state_from_prev_run) or self.is_gp_segment_configuration_shrinked():
+                    self.logger.info("Can't perform rollback as the catalog is already updated")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                    return
+
+        self.trigger('move_to_STATE_CHECK_PREVIOUS_RUN')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START(self) -> None:
+        dbconn.execSQL(self.conn, 'BEGIN')
+        dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+        dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
+        # Store state here in case we fail before we enter 'on_every_state()'
+        # because after COMMIT we are on a one-way road of rollback.
+        self.rebalance_schema.storeState(self.state)
+        dbconn.execSQL(self.conn, 'COMMIT')
+
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE(self) -> None:
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START(self) -> None:
+        # TODO: fill the tables that could be created after interruption
+
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE(self) -> None:
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START(self) -> None:
+        self.logger.info('Start tables rebalance for rollback')
+        # perform 'ALTER TABLE REBALANCE' for all not yet processed tables
+        self.rebalance_tables('done', 'none', self.gparray.get_segment_count())
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE(self) -> None:
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START(self) -> None:
+        if os.path.exists(self.gparray_dump_file):
+            os.remove(self.gparray_dump_file)
+        self.rebalance_schema.dropSchema()
+        self.trigger('move_to_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE(self) -> None:
+        self.logger.info('Rollback is complete.')
+        self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_END_FROM_ROLLBACK(self) -> None:
         self.trigger('move_to_STATE_END')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_END(self) -> None:
         self.conn.close()
 
+    @wrap_state_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:
         sys.exit(1)
 
     # state callbacks end here
+
+    class SegmentStopAfterShrink(SegmentStop):
+        def __init__(self, shrink: 'GGShrink', segment: Segment) -> None:
+            self.shrink = shrink
+            self.segment = segment
+            if self.segment.isSegmentPrimary():
+                name = f'stop primary (content {self.segment.getSegmentContentId()}, dbid {self.segment.getSegmentDbId()})'
+            else:
+                name = f'stop mirror (content {self.segment.getSegmentContentId()}, dbid {self.segment.getSegmentDbId()})'
+            self.checkRunningSegment = SegmentIsShutDown(name, self.segment.getSegmentDataDirectory(), base.REMOTE, self.segment.getSegmentHostName())
+            SegmentStop.__init__(self,
+                                 name,
+                                 self.segment.getSegmentDataDirectory(),
+                                 self.shrink.stop_mode,
+                                 False,
+                                 base.REMOTE,
+                                 self.segment.getSegmentHostName(),
+                                 self.shrink.timeout)
+
+        # decorator to inject a fault before running SegmentStopAfterShrink for a specific dbid
+        def wrap_segment_stop_with_faults(fun):
+            def func_with_faults(self):
+                inject_fault(f'fault_segment_stop_dbid_{self.segment.getSegmentDbId()}')
+                fun(self)
+            return func_with_faults
+
+        @wrap_segment_stop_with_faults
+        def run(self) -> None:
+            self.shrink.logger.info(f'Stopping shrinked segment dbid {self.segment.getSegmentDbId()} @ host={self.remoteHost}, datadir={self.segment.getSegmentDataDirectory()}')
+            self.checkRunningSegment.run()
+            if self.checkRunningSegment.is_shutdown():
+                self.shrink.logger.info(f'Segment dbid {self.segment.getSegmentDbId()} is already down @ host={self.remoteHost}, datadir={self.segment.getSegmentDataDirectory()} ')
+                self.set_results(CommandResult(0, b'', b'', True, False))
+            else:
+                SegmentStop.run(self)
+                self.shrink.logger.info(f'Stopped shrinked segment dbid {self.segment.getSegmentDbId()} @ host={self.remoteHost}, datadir={self.segment.getSegmentDataDirectory()}')
+
+    class TableRebalanceTask(SQLCommand):
+        def __init__(self,
+                     shrink: 'GGShrink',
+                     db_name: str,
+                     schema_name: str,
+                     rel_name: str,
+                     target_segment_count: int,
+                     table_status_after_rebalance: str) -> None:
+            self.shrink = shrink
+            self.db_name = db_name
+            self.schema_name = schema_name
+            self.rel_name = rel_name
+            self.target_segment_count = target_segment_count
+            self.table_status_after_rebalance = table_status_after_rebalance
+            SQLCommand.__init__(self, f'task rebalance for {self.db_name}.{self.schema_name}.{self.rel_name}')
+
+        # decorator to inject a fault before running TableRebalanceTask for a specific {db_name, schema_name, rel_name}
+        def wrap_table_rebalance_with_faults(fun):
+            def func_with_faults(self):
+                inject_fault(f'fault_rebalance_table_{self.db_name}.{self.schema_name}.{self.rel_name}')
+                fun(self)
+            return func_with_faults
+
+        @wrap_table_rebalance_with_faults
+        def run(self) -> None:
+            self.shrink.logger.info(f'Start table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}" to {self.target_segment_count} segments')
+            dburl = dbconn.DbURL(dbname=self.db_name, port=self.shrink.gpEnv.getCoordinatorPort())
+            with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+                dbconn.execSQL(conn, 'BEGIN')
+                dbconn.execSQL(conn,
+                               f'''ALTER TABLE "{self.schema_name}"."{self.rel_name}"
+                               REBALANCE {self.target_segment_count}''')
+                self.shrink.rebalance_schema.setStatusForTableToRebalance(self.db_name, self.schema_name, self.rel_name, self.table_status_after_rebalance)
+                dbconn.execSQL(conn, 'COMMIT')
+            self.shrink.logger.info(f'Complete table rebalance for "{self.db_name}"."{self.schema_name}"."{self.rel_name}"')
+            self.set_results(CommandResult(0, b'', b'', True, False))
+
+    def rebalance_tables(self, original_status: str, target_status: str, target_segment_count: int) -> None:
+        cursor = self.rebalance_schema.getTablesToRebalanceWithStatus(original_status)
+
+        self.logger.info(f'Tables to process {cursor.rowcount}')
+
+        if cursor.rowcount > 0:
+            self.workers_for_tables_rebalance = WorkerPool(numWorkers=min(cursor.rowcount, self.options.parallel))
+
+            for db_name, schema_name, rel_name in cursor:
+                task = self.TableRebalanceTask(self,
+                                               db_name,
+                                               schema_name,
+                                               rel_name,
+                                               target_segment_count,
+                                               target_status)
+                self.workers_for_tables_rebalance.addCommand(task)
+
+            print_progress(self.workers_for_tables_rebalance, interval=1)
+
+            self.workers_for_tables_rebalance.haltWork()
+            self.workers_for_tables_rebalance.joinWorkers()
+
+            for task in self.workers_for_tables_rebalance.getCompletedItems():
+                if not task.was_successful():
+                    raise Exception(f'Failed to do ALTER REBALANCE: {task.get_results().stderr}')
+
+            self.workers_for_tables_rebalance = None
+
+    def get_state_after_interrupt(self, prev_state) -> str:
+        prev_idx = self.states_main_shrink_flow.index(prev_state)
+        lower = self.states_main_shrink_flow.index('STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
+        upper = self.states_main_shrink_flow.index('STATE_SHRINK_TABLES_DONE')
+        if prev_idx >= lower and prev_idx <= upper:
+
+            #if shrink is interrupted after catalog update and before the state is logged
+            if prev_state == 'STATE_SHRINK_TABLES_DONE' and \
+                self.dumped_gparray is not None \
+                and self.gparray.get_segment_count() + self.shrink_plan.target_segment_count == self.dumped_gparray.get_segment_count():
+                return 'STATE_SHRINK_CATALOG_DONE'
+
+            row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set();')
+            # means that target rebalance numsegments is reset, and new tables are created at old segment count
+            if bool(row[0]) is False:
+                self.logger.info("Cluster restarted after previous run, trying to repopulate the relation queue")
+                self.needs_repopulate = True
+                return 'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED'
+        
+        return self.states_main_shrink_flow[prev_idx + 1]
+
+    def state_can_rollback(self, state: str) -> bool:
+        if (state in self.states_main_shrink_flow):
+            if self.states_main_shrink_flow.index(state) <= self.states_main_shrink_flow.index('STATE_SHRINK_TABLES_DONE'):
+                return True
+        return False
+
+    def is_gp_segment_configuration_shrinked(self) -> bool:
+        # TODO
+        if not os.path.exists(self.gparray_dump_file):
+            return False
+        gparray_from_file = GpArray.initFromFile(self.gparray_dump_file)
+        gparray_from_catalog = GpArray.initFromCatalog(self.dburl, utility=True)
+        return gparray_from_file.get_segment_count() != gparray_from_catalog.get_segment_count()
 
     def shutdown(self) -> None:
         if self.workers_for_tables_rebalance != None:

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -269,6 +269,27 @@ class GGShrink:
         self.shrink_plan = shrinkPlan
         self.trigger('start')
 
+    def get_state_after_interrupt(self, prev_state) -> str:
+        prev_idx = self.states_main_shrink_flow.index(prev_state)
+        lower = self.states_main_shrink_flow.index('STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
+        upper = self.states_main_shrink_flow.index('STATE_SHRINK_TABLES_DONE')
+        if prev_idx >= lower and prev_idx <= upper:
+
+            #if shrink is interrupted after catalog update and before the state is logged
+            if prev_state == 'STATE_SHRINK_TABLES_DONE' and \
+                self.dumped_gparray is not None \
+                and self.gparray.get_segment_count() + self.shrink_plan.target_segment_count == self.dumped_gparray.get_segment_count():
+                return 'STATE_SHRINK_CATALOG_DONE'
+
+            row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set();')
+            # means that target rebalance numsegments is reset, and new tables are created at old segment count
+            if bool(row[0]) is False:
+                self.logger.info("Cluster restarted after previous run, trying to repopulate the relation queue")
+                self.needs_repopulate = True
+                return 'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED'
+
+        return self.states_main_shrink_flow[prev_idx + 1]
+
     def on_every_state(self) -> None:
         if self.shutdown_requested:
             self.logger.info('Shrink was interrupted')
@@ -742,27 +763,6 @@ class GGShrink:
                     raise Exception(f'Failed to do ALTER REBALANCE: {task.get_results().stderr}')
 
             self.workers_for_tables_rebalance = None
-
-    def get_state_after_interrupt(self, prev_state) -> str:
-        prev_idx = self.states_main_shrink_flow.index(prev_state)
-        lower = self.states_main_shrink_flow.index('STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
-        upper = self.states_main_shrink_flow.index('STATE_SHRINK_TABLES_DONE')
-        if prev_idx >= lower and prev_idx <= upper:
-
-            #if shrink is interrupted after catalog update and before the state is logged
-            if prev_state == 'STATE_SHRINK_TABLES_DONE' and \
-                self.dumped_gparray is not None \
-                and self.gparray.get_segment_count() + self.shrink_plan.target_segment_count == self.dumped_gparray.get_segment_count():
-                return 'STATE_SHRINK_CATALOG_DONE'
-
-            row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set();')
-            # means that target rebalance numsegments is reset, and new tables are created at old segment count
-            if bool(row[0]) is False:
-                self.logger.info("Cluster restarted after previous run, trying to repopulate the relation queue")
-                self.needs_repopulate = True
-                return 'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED'
-        
-        return self.states_main_shrink_flow[prev_idx + 1]
 
     def state_can_rollback(self, state: str) -> bool:
         if (state in self.states_main_shrink_flow):

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -287,7 +287,7 @@ class GGShrink:
                 self.logger.info("Cluster restarted after previous run, trying to repopulate the relation queue")
                 self.needs_repopulate = True
                 return 'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED'
-
+        
         return self.states_main_shrink_flow[prev_idx + 1]
 
     def on_every_state(self) -> None:
@@ -390,7 +390,7 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE(self) -> None:
-        self.logger.info('Created rebalance schema')
+        self.logger.info(f'Created "{self.rebalance_schema.getSchemaName()}" schema')
         self.trigger('move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
 
     @wrap_state_func_with_faults

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -279,8 +279,6 @@ class GGShrink:
         if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
             self.rebalance_schema.storeState(self.state)
 
-    # decorator to inject a fault before or after the given 'on_enter_' state callback
-
     # state callbacks start here
     @wrap_state_func_with_faults
     def on_enter_STATE_OPTIONS_VALIDATION(self) -> None:

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -530,12 +530,12 @@ class GGShrink:
                 # get default num segments
                 dbconn.execSQL(self.conn, 'BEGIN')
                 dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
-                row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_get_rebalance_numsegments()')
-                current_num_segments = int(row[0])
+                row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set()')
+                numsegments_is_set = bool(row[0])
                 dbconn.execSQL(self.conn, 'END')
 
-                if current_num_segments != 0x7FFFFFFF:
-                    self.logger.warning(f'Current numsegments {current_num_segments} is not equal to default value.')
+                if numsegments_is_set:
+                    self.logger.warning('Current numsegments is not equal to default value.')
                     self.logger.info('Suggestion: explicitly reset the value before cleanup. Note: cluster restart will implicitly reset the value.')
 
                 if (self.options.interactive and
@@ -543,8 +543,8 @@ class GGShrink:
                     self.logger.info('Cleanup was interrupted...')
                     self.trigger('move_to_STATE_END')
                     return
-                # TODO: use new api to avoid 0x7FFFFFFF
-                if (current_num_segments != 0x7FFFFFFF and
+
+                if (numsegments_is_set and
                     (not self.options.interactive or userinput.ask_yesno(None, "\nReset numsegments to default?", 'Y'))):
                     dbconn.execSQL(self.conn, 'BEGIN')
                     dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -1,7 +1,7 @@
 @ggrebalance
 Feature: ggrebalance behave tests
 
-    Scenario: test 1.1 ggrebalance simple scenarious
+    Scenario: test 1.1 ggrebalance simple scenarios
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -475,6 +475,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | fault_rebalance_table_test_db_2.test_schema_2.test_table_1              |
 
     Scenario Outline: test 4.3. shrink - check continue after interrupted rollback state (interruption is done after rebalance schema is dropped)
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -326,6 +326,58 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_end                             |
         | fault_segment_stop_dbid_3                                                   |
 
+    Scenario Outline: test 3.4. shrink - check rollback after interrupted state and cluster restart
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When set fault inject "<fault_name>"
+         And the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And there is a "heap" table "test_schema_2.test_table_3" in "test_db_2" with "200" rows
+        When the user runs "gpstop -arf"
+        Then gpstart should return a return code of 0
+        When there is a "heap" table "test_schema_2.test_table_4" in "test_db_2" with "300" rows
+         And the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_3" with data in "test_db_2" is equal to segment count = 2, row count = 200
+         And distribution information from table "test_schema_2.test_table_4" with data in "test_db_2" is equal to segment count = 2, row count = 300
+         And ggrebalance should return a return code of 0
+    Examples:
+        | fault_name                                                                  |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end                              |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_begin                               |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_end      |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_begin                          |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end                            |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin                             |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_end                               |
+        | on_enter_STATE_SHRINK_TABLES_STARTED_begin                                  |
+        | on_enter_STATE_SHRINK_TABLES_STARTED_end                                    |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_end                                       |
+        | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
+
     Scenario Outline: test 4.1. shrink - check continue after interrupted rollback state. In this case we fail in rollback too early, and normal shrink will be complete.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -5,6 +5,9 @@ Feature: ggrebalance behave tests
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"
+         And segment information for content 1 is saved in context
+         And segment information for content 2 is saved in context
+         And segment information for content 3 is saved in context
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -x 4"
         Then ggrebalance should return a return code of 1
@@ -23,7 +26,8 @@ Feature: ggrebalance behave tests
          And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
         When the user runs "ggrebalance -x 2"
         Then ggrebalance should return a return code of 0
-        And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
         When the user runs "ggrebalance -x 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
@@ -49,12 +53,11 @@ Feature: ggrebalance behave tests
          And ggrebalance should print "Reset numsegments to default is done." to logfile with latest timestamp
          And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
 
-# TODO: add tables creation after shrink or rollback interruption
-
     Scenario: test 2.1. shrink - check continue after interrupted state, if interruption is done before the rebalance schema creation
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
+         And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
          And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_begin"
          And database "test_db_1" exists
@@ -75,6 +78,7 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance -x 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
@@ -86,6 +90,7 @@ Feature: ggrebalance behave tests
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
+         And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
          And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end"
          And database "test_db_1" exists
@@ -108,6 +113,7 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance -x 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
@@ -119,6 +125,7 @@ Feature: ggrebalance behave tests
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
+         And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
          And database "test_db_1" exists
@@ -142,6 +149,7 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance --parallel 1 --batch-size 1"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
@@ -178,6 +186,7 @@ Feature: ggrebalance behave tests
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
+         And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
@@ -198,6 +207,7 @@ Feature: ggrebalance behave tests
          And the user runs "ggrebalance"
         Then ggrebalance should print "Cluster restarted after previous run, trying to repopulate the relation queue" to logfile
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_3" with data in "test_db_2" is equal to segment count = 1, row count = 1094
@@ -290,6 +300,7 @@ Feature: ggrebalance behave tests
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
+         And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
          And database "test_db_1" exists
@@ -310,6 +321,7 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
@@ -382,6 +394,7 @@ Feature: ggrebalance behave tests
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
+         And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name_shrink>"
          And database "test_db_1" exists
@@ -404,6 +417,7 @@ Feature: ggrebalance behave tests
         When the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -425,8 +425,9 @@ Feature: ggrebalance behave tests
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
 
     Examples:
-        | fault_name_shrink                       | fault_name_rollback                                                     |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_begin |
+        | fault_name_shrink                                          | fault_name_rollback                                                     |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_begin |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_begin |
 
     Scenario Outline: test 4.2. shrink - check continue after interrupted rollback state
         Given the database is not running
@@ -462,20 +463,32 @@ Feature: ggrebalance behave tests
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
 
     Examples:
-        | fault_name_shrink                       | fault_name_rollback                                                     |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | fault_rebalance_table_test_db_2.test_schema_2.test_table_1              |
+        | fault_name_shrink                                          | fault_name_rollback                                                     |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin                    | fault_rebalance_table_test_db_2.test_schema_2.test_table_1              |
 
     Scenario Outline: test 4.3. shrink - check continue after interrupted rollback state (interruption is done after rebalance schema is dropped)
         Given the database is not running
@@ -511,10 +524,13 @@ Feature: ggrebalance behave tests
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
 
     Examples:
-        | fault_name_shrink                       | fault_name_rollback                                                     |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_end                    |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_begin                   |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_end                     |
+        | fault_name_shrink                                          | fault_name_rollback                                                     |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_end                    |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_begin                   |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_end                     |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_end                    |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_begin                   |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_end                     |
 
     Scenario Outline: test 4.4. shrink - check continue after interrupted rollback state and cluster restart
         Given the database is not running
@@ -556,17 +572,29 @@ Feature: ggrebalance behave tests
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
 
     Examples:
-        | fault_name_shrink                       | fault_name_rollback                                                     |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
-        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+        | fault_name_shrink                                          | fault_name_rollback                                                     |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -1,36 +1,451 @@
 @ggrebalance
 Feature: ggrebalance behave tests
 
-    Scenario Outline: test shrink continue after cluster restart
-    Given the database is not running
-    And a working directory of the test as '/data/gpdata/ggrebalance'
-    And a cluster is created with mirrors on "cdw" and "sdw1"
-    And all files in gpAdminLogs directory are deleted
-    And database "test_db_1" exists
-    And schema "test_schema_1" exists in "test_db_1"
-    And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
-    And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
-    And database "test_db_2" exists
-    And schema "test_schema_2" exists in "test_db_2"
-    And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
-    And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-    When set fault inject "<fault_name>"
-    And the user runs "ggrebalance -x 1"
-    Then ggrebalance should return a return code of 1
-    And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
-    And unset fault inject
-    When the user runs "gpstop -arf"
-    Then gpstart should return a return code of 0
-    When there is a "heap" table "test_schema_2.test_table_3" in "test_db_2" with data
-    And the user runs "ggrebalance -x 1"
-    Then ggrebalance should print "Cluster restarted after previous run, trying to repopulate the relation queue" to logfile
-    And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
-    And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
-    And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
-    And distribution information from table "test_schema_2.test_table_3" with data in "test_db_2" is equal to segment count = 1, row count = 1094
-    And ggrebalance should return a return code of 0
+    Scenario: test 1.1 ggrebalance simple scenarious
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 4"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Target segment count (4) >= current segment count (4)." to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -x 2"
+        Then ggrebalance should return a return code of 0
+        And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
+
+    Scenario: test 1.2. check cleanup after the target segment count was updated
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end"
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance -c -y"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Reset numsegments to default is done." to logfile with latest timestamp
+         And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
+
+# TODO: add tables creation after shrink or rollback interruption
+
+    Scenario: test 2.1. shrink - check continue after interrupted state, if interruption is done before the rebalance schema creation
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_begin"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Rebalance schema doesn't exists and no shrink plan is supplied. Please specify shrink plan." to logfile with latest timestamp
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
+
+    Scenario: test 2.2. shrink - check continue after interrupted state, if interruption is done after the rebalance schema creation, but before any state is saved there
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Can't determine next state. Try to execute cleanup." to logfile with latest timestamp
+        When the user runs "ggrebalance -c -y"
+        Then ggrebalance should return a return code of 0
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
+
+    Scenario Outline: test 2.3. shrink - check continue after interrupted state
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1 --parallel 1 --batch-size 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance -x 1 --parallel 1 --batch-size 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Can't start a new operation, because the previous one was interrupted" to logfile with latest timestamp
+        When the user runs "ggrebalance -x 1 --parallel 1 --batch-size 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Can't start a new operation, because the previous one was interrupted" to logfile with latest timestamp
+        When the user runs "ggrebalance --parallel 1 --batch-size 1"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
+
+    Examples:
+        | fault_name                                                                  |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_begin                               |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_end      |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_begin                          |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end                            |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin                             |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_end                               |
+        | on_enter_STATE_SHRINK_TABLES_STARTED_begin                                  |
+        | on_enter_STATE_SHRINK_TABLES_STARTED_end                                    |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_end                                       |
+        | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
+        | on_enter_STATE_SHRINK_CATALOG_STARTED_end                                   |
+        | on_enter_STATE_SHRINK_CATALOG_DONE_begin                                    |
+        | on_enter_STATE_SHRINK_CATALOG_DONE_end                                      |
+        | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_begin                           |
+        | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_end                             |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
+        | fault_segment_stop_dbid_3                                                   |
+
+    Scenario Outline: test 2.4. test shrink continue after cluster restart
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When set fault inject "<fault_name>"
+         And the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "gpstop -arf"
+        Then gpstart should return a return code of 0
+        When there is a "heap" table "test_schema_2.test_table_3" in "test_db_2" with data
+         And the user runs "ggrebalance"
+        Then ggrebalance should print "Cluster restarted after previous run, trying to repopulate the relation queue" to logfile
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_3" with data in "test_db_2" is equal to segment count = 1, row count = 1094
+         And ggrebalance should return a return code of 0
     Examples:
         | fault_name                                                                  |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
         | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin                             |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin                                     |
+
+    Scenario: test 3.1. shrink - check rollback after interrupted state, if interruption is done before the rebalance schema creation
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_begin"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
+
+    Scenario Outline: test 3.2. shrink - check rollback after interrupted state
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1 --parallel 1 --batch-size 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
+
+    Examples:
+        | fault_name                                                                  |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end                              |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_begin                               |
+        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
+        | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_end      |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_begin                          |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end                            |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin                             |
+        | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_end                               |
+        | on_enter_STATE_SHRINK_TABLES_STARTED_begin                                  |
+        | on_enter_STATE_SHRINK_TABLES_STARTED_end                                    |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_end                                       |
+        | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
+        | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
+
+    Scenario Outline: test 3.3. shrink - check rollback after interrupted state (interruption is done after the point of no return). Rollback fails. So just continue shrink.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Can't perform rollback as the catalog is already updated" to logfile with latest timestamp
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
+
+    Examples:
+        | fault_name                                                                  |
+        | on_enter_STATE_SHRINK_CATALOG_STARTED_end                                   |
+        | on_enter_STATE_SHRINK_CATALOG_DONE_begin                                    |
+        | on_enter_STATE_SHRINK_CATALOG_DONE_end                                      |
+        | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_begin                           |
+        | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_end                             |
+        | fault_segment_stop_dbid_3                                                   |
+
+    Scenario Outline: test 4.1. shrink - check continue after interrupted rollback state. In this case we fail in rollback too early, and normal shrink will be complete.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name_shrink>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And set fault inject "<fault_name_rollback>"
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
+
+    Examples:
+        | fault_name_shrink                       | fault_name_rollback                                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_begin |
+
+    Scenario Outline: test 4.2. shrink - check continue after interrupted rollback state
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name_shrink>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And set fault inject "<fault_name_rollback>"
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
+
+    Examples:
+        | fault_name_shrink                       | fault_name_rollback                                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+
+    Scenario Outline: test 4.3. shrink - check continue after interrupted rollback state (interruption is done after rebalance schema is dropped)
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name_shrink>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And set fault inject "<fault_name_rollback>"
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Rebalance schema doesn't exists and no shrink plan is supplied. Please specify shrink plan." to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
+
+    Examples:
+        | fault_name_shrink                       | fault_name_rollback                                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_end                    |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_begin                   |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_end                     |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -515,3 +515,58 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_end                    |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_begin                   |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_end                     |
+
+    Scenario Outline: test 4.4. shrink - check continue after interrupted rollback state and cluster restart
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name_shrink>"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And set fault inject "<fault_name_rollback>"
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And there is a "heap" table "test_schema_2.test_table_3" in "test_db_2" with "200" rows
+        When the user runs "gpstop -arf"
+        Then gpstart should return a return code of 0
+        When there is a "heap" table "test_schema_2.test_table_4" in "test_db_2" with "300" rows
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rollback is complete" to logfile with latest timestamp
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
+         And distribution information from table "test_schema_2.test_table_3" with data in "test_db_2" is equal to segment count = 2, row count = 200
+         And distribution information from table "test_schema_2.test_table_4" with data in "test_db_2" is equal to segment count = 2, row count = 300
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
+
+    Examples:
+        | fault_name_shrink                       | fault_name_rollback                                                     |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_end   |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_begin  |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE_end    |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_begin               |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_START_end                 |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_begin                |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_PREPARE_SCHEMA_DONE_end                  |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_begin              |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_START_end                |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_begin               |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_SHRINKED_TABLES_DONE_end                 |
+        | on_enter_STATE_SHRINK_TABLES_DONE_begin | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
+

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance.feature
@@ -369,7 +369,6 @@ Feature: ggrebalance behave tests
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 2, row count = 100
          And distribution information from table "test_schema_2.test_table_3" with data in "test_db_2" is equal to segment count = 2, row count = 200
          And distribution information from table "test_schema_2.test_table_4" with data in "test_db_2" is equal to segment count = 2, row count = 300
-         And ggrebalance should return a return code of 0
     Examples:
         | fault_name                                                                  |
         | on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end                              |

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4160,6 +4160,29 @@ def impl(context):
                 raise Exception("Postgres process {0} not killed on {1}.".format(pid, host))
 
 
+@given('segment information for content {content} is saved in context')
+@when('segment information for content {content} is saved in context')
+@then('segment information for content {content} is saved in context')
+def impl(context, content):
+    segment_information = []
+    segs = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    for seg in segs:
+        if int(content) == int(seg.getSegmentContentId()):
+            segment_information.append(seg)
+
+    context.segment_information = segment_information
+
+
+@given('verify no segment running for saved segment information')
+@when('verify no segment running for saved segment information')
+@then('verify no segment running for saved segment information')
+def impl(context):
+    for seg in context.segment_information:
+        segment_check = gp.SegmentIsShutDown('', seg.getSegmentDataDirectory(), REMOTE, seg.getSegmentHostName())
+        segment_check.run()
+        if not segment_check.is_shutdown():
+            raise Exception(f'Segment is up (dbid {seg.getSegmentDbId()})')
+
 @then('the database segments are in execute mode')
 def impl(context):
     # Get all primary segments details

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2283,6 +2283,7 @@ def impl(context):
     ''')
 
 @given('there is a "{tabletype}" table "{tablename}" in "{dbname}" with "{numrows}" rows')
+@when('there is a "{tabletype}" table "{tablename}" in "{dbname}" with "{numrows}" rows')
 def impl(context, tabletype, tablename, dbname, numrows):
     populate_regular_table_data(context, tabletype, tablename, dbname, compression_type=None, with_data=True, rowcount=int(numrows))
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2283,6 +2283,7 @@ def impl(context):
     ''')
 
 @given('there is a "{tabletype}" table "{tablename}" in "{dbname}" with "{numrows}" rows')
+@then('there is a "{tabletype}" table "{tablename}" in "{dbname}" with "{numrows}" rows')
 @when('there is a "{tabletype}" table "{tablename}" in "{dbname}" with "{numrows}" rows')
 def impl(context, tabletype, tablename, dbname, numrows):
     populate_regular_table_data(context, tabletype, tablename, dbname, compression_type=None, with_data=True, rowcount=int(numrows))


### PR DESCRIPTION
Implement cleanup and rollback options for the cluster shrink

In this patch:
1. The new option '--clean' is added for the cluster shrink by the ggrebalance
tool.
2. The new option '--rollback' is added for the cluster shrink by the
ggrebalance tool.
3. The new option '--non-interactive-mode' is added for the ggrebalance tool. It
is essential to allow auto testing of some cleanup scenarios that would expect
user confirmation without such an option.
4. As the existing 'main' and the new 'rollback' shrink workflows use similar
functionality, the shrink code is reorganized to reduce code duplication:
a. New functions that are used in both 'main' and 'rollback' workflows are
introduced (like 'prepare_shrink_schema()', 'rebalance_tables()').
b. All logic related to the ggrebalance schema handling is moved to a separate
class named 'RebalanceSchema' in 'rebalance_commons.py'.
5. A new entity, 'Plan,' is added. It is used to pass information about required
shrink configuration of the target cluster to the shrink engine. We store it in
the rebalance schema and used for the 'rollback' workflow, and when we recover
from an interrupted shrink state. It is added due to the following reasons:
a. As already stated above, we need it during rollback. When the user starts the
rollback operation, he doesn't specify the target segment count that was used
at the preceding shrink operation. Thus we need to store this information at
shrink for the later usage.
b. When the user tries to re-enter the shrink procedure from an interrupted
state, we need to re-start with the same target segment count that was specified
originally. Otherwise we may get the cluster in some invalid configuration where
tables are shrunk to different segment counts. Giving the user the ability
to specify target segment count for the re-enter launch opens the way for such
error prone scenarios. So we just forbid specifying segment count configuration
if we re-enter the interrupted state or start the rollback, and use the saved
plan information that we got at the very first operation start.
c. According to the current design, at the later phase we'll introduce a Planner
entity, that will perform planning for all shrink/expand/rebalance operations.
And its output Plan will be the input to the shrink engine. So this change is
aligned with the overall design.
6. New behave test cases are added. The test cases cover not only the 'cleanup'
and 'rollback' flows, but also the existing 'main' shrink flow, as we can't
guarantee the correctness of rollback without proving the 'main' flow works Ok.
The existing test case is renamed to 'test 2.4' and moved to be near the new
tests that cover similar functionality.
7. New steps are added to mgmt_utils.py, that are used to verify that the
shrinked segments are actually down. Also a small change in 'SegmentIsShutDown'
is done - it is required to check that the mirror is down.
8. In order to recover properly, if we are interrupted in the middle of stopping
shrinked segments, a new class 'SegmentStopAfterShrink' is introduced. It wraps
the 'SegmentStop' with the checking whether the segment is actually still
running. Without it, if shrink was re-entered and some segments were already
shut down by the preceding interrupted launch, we got an error when trying to
shut down such segments.