### PR TITLE
Resolve conflicts in src/include/access/heapam.h

### DIFF
--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -192,15 +192,9 @@ extern BlockNumber ss_get_location(Relation rel, BlockNumber relnblocks);
 extern void SyncScanShmemInit(void);
 extern Size SyncScanShmemSize(void);
 
-<<<<<<< HEAD
-=======
 /* in heap/vacuumlazy.c */
-struct VacuumParams;
-extern void heap_vacuum_rel(Relation onerel,
-							struct VacuumParams *params, BufferAccessStrategy bstrategy);
 extern void parallel_vacuum_main(dsm_segment *seg, shm_toc *toc);
 
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 /* in heap/heapam_visibility.c */
 extern bool HeapTupleSatisfiesVisibility(Relation relation, HeapTuple stup, Snapshot snapshot,
 										 Buffer buffer);


### PR DESCRIPTION
Resolve conflicts in src/include/access/heapam.h

Commit 40d964e added a new function, parallel_vacuum_main, to
src/include/access/heapam.h, although the function heap_vacuum_rel was
previously missing from this file.