### PR TITLE
Resolve conflicts in src/backend/utils/misc/guc.c

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -9424,7 +9424,6 @@ ShowAllGUCConfig(DestReceiver *dest)
 }
 
 /*
-<<<<<<< HEAD
  * return if the option were modified (w.r.t. config file)
  */
 bool is_guc_modified(struct config_generic *conf)
@@ -9479,15 +9478,10 @@ bool is_guc_modified(struct config_generic *conf)
 }
 
 /*
- * Returns an array of modified GUC options to show in EXPLAIN. Only options
- * related to query planning (marked with GUC_EXPLAIN), with values different
- * from built-in defaults.
-=======
  * Return an array of modified GUC options to show in EXPLAIN.
  *
  * We only report options related to query planning (marked with GUC_EXPLAIN),
  * with values different from their built-in defaults.
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
  */
 struct config_generic **
 get_explain_guc_options(int *num)
@@ -9516,65 +9510,8 @@ get_explain_guc_options(int *num)
 			 !is_member_of_role(GetUserId(), DEFAULT_ROLE_READ_ALL_SETTINGS)))
 			continue;
 
-<<<<<<< HEAD
-		/* only parameters explicitly marked for inclusion in explain */
-		if (!(conf->flags & GUC_EXPLAIN))
-			continue;
-
 		/* skip GUC variables that match the built-in default */
 		if (!is_guc_modified(conf))
-=======
-		/* return only options that are different from their boot values */
-		modified = false;
-
-		switch (conf->vartype)
-		{
-			case PGC_BOOL:
-				{
-					struct config_bool *lconf = (struct config_bool *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			case PGC_INT:
-				{
-					struct config_int *lconf = (struct config_int *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			case PGC_REAL:
-				{
-					struct config_real *lconf = (struct config_real *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			case PGC_STRING:
-				{
-					struct config_string *lconf = (struct config_string *) conf;
-
-					modified = (strcmp(lconf->boot_val, *(lconf->variable)) != 0);
-				}
-				break;
-
-			case PGC_ENUM:
-				{
-					struct config_enum *lconf = (struct config_enum *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			default:
-				elog(ERROR, "unexpected GUC type: %d", conf->vartype);
-		}
-
-		if (!modified)
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 			continue;
 
 		/* OK, report it */


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/misc/guc.c

1. Commit 3ec20c7091e9 updated the comment for the function
get_explain_guc_options(), while bd7453030e95 added a new function
is_guc_modified() before this comment.

2. Commit 3ec20c7091e9 updated part of code in get_explain_guc_options(),
while bd7453030e95 had also modified that part of code.