### PR TITLE
Resolve conflicts in vacuum.h, vacuum.c, and vacuumlazy.c

### DIFF
--- a/src/backend/access/heap/vacuumlazy.c
+++ b/src/backend/access/heap/vacuumlazy.c
@@ -56,11 +56,8 @@
 #include "access/heapam_xlog.h"
 #include "access/htup_details.h"
 #include "access/multixact.h"
-<<<<<<< HEAD
 #include "access/nbtree.h"
-=======
 #include "access/parallel.h"
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 #include "access/transam.h"
 #include "access/aosegfiles.h"
 #include "access/aocssegfiles.h"
@@ -2389,27 +2386,10 @@ lazy_cleanup_index(Relation indrel,
 	if (!(*stats))
 		return;
 
-<<<<<<< HEAD
-	/*
-	 * Now update statistics in pg_class, but only if the index says the count
-	 * is accurate.
-	 */
-	if (!stats->estimated_count)
-		vac_update_relstats(indrel,
-							stats->num_pages,
-							stats->num_index_tuples,
-							0,
-							false,
-							InvalidTransactionId,
-							InvalidMultiXactId,
-							false,
-							true /* isvacuum */);
-=======
 	if (IsParallelWorker())
 		msg = gettext_noop("index \"%s\" now contains %.0f row versions in %u pages as reported by parallel vacuum worker");
 	else
 		msg = gettext_noop("index \"%s\" now contains %.0f row versions in %u pages");
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 	ereport(elevel,
 			(errmsg(msg,
@@ -3084,7 +3064,8 @@ update_index_statistics(Relation *Irel, IndexBulkDeleteResult **stats,
 							false,
 							InvalidTransactionId,
 							InvalidMultiXactId,
-							false);
+							false,
+							true /* isvacuum */);
 		pfree(stats[i]);
 	}
 }

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -108,13 +108,9 @@ static void vac_truncate_clog(TransactionId frozenXID,
 							  MultiXactId minMulti,
 							  TransactionId lastSaneFrozenXid,
 							  MultiXactId lastSaneMinMulti);
-<<<<<<< HEAD
 static bool vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 					   bool recursing);
-=======
-static bool vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params);
 static double compute_parallel_delay(void);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 static VacOptTernaryValue get_vacopt_ternary_value(DefElem *def);
 
 static void dispatchVacuum(VacuumParams *params, Oid relid,
@@ -140,13 +136,10 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 	bool		freeze = false;
 	bool		full = false;
 	bool		disable_page_skipping = false;
-<<<<<<< HEAD
 	bool		rootonly = false;
 	bool		fullscan = false;
 	int			ao_phase = 0;
-=======
 	bool		parallel_option = false;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	ListCell   *lc;
 
 	/* Set default value */
@@ -189,12 +182,11 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 			params.index_cleanup = get_vacopt_ternary_value(opt);
 		else if (strcmp(opt->defname, "truncate") == 0)
 			params.truncate = get_vacopt_ternary_value(opt);
-<<<<<<< HEAD
 		else if (Gp_role == GP_ROLE_EXECUTE && strcmp(opt->defname, "ao_phase") == 0)
 		{
 			ao_phase = defGetInt32(opt);
 			Assert((ao_phase & VACUUM_AO_PHASE_MASK) == ao_phase);
-=======
+		}
 		else if (strcmp(opt->defname, "parallel") == 0)
 		{
 			parallel_option = true;
@@ -227,7 +219,6 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 				else
 					params.nworkers = nworkers;
 			}
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 		}
 		else
 			ereport(ERROR,

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -283,7 +283,6 @@ typedef struct VacuumParams
 										 * default value depends on reloptions */
 	VacOptTernaryValue truncate;	/* Truncate empty pages at the end,
 									 * default value depends on reloptions */
-	bool auto_stats;      /* invoked via automatic statistic collection */
 
 	/*
 	 * The number of parallel vacuum workers.  0 by default which means choose
@@ -291,6 +290,8 @@ typedef struct VacuumParams
 	 * disabled.
 	 */
 	int			nworkers;
+
+	bool		auto_stats;		/* invoked via automatic statistic collection */
 } VacuumParams;
 
 typedef struct

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -283,9 +283,7 @@ typedef struct VacuumParams
 										 * default value depends on reloptions */
 	VacOptTernaryValue truncate;	/* Truncate empty pages at the end,
 									 * default value depends on reloptions */
-<<<<<<< HEAD
 	bool auto_stats;      /* invoked via automatic statistic collection */
-=======
 
 	/*
 	 * The number of parallel vacuum workers.  0 by default which means choose
@@ -293,7 +291,6 @@ typedef struct VacuumParams
 	 * disabled.
 	 */
 	int			nworkers;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 } VacuumParams;
 
 typedef struct


### PR DESCRIPTION
Resolve conflicts in vacuum.h, vacuum.c, and vacuumlazy.c

1) Commit 40d964e added a new field, nworkers, to the VacuumParams structure in
src/include/commands/vacuum.h, while earlier commit 781d7fe had already added
another new field, auto_stats, to the same location.

2) Commit 40d964e added a declaration of a new function,
compute_parallel_delay, to src/backend/commands/vacuum.c, while earlier commit
5778f31 had already added a GPDB-specific argument, recursing, to the
declaration of the previous function, vacuum_rel.

3) Commit 40d964e added a new local variable, parallel_option, to the
ExecVacuum function in src/backend/commands/vacuum.c, while the earlier commit
19cd1cf had already added the new GPDB-specific local variables, rootonly,
fullscan, and ao_phase, to the same location.

4) Commit 40d964e added handling of the new parallel option to the ExecVacuum
function in src/backend/commands/vacuum.c, while the earlier commit 19cd1cf had
already added handling of the GPDB-specific ao_phase option to the same
location.

5) Commit 40d964e added a new include access/parallel.h to
src/backend/access/heap/vacuumlazy.c, while earlier commit 17c4dd1 had already
added another include access/nbtree.h to the same location.

6) Commit 40d964e replaced the conditional update of vac_update_relstats
statistics in the lazy_cleanup_index function in
src/backend/access/heap/vacuumlazy.c with conditional messages, while earlier
commit e5d1779 had already added the final argument, isvacuum, to the
vac_update_relstats function call.