### PR TITLE
Resolve conflicts in src/include/catalog/pg_class.h and src/include/catalog/pg_class.dat

### DIFF
--- a/src/include/catalog/pg_class.dat
+++ b/src/include/catalog/pg_class.dat
@@ -21,19 +21,7 @@
 { oid => '1249',
   relname => 'pg_attribute', reltype => 'pg_attribute' },
 { oid => '1255',
-<<<<<<< HEAD
-  relname => 'pg_proc', reltype => 'pg_proc', relam => 'heap',
-  relfilenode => '0', relpages => '0', reltuples => '0', relallvisible => '0',
-  reltoastrelid => '0', relhasindex => 'f', relisshared => 'f',
-  relpersistence => 'p', relkind => 'r', relnatts => '31', relchecks => '0',
-  relhasrules => 'f', relhastriggers => 'f', relhassubclass => 'f',
-  relrowsecurity => 'f', relforcerowsecurity => 'f', relispopulated => 't',
-  relreplident => 'n', relispartition => 'f', relfrozenxid => '3',
-  relminmxid => '1', relacl => '_null_', reloptions => '_null_',
-  relpartbound => '_null_' },
-=======
   relname => 'pg_proc', reltype => 'pg_proc' },
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 { oid => '1259',
   relname => 'pg_class', reltype => 'pg_class' },
 

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -22,17 +22,11 @@
 #include "catalog/pg_class_d.h"
 
 /* ----------------
-<<<<<<< HEAD
- *		postgres.h contains the system type definitions and the
- *		CATALOG(), BKI_BOOTSTRAP and DATA() sugar words so this file
- *		can be read by both genbki.sh and the C compiler.
-=======
  *		pg_class definition.  cpp turns this into
  *		typedef struct FormData_pg_class
  *
  * Note that the BKI_DEFAULT values below are only used for rows describing
  * BKI_BOOTSTRAP catalogs, since only those rows appear in pg_class.dat.
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
  * ----------------
  */
 CATALOG(pg_class,1259,RelationRelationId) BKI_BOOTSTRAP BKI_ROWTYPE_OID(83,RelationRelation_Rowtype_Id) BKI_SCHEMA_MACRO


### PR DESCRIPTION
Commit 86ff085 simplified definitions in the pg_class.dat and changed comment 
in the pg_class.h. This conflicted with older Greenplum changes.
Resolved by preferring Postgres changes.