### PR TITLE
Resolve conflicts in hashfn.h, hashfn.c, and dshash.c

### DIFF
--- a/src/backend/lib/dshash.c
+++ b/src/backend/lib/dshash.c
@@ -36,10 +36,6 @@
 #include "storage/ipc.h"
 #include "storage/lwlock.h"
 #include "utils/dsa.h"
-<<<<<<< HEAD
-=======
-#include "utils/hashutils.h"
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 #include "utils/memutils.h"
 
 /*

--- a/src/common/hashfn.c
+++ b/src/common/hashfn.c
@@ -29,7 +29,6 @@
  *-------------------------------------------------------------------------
  */
 
-<<<<<<< HEAD:src/common/hashfn.c
 /*
  * GPDB: We carry a dependency on pthread_win32.h in elog.h, which causes
  * compilation errors when building Windows clients (as elog.h is included by
@@ -42,9 +41,6 @@
 #endif
 
 #include "common/hashfn.h"
-=======
-#include "utils/hashutils.h"
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089:src/backend/utils/hash/hashfn.c
 
 
 /*
@@ -710,8 +706,8 @@ uint32_hash(const void *key, Size keysize)
 {
 	Assert(keysize == sizeof(uint32));
 	return hash_bytes_uint32(*((const uint32 *) key));
-<<<<<<< HEAD:src/common/hashfn.c
 }
+
 /*
  * int32_hash: hash function for int32: no-op
  */
@@ -719,6 +715,4 @@ uint32
 int32_hash(const void *key, Size keysize)
 {
 	return *(uint32 *)key;
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089:src/backend/utils/hash/hashfn.c
 }

--- a/src/include/common/hashfn.h
+++ b/src/include/common/hashfn.h
@@ -55,10 +55,7 @@ hash_uint32_extended(uint32 k, uint64 seed)
 extern uint32 string_hash(const void *key, Size keysize);
 extern uint32 tag_hash(const void *key, Size keysize);
 extern uint32 uint32_hash(const void *key, Size keysize);
-<<<<<<< HEAD:src/include/common/hashfn.h
 extern uint32 int32_hash(const void *key, Size keysize);
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089:src/include/utils/hashutils.h
 
 #define oid_hash uint32_hash	/* Remove me eventually */
 


### PR DESCRIPTION
Resolve conflicts in hashfn.h, hashfn.c, and dshash.c

1) Commit 9341c78 added new definitions of string_hash, tag_hash, and
uint32_hash to src/include/utils/hashutils.h, as well as a new oid_hash
definition. Earlier commit 0c30498 had already done this but added a definition
of int32_hash, and earlier commit 5d3dc2e had already renamed
src/include/utils/hashutils.h to src/include/common/hashfn.h.

2) Commit af38498 replaced the access/hash.h include in
src/backend/utils/hash/hashfn.c with the fmgr.h, nodes/bitmapset.h, and
utils/hashutils.h includes. However, the earlier commit 5d3dc2e had already
renamed the utils/hashutils.h include to common/hashfn.h.

3) Commit c264869 removed the bitmap_hash and bitmap_match functions from
src/backend/utils/hash/hashfn.c, while earlier commit 6b0e52b had already added
a new function, int32_hash, to the same location, and commit 5d3dc2e had
already renamed src/backend/utils/hash/hashfn.c to src/common/hashfn.c.

4) Commit 9341c78 added a new include, utils/hashutils.h, to
src/backend/lib/dshash.c, while earlier commit 5d3dc2e had already renamed the
include, utils/hashutils.h, to include common/hashfn.h.