### PR TITLE
Fix conflicts related to pg_stat_get_activity

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -852,11 +852,8 @@ CREATE VIEW pg_stat_activity AS
             S.datid AS datid,
             D.datname AS datname,
             S.pid,
-<<<<<<< HEAD
-            S.sess_id,
-=======
             S.leader_pid,
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
+            S.sess_id,
             S.usesysid,
             U.rolname AS usename,
             S.application_name,

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -553,11 +553,7 @@ pg_stat_get_progress_info(PG_FUNCTION_ARGS)
 Datum
 pg_stat_get_activity(PG_FUNCTION_ARGS)
 {
-<<<<<<< HEAD
-#define PG_STAT_GET_ACTIVITY_COLS	32
-=======
-#define PG_STAT_GET_ACTIVITY_COLS	30
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
+#define PG_STAT_GET_ACTIVITY_COLS	33
 	int			num_backends = pgstat_fetch_stat_numbackends();
 	int			curr_backend;
 	int			pid = PG_ARGISNULL(0) ? -1 : PG_GETARG_INT32(0);
@@ -701,30 +697,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 
 			proc = BackendPidGetProc(beentry->st_procpid);
 
-<<<<<<< HEAD
-				raw_wait_event = UINT32_ACCESS_ONCE(proc->wait_event_info);
-				wait_event_type = pgstat_get_wait_event_type(raw_wait_event);
-
-				/*
-				 * We don't pass details for resource groups via event id,
-				 * since it's an uint16 and resource group id is an Oid.
-				 *
-				 * Get it from the backend entry, waitOnGroup() had set the
-				 * information in it.
-				 */
-				if (wait_event_type && (pg_strcasecmp(wait_event_type, "ResourceGroup") == 0))
-				{
-					wait_event = GetResGroupNameForId(beentry->st_rsgid);
-				}
-				else
-				{
-					wait_event = pgstat_get_wait_event(raw_wait_event);
-				}
-			}
-			else if (beentry->st_backendType != B_BACKEND)
-=======
 			if (proc == NULL && (beentry->st_backendType != B_BACKEND))
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 			{
 				/*
 				 * For an auxiliary process, retrieve process info from
@@ -922,17 +895,17 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 													 * use */
 			}
 
-			values[29] = Int32GetDatum(beentry->st_session_id);  /* GPDB */
+			values[30] = Int32GetDatum(beentry->st_session_id);  /* GPDB */
 
 			{
 				char *groupName = GetResGroupNameForId(beentry->st_rsgid);
 
-				values[30] = ObjectIdGetDatum(beentry->st_rsgid);
+				values[31] = ObjectIdGetDatum(beentry->st_rsgid);
 
 				if (groupName != NULL)
-					values[31] = CStringGetTextDatum(groupName);
+					values[32] = CStringGetTextDatum(groupName);
 				else
-					nulls[31] = true;
+					nulls[32] = true;
 			}
 		}
 		else
@@ -961,14 +934,10 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 			nulls[26] = true;
 			nulls[27] = true;
 			nulls[28] = true;
-<<<<<<< HEAD
-
-			values[29] = Int32GetDatum(beentry->st_session_id);
-			nulls[30] = true;
-			nulls[31] = true;
-=======
 			nulls[29] = true;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
+			values[30] = Int32GetDatum(beentry->st_session_id);
+			nulls[31] = true;
+			nulls[32] = true;
 		}
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -696,14 +696,47 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 			nulls[29] = true;
 
 			proc = BackendPidGetProc(beentry->st_procpid);
+			if (proc != NULL)
+			{
+				uint32		raw_wait_event;
 
-			if (proc == NULL && (beentry->st_backendType != B_BACKEND))
+				raw_wait_event = UINT32_ACCESS_ONCE(proc->wait_event_info);
+				wait_event_type = pgstat_get_wait_event_type(raw_wait_event);
+
+				/*
+				 * We don't pass details for resource groups via event id,
+				 * since it's an uint16 and resource group id is an Oid.
+				 *
+				 * Get it from the backend entry, waitOnGroup() had set the
+				 * information in it.
+				 */
+				if (wait_event_type && (pg_strcasecmp(wait_event_type, "ResourceGroup") == 0))
+				{
+					wait_event = GetResGroupNameForId(beentry->st_rsgid);
+				}
+				else
+				{
+					wait_event = pgstat_get_wait_event(raw_wait_event);
+				}
+			}
+			else if (beentry->st_backendType != B_BACKEND)
 			{
 				/*
 				 * For an auxiliary process, retrieve process info from
 				 * AuxiliaryProcs stored in shared-memory.
 				 */
 				proc = AuxiliaryPidGetProc(beentry->st_procpid);
+
+				if (proc != NULL)
+				{
+					uint32		raw_wait_event;
+
+					raw_wait_event =
+						UINT32_ACCESS_ONCE(proc->wait_event_info);
+					wait_event_type =
+						pgstat_get_wait_event_type(raw_wait_event);
+					wait_event = pgstat_get_wait_event(raw_wait_event);
+				}
 			}
 
 			/*
@@ -714,12 +747,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 			 */
 			if (proc != NULL)
 			{
-				uint32		raw_wait_event;
 				PGPROC	   *leader;
-
-				raw_wait_event = UINT32_ACCESS_ONCE(proc->wait_event_info);
-				wait_event_type = pgstat_get_wait_event_type(raw_wait_event);
-				wait_event = pgstat_get_wait_event(raw_wait_event);
 
 				leader = proc->lockGroupLeader;
 				if (leader)

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -5255,15 +5255,9 @@
   proname => 'pg_stat_get_activity', prorows => '100', proisstrict => 'f',
   proretset => 't', provolatile => 's', proparallel => 'r',
   prorettype => 'record', proargtypes => 'int4',
-<<<<<<< HEAD
-  proallargtypes => '{int4,oid,int4,oid,text,text,text,text,text,timestamptz,timestamptz,timestamptz,timestamptz,inet,text,int4,xid,xid,text,bool,text,text,int4,bool,text,numeric,text,bool,text,bool,int4,int4,text}',
-  proargmodes => '{i,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o}',
-  proargnames => '{pid,datid,pid,usesysid,application_name,state,query,wait_event_type,wait_event,xact_start,query_start,backend_start,state_change,client_addr,client_hostname,client_port,backend_xid,backend_xmin,backend_type,ssl,sslversion,sslcipher,sslbits,sslcompression,ssl_client_dn,ssl_client_serial,ssl_issuer_dn,gss_auth,gss_princ,gss_enc,sess_id,rsgid,rsgname}',
-=======
-  proallargtypes => '{int4,oid,int4,oid,text,text,text,text,text,timestamptz,timestamptz,timestamptz,timestamptz,inet,text,int4,xid,xid,text,bool,text,text,int4,bool,text,numeric,text,bool,text,bool,int4}',
-  proargmodes => '{i,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o}',
-  proargnames => '{pid,datid,pid,usesysid,application_name,state,query,wait_event_type,wait_event,xact_start,query_start,backend_start,state_change,client_addr,client_hostname,client_port,backend_xid,backend_xmin,backend_type,ssl,sslversion,sslcipher,sslbits,sslcompression,ssl_client_dn,ssl_client_serial,ssl_issuer_dn,gss_auth,gss_princ,gss_enc,leader_pid}',
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
+  proallargtypes => '{int4,oid,int4,oid,text,text,text,text,text,timestamptz,timestamptz,timestamptz,timestamptz,inet,text,int4,xid,xid,text,bool,text,text,int4,bool,text,numeric,text,bool,text,bool,int4,int4,int4,text}',
+  proargmodes => '{i,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o}',
+  proargnames => '{pid,datid,pid,usesysid,application_name,state,query,wait_event_type,wait_event,xact_start,query_start,backend_start,state_change,client_addr,client_hostname,client_port,backend_xid,backend_xmin,backend_type,ssl,sslversion,sslcipher,sslbits,sslcompression,ssl_client_dn,ssl_client_serial,ssl_issuer_dn,gss_auth,gss_princ,gss_enc,leader_pid,sess_id,rsgid,rsgname}',
   prosrc => 'pg_stat_get_activity' },
 { oid => '3318',
   descr => 'statistics: information about progress of backends running maintenance command',


### PR DESCRIPTION
Commit b025f32 added leader_pid to the pg_stat_activity. GPDB has its own 
additions to it, which made a conflicts to src/backend/catalog/system_views.sql, 
src/include/catalog/pg_proc.dat and src/backend/utils/adt/pgstatfuncs.c.

This commit resolves conflicts in a way that Postgres changes are clustered, 
allowing easier conflict resolution in a future.