### PR TITLE
resolve conflicts in configure.in and configure

### DIFF
--- a/configure
+++ b/configure
@@ -808,11 +808,7 @@ build_vendor
 build_cpu
 build
 PG_MAJORVERSION
-<<<<<<< HEAD
-configure_args
 PG_PACKAGE_VERSION
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 target_alias
 host_alias
 build_alias
@@ -9578,6 +9574,7 @@ fi
 
 
 
+
 #
 # Assignments
 #
@@ -16234,7 +16231,6 @@ if test x"$pgac_cv__builtin_frame_address" = xyes ; then
 $as_echo "#define HAVE__BUILTIN_FRAME_ADDRESS 1" >>confdefs.h
 
 fi
-
 ac_fn_c_check_member "$LINENO" "struct tm" "tm_zone" "ac_cv_member_struct_tm_tm_zone" "#include <sys/types.h>
 #include <time.h>
 

--- a/configure.in
+++ b/configure.in
@@ -31,13 +31,8 @@ dnl your responsibility whether the result works or not.])])
 AC_COPYRIGHT([Copyright (c) 1996-2020, PostgreSQL Global Development Group])
 AC_CONFIG_SRCDIR([src/backend/access/common/heaptuple.c])
 AC_CONFIG_AUX_DIR(config)
-<<<<<<< HEAD
 AC_PREFIX_DEFAULT(/usr/local/gpdb)
-AC_SUBST(configure_args, [$ac_configure_args])
-=======
-AC_PREFIX_DEFAULT(/usr/local/pgsql)
 AC_DEFINE_UNQUOTED(CONFIGURE_ARGS, ["$ac_configure_args"], [Saved arguments from configure])
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 [PG_MAJORVERSION=`expr "$PG_PACKAGE_VERSION" : '\([0-9][0-9]*\)'`]
 AC_SUBST(PG_MAJORVERSION)


### PR DESCRIPTION
Commit b691c18 changes ac_configure_args variable in configure.in, but adjacent 
line is gpdb-specific.

File configure was prepared by GNU vanilla autoconf 2.69 to accomodate 
the change.
