### PR TITLE
Resolve conflicts in src/include/storage/proc.h

### DIFF
--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -357,16 +357,10 @@ extern PGPROC *PreparedXactProcs;
 
 /* configurable options */
 extern PGDLLIMPORT int DeadlockTimeout;
-<<<<<<< HEAD
-extern int	StatementTimeout;
-extern int	LockTimeout;
-extern int	IdleInTransactionSessionTimeout;
-extern int	IdleSessionGangTimeout;
-=======
 extern PGDLLIMPORT int StatementTimeout;
 extern PGDLLIMPORT int LockTimeout;
 extern PGDLLIMPORT int IdleInTransactionSessionTimeout;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
+extern PGDLLIMPORT int IdleSessionGangTimeout;
 extern bool log_lock_waits;
 
 


### PR DESCRIPTION
Resolve conflicts in src/include/storage/proc.h

Commit 62c9b52 added the PGDLLIMPORT modifier to the definitions of the global
variables StatementTimeout, LockTimeout, and IdleInTransactionSessionTimeout in
src/include/storage/proc.h. An earlier commit, cdc0104, also added a new global
variable, IdleSessionGangTimeout, to the same location.