### PR TITLE
Resolve conflicts in src/include/nodes/bitmapset.h

### DIFF
--- a/src/include/nodes/bitmapset.h
+++ b/src/include/nodes/bitmapset.h
@@ -134,7 +134,6 @@ extern int	bms_prev_member(const Bitmapset *a, int prevbit);
 extern uint32 bms_hash_value(const Bitmapset *a);
 extern uint32 bitmap_hash(const void *key, Size keysize);
 extern int	bitmap_match(const void *key1, const void *key2, Size keysize);
-<<<<<<< HEAD
 
 /* 
  * returns true iff the bitmap is sufficently large that
@@ -148,7 +147,5 @@ extern bool bms_covers_member(const Bitmapset *a, int x);
  * is returned
  */
 extern Bitmapset *bms_resize(Bitmapset *a, int wc);
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 #endif							/* BITMAPSET_H */


### PR DESCRIPTION
Resolve conflicts in src/include/nodes/bitmapset.h

Commit 07b95c3 added definitions of new functions bitmap_hash and bitmap_match
to src/include/nodes/bitmapset.h, although earlier commit c264869 had already
done so.