### PR TITLE
Resolve conflicts in src/pl/plperl/GNUmakefile

### DIFF
--- a/src/pl/plperl/GNUmakefile
+++ b/src/pl/plperl/GNUmakefile
@@ -55,16 +55,11 @@ endif # win32
 
 SHLIB_LINK = $(perl_embed_ldflags)
 
-<<<<<<< HEAD
-REGRESS_OPTS = --dbname=$(PL_TESTDB) --load-extension=plperl  --load-extension=plperlu
-REGRESS_OPTS += --init-file=init_file
-REGRESS = plperl plperl_lc plperl_trigger plperl_shared plperl_elog plperl_util plperl_init plperlu plperl_array plperl_call plperl_transaction
-=======
 REGRESS_OPTS = --dbname=$(PL_TESTDB)
+REGRESS_OPTS += --init-file=init_file
 REGRESS = plperl_setup plperl plperl_lc plperl_trigger plperl_shared \
 	plperl_elog plperl_util plperl_init plperlu plperl_array \
 	plperl_call plperl_transaction
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 # if Perl can support two interpreters in one backend,
 # test plperl-and-plperlu cases
 ifneq ($(PERL),)


### PR DESCRIPTION
Resolve conflicts in src/pl/plperl/GNUmakefile

Commit 50fc694 reformatted the REGRESS variable in src/pl/plperl/GNUmakefile,
adding the new value plperl_setup to it, and also removed the values
load-extension=plperl and load-extension=plperlu from the REGRESS_OPTS
variable. However, the earlier commit 25a9039 had already added the value
init-file=init_file to the REGRESS_OPTS variable.