### PR TITLE
Resolve conflicts in src/backend/utils/adt/jsonb_util.c

### DIFF
--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -15,20 +15,12 @@
 
 #include "catalog/pg_collation.h"
 #include "catalog/pg_type.h"
-<<<<<<< HEAD
 #include "common/hashfn.h"
-#include "miscadmin.h"
-#include "utils/builtins.h"
-#include "utils/datetime.h"
-#include "utils/jsonapi.h"
-=======
 #include "common/jsonapi.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
 #include "utils/datetime.h"
-#include "utils/hashutils.h"
 #include "utils/json.h"
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 #include "utils/jsonb.h"
 #include "utils/memutils.h"
 #include "utils/varlena.h"


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/adt/jsonb_util.c

Commit ce0425b added the utils/json.h include to
src/backend/utils/adt/jsonb_util.c, and commit beb4699 renamed the
utils/jsonapi.h include to common/jsonapi.h. However, an earlier commit,
5d3dc2e, had already renamed the utils/hashutils.h include to common/hashfn.h.