### PR TITLE
Resolve conflicts in nodeAgg.h, nodeAgg.c, and planner.c

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1729,6 +1729,7 @@ find_hash_columns(AggState *aggstate)
 /*
  * Estimate per-hash-table-entry overhead.
  */
+Size
 hash_agg_entry_size(int numAggs, Size tupleWidth, Size transitionSpace)
 {
 	return

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -413,7 +413,6 @@ static Bitmapset *find_unaggregated_cols(AggState *aggstate);
 static bool find_unaggregated_cols_walker(Node *node, Bitmapset **colnos);
 static void build_hash_tables(AggState *aggstate);
 static void build_hash_table(AggState *aggstate, int setno, long nbuckets);
-<<<<<<< HEAD
 static void hashagg_recompile_expressions(AggState *aggstate, bool minslot,
 										  bool nullcheck);
 static long hash_choose_num_buckets(double hashentrysize,
@@ -426,9 +425,6 @@ static int hash_choose_num_partitions(AggState *aggstate,
 									  int *log2_npartittions);
 static AggStatePerGroup lookup_hash_entry(AggState *aggstate, uint32 hash,
 										  bool *in_hash_table);
-=======
-static AggStatePerGroup lookup_hash_entry(AggState *aggstate, uint32 hash);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 static void lookup_hash_entries(AggState *aggstate);
 static TupleTableSlot *agg_retrieve_direct(AggState *aggstate);
 static void agg_fill_hash_table(AggState *aggstate);
@@ -1492,7 +1488,6 @@ build_hash_tables(AggState *aggstate)
 	for (setno = 0; setno < aggstate->num_hashes; ++setno)
 	{
 		AggStatePerHash perhash = &aggstate->perhash[setno];
-<<<<<<< HEAD
 		long			nbuckets;
 		Size			memory;
 
@@ -1511,15 +1506,6 @@ build_hash_tables(AggState *aggstate)
 			aggstate->hashentrysize, perhash->aggnode->numGroups, memory);
 
 		build_hash_table(aggstate, setno, nbuckets);
-=======
-
-		Assert(perhash->aggnode->numGroups > 0);
-
-		if (perhash->hashtable)
-			ResetTupleHashTable(perhash->hashtable);
-		else
-			build_hash_table(aggstate, setno, perhash->aggnode->numGroups);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	}
 
 	aggstate->hash_ngroups_current = 0;
@@ -1743,34 +1729,14 @@ find_hash_columns(AggState *aggstate)
 /*
  * Estimate per-hash-table-entry overhead.
  */
-Size
-<<<<<<< HEAD
-hash_agg_entry_size(int numTrans, Size tupleWidth, Size transitionSpace)
+hash_agg_entry_size(int numAggs, Size tupleWidth, Size transitionSpace)
 {
-	Size    tupleChunkSize;
-	Size    pergroupChunkSize;
-	Size    transitionChunkSize;
-	Size    tupleSize	 = (MAXALIGN(SizeofMinimalTupleHeader) +
-							tupleWidth);
-	Size    pergroupSize = numTrans * sizeof(AggStatePerGroupData);
-
-	tupleChunkSize = CHUNKHDRSZ + tupleSize;
-
-	if (pergroupSize > 0)
-		pergroupChunkSize = CHUNKHDRSZ + pergroupSize;
-	else
-		pergroupChunkSize = 0;
-
-	if (transitionSpace > 0)
-		transitionChunkSize = CHUNKHDRSZ + transitionSpace;
-	else
-		transitionChunkSize = 0;
-
 	return
-		sizeof(TupleHashEntryData) +
-		tupleChunkSize +
-		pergroupChunkSize +
-		transitionChunkSize;
+		MAXALIGN(SizeofMinimalTupleHeader) +
+		MAXALIGN(tupleWidth) +
+		MAXALIGN(sizeof(TupleHashEntryData) +
+				 numAggs * sizeof(AggStatePerGroupData)) +
+		transitionSpace;
 }
 
 /*
@@ -2111,16 +2077,6 @@ hash_choose_num_partitions(AggState *aggstate, uint64 input_groups, double hashe
 	npartitions = 1L << partition_bits;
 
 	return npartitions;
-=======
-hash_agg_entry_size(int numAggs, Size tupleWidth, Size transitionSpace)
-{
-	return
-		MAXALIGN(SizeofMinimalTupleHeader) +
-		MAXALIGN(tupleWidth) +
-		MAXALIGN(sizeof(TupleHashEntryData) +
-				 numAggs * sizeof(AggStatePerGroupData)) +
-		transitionSpace;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 }
 
 /*
@@ -2131,7 +2087,6 @@ hash_agg_entry_size(int numAggs, Size tupleWidth, Size transitionSpace)
  *
  * When called, CurrentMemoryContext should be the per-query context. The
  * already-calculated hash value for the tuple must be specified.
-<<<<<<< HEAD
  *
  * If in "spill mode", then only find existing hashtable entries; don't create
  * new ones. If a tuple's group is not already present in the hash table for
@@ -2140,16 +2095,10 @@ hash_agg_entry_size(int numAggs, Size tupleWidth, Size transitionSpace)
  */
 static AggStatePerGroup
 lookup_hash_entry(AggState *aggstate, uint32 hash, bool *in_hash_table)
-=======
- */
-static AggStatePerGroup
-lookup_hash_entry(AggState *aggstate, uint32 hash)
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 {
 	AggStatePerHash perhash = &aggstate->perhash[aggstate->current_set];
 	TupleTableSlot *hashslot = perhash->hashslot;
 	TupleHashEntryData *entry;
-<<<<<<< HEAD
 	bool			isnew = false;
 	bool		   *p_isnew;
 
@@ -2167,13 +2116,6 @@ lookup_hash_entry(AggState *aggstate, uint32 hash)
 	}
 	else
 		*in_hash_table = true;
-=======
-	bool		isnew;
-
-	/* find or create the hashtable entry using the filtered tuple */
-	entry = LookupTupleHashEntryHash(perhash->hashtable, hashslot, &isnew,
-									 hash);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 	if (isnew)
 	{
@@ -2235,19 +2177,13 @@ lookup_hash_entries(AggState *aggstate)
 
 	for (setno = 0; setno < aggstate->num_hashes; setno++)
 	{
-<<<<<<< HEAD
 		AggStatePerHash	perhash = &aggstate->perhash[setno];
 		uint32			hash;
 		bool			in_hash_table;
-=======
-		AggStatePerHash perhash = &aggstate->perhash[setno];
-		uint32			hash;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 		select_current_set(aggstate, setno, true);
 		prepare_hash_slot(aggstate);
 		hash = TupleHashTableHash(perhash->hashtable, perhash->hashslot);
-<<<<<<< HEAD
 		pergroup[setno] = lookup_hash_entry(aggstate, hash, &in_hash_table);
 
 		/* check to see if we need to spill the tuple for this grouping set */
@@ -2263,9 +2199,6 @@ lookup_hash_entries(AggState *aggstate)
 
 			hashagg_spill_tuple(spill, slot, hash);
 		}
-=======
-		pergroup[setno] = lookup_hash_entry(aggstate, hash);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	}
 }
 
@@ -3802,15 +3735,11 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 							&aggstate->hash_ngroups_limit,
 							&aggstate->hash_planned_partitions);
 		find_hash_columns(aggstate);
-<<<<<<< HEAD
 
 		/* Skip massive memory allocation if we are just doing EXPLAIN */
 		if (!(eflags & EXEC_FLAG_EXPLAIN_ONLY))
 			build_hash_tables(aggstate);
 
-=======
-		build_hash_tables(aggstate);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 		aggstate->table_filled = false;
 	}
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -5496,17 +5496,7 @@ create_distinct_paths(PlannerInfo *root,
 	else if (parse->hasDistinctOn || !enable_hashagg)
 		allow_hash = false;		/* policy-based decision not to hash */
 	else
-<<<<<<< HEAD
 		allow_hash = true;		/* default */
-=======
-	{
-		Size		hashentrysize = hash_agg_entry_size(
-			0, cheapest_input_path->pathtarget->width, 0);
-
-		/* Allow hashing only if hashtable is predicted to fit in work_mem */
-		allow_hash = (hashentrysize * numDistinctRows <= work_mem * 1024L);
-	}
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 	if (allow_hash && grouping_is_hashable(parse->distinctClause))
 	{

--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -317,8 +317,7 @@ extern AggState *ExecInitAgg(Agg *node, EState *estate, int eflags);
 extern void ExecEndAgg(AggState *node);
 extern void ExecReScanAgg(AggState *node);
 
-<<<<<<< HEAD
-extern Size hash_agg_entry_size(int numTrans, Size tupleWidth,
+extern Size hash_agg_entry_size(int numAggs, Size tupleWidth,
 								Size transitionSpace);
 extern void hash_agg_set_limits(AggState *aggstate, double hashentrysize, uint64 input_groups,
 								int used_bits, Size *mem_limit,
@@ -326,9 +325,5 @@ extern void hash_agg_set_limits(AggState *aggstate, double hashentrysize, uint64
 
 extern void ExecSquelchAgg(AggState *aggstate);
 extern bool ReuseHashTable(AggState *node);
-=======
-extern Size hash_agg_entry_size(int numAggs, Size tupleWidth,
-								Size transitionSpace);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 #endif							/* NODEAGG_H */


### PR DESCRIPTION
Resolve conflicts in nodeAgg.h, nodeAgg.c, and planner.c

1) Commit 7d4395d added new arguments, tupleWidth and transitionSpace, to the
definition of the hash_agg_entry_size function in
src/include/executor/nodeAgg.h, while the earlier commit 19cd1cf had already
done this.

2) Commit 5b618e1 added a definition of the new build_hash_tables function in
src/backend/executor/nodeAgg.c, as well as new arguments, setno and nbuckets,
to the definition of build_hash_table, and a new argument, hash, to the
lookup_hash_entry function. The earlier commit 19cd1cf had already done this,
but added an additional new argument, in_hash_table, to the lookup_hash_entry
function.

3) Commit b7fabe8 added a conditional call to the ResetTupleHashTable function
in the build_hash_tables function in src/backend/executor/nodeAgg.c, while the
earlier commit 19cd1cf had already done this, but in a different way.

4) Commit 7d4395d added new tupleWidth and transitionSpace arguments to the
hash_agg_entry_size function in src/backend/executor/nodeAgg.c, while the
earlier commit 19cd1cf had already done this.

5) Commit 5b618e1 added the lookup_hash_entry function with the new hash
argument to the src/backend/executor/nodeAgg.c function lookup_hash_entries,
while the earlier commit 19cd1cf had already done this, but added the use of
another new argument, in_hash_table.

6) Commit 5b618e1 added the build_hash_table function call to the ExecInitAgg
function in src/backend/executor/nodeAgg.c, replacing it with a call to
build_hash_tables. The earlier commit 44fc83f had already done this, but with
a condition.

7) Commit 7d4395d added the use of hash_agg_entry_size in the
create_distinct_paths function in src/backend/optimizer/plan/planner.c, while
the earlier commit 1818894 had already removed this.