### PR TITLE
Resolve conflicts in src/backend/utils/adt/datetime.c

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -3946,40 +3946,12 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 		case USE_ISO_DATES:
 		case USE_XSD_DATES:
 			/* compatible with ISO date formats */
-<<<<<<< HEAD
-
-			/* GPDB_96_MERGE_FIXME: We had this faster version in GPDB. PostgreSQL
-			 * also added faster versions in commit aa2387e2fd. Performance test is
-			 * the old GPDB variants are even faster, or if we could drop the diff
-			 * and just use upstream code. For now, the GPDB version is disabled
-			 * and we use the upstream code.
-			 */
-#if 0
-			if (tm->tm_year > 0)
-			{
-				//				sprintf(str, "%04d-%02d-%02d",
-				//		tm->tm_year, tm->tm_mon, tm->tm_mday);
-				int j = 0;
-				fast_encode_date(tm, str, &j);
-			}
-			else
-				sprintf(str, "%04d-%02d-%02d %s",
-						-(tm->tm_year - 1), tm->tm_mon, tm->tm_mday, "BC");
-#else
-			str = pg_ltostr_zeropad(str,
-=======
 			str = pg_ultostr_zeropad(str,
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = '-';
 			str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			*str++ = '-';
-<<<<<<< HEAD
-			str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
-#endif
-=======
 			str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 			break;
 
 		case USE_SQL_DATES:
@@ -4052,33 +4024,7 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 void
 EncodeTimeOnly(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, int style, char *str)
 {
-<<<<<<< HEAD
-	/* GPDB_96_MERGE_FIXME: We had this faster version in GPDB. PostgreSQL
-	 * also added faster versions in commit aa2387e2fd. Performance test is
-	 * the old GPDB variants are even faster, or if we could drop the diff
-	 * and just use upstream code. For now, the GPDB version is disabled
-	 * and we use the upstream code.
-	 *
-	 * If we still need the old GPDB version, make sure it was actually correct.
-	 * It seems to ignore the 'print_tz' argument...
-	 */
-#if 0
-	str[0] = tm->tm_hour/10 + '0';
-	str[1] = tm->tm_hour % 10 + '0';
-	str[2] = ':';
-	str[3] = tm->tm_min/10 + '0';
-	str[4] = tm->tm_min % 10 + '0';
-	str[5] = ':';
-	str[6] = '\0';
-	str += strlen(str);
-
-	AppendSeconds(str, tm->tm_sec, fsec, MAX_TIME_PRECISION, true);
-#else
-
-	str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
-=======
 	str = pg_ultostr_zeropad(str, tm->tm_hour, 2);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	*str++ = ':';
 	str = pg_ultostr_zeropad(str, tm->tm_min, 2);
 	*str++ = ':';
@@ -4086,7 +4032,6 @@ EncodeTimeOnly(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, int style, 
 	if (print_tz)
 		str = EncodeTimezone(str, tz, style);
 	*str = '\0';
-#endif
 }
 
 


### PR DESCRIPTION
Commit 1fd687a introduced new optimizations for integer to decimal output and
replaced `pg_ltostr_zeropad` to `pg_ultostr_zeropad`. However in 
src/backend/utils/adt/datetime.c calls to `pg_ltostr_zeropad` had a GPDB-specific 
code nearby. 

This is an ancient dead code with possible optimization of integer to decimal 
conversion and is not used. Dead code removed as well.
