### PR TITLE
Resolve conflicts in src/backend/utils/sort/logtape.c

### DIFF
--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -223,10 +223,7 @@ static long ltsGetPreallocBlock(LogicalTapeSet *lts, LogicalTape *lt);
 static void ltsReleaseBlock(LogicalTapeSet *lts, long blocknum);
 static void ltsConcatWorkerTapes(LogicalTapeSet *lts, TapeShare *shared,
 								 SharedFileSet *fileset);
-<<<<<<< HEAD
 static void ltsInitTape(LogicalTape *lt);
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 static void ltsInitReadBuffer(LogicalTapeSet *lts, LogicalTape *lt);
 
 char *
@@ -385,15 +382,9 @@ parent_offset(unsigned long i)
 static long
 ltsGetFreeBlock(LogicalTapeSet *lts)
 {
-<<<<<<< HEAD
-	long	   *heap = lts->freeBlocks;
-	long		blocknum;
-	int			heapsize;
-=======
 	long	*heap = lts->freeBlocks;
 	long	 blocknum;
 	int		 heapsize;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	unsigned long pos;
 
 	/* freelist empty; allocate a new block */
@@ -417,11 +408,7 @@ ltsGetFreeBlock(LogicalTapeSet *lts)
 	heapsize = lts->nFreeBlocks;
 	while (true)
 	{
-<<<<<<< HEAD
-		unsigned long left = left_offset(pos);
-=======
 		unsigned long left  = left_offset(pos);
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 		unsigned long right = right_offset(pos);
 		unsigned long min_child;
 
@@ -442,7 +429,6 @@ ltsGetFreeBlock(LogicalTapeSet *lts)
 	}
 
 	return blocknum;
-<<<<<<< HEAD
 }
 
 /*
@@ -482,8 +468,6 @@ ltsGetPreallocBlock(LogicalTapeSet *lts, LogicalTape *lt)
 	}
 
 	return lt->prealloc[--lt->nprealloc];
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 }
 
 /*
@@ -492,11 +476,7 @@ ltsGetPreallocBlock(LogicalTapeSet *lts, LogicalTape *lt)
 static void
 ltsReleaseBlock(LogicalTapeSet *lts, long blocknum)
 {
-<<<<<<< HEAD
-	long	   *heap;
-=======
 	long	*heap;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	unsigned long pos;
 
 	/*
@@ -533,10 +513,6 @@ ltsReleaseBlock(LogicalTapeSet *lts, long blocknum)
 	while (pos != 0)
 	{
 		unsigned long parent = parent_offset(pos);
-<<<<<<< HEAD
-
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 		if (heap[parent] < heap[pos])
 			break;
 
@@ -635,7 +611,6 @@ ltsConcatWorkerTapes(LogicalTapeSet *lts, TapeShare *shared,
 }
 
 /*
-<<<<<<< HEAD
  * Initialize per-tape struct.  Note we allocate the I/O buffer lazily.
  */
 static void
@@ -660,8 +635,6 @@ ltsInitTape(LogicalTape *lt)
 }
 
 /*
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
  * Lazily allocate and initialize the read buffer. This avoids waste when many
  * tapes are open at once, but not all are active between rewinding and
  * reading.
@@ -947,7 +920,6 @@ LogicalTapeRewindForRead(LogicalTapeSet *lts, int tapenum, size_t buffer_size)
 	/* the buffer is lazily allocated, but set the size here */
 	lt->buffer = NULL;
 	lt->buffer_size = buffer_size;
-<<<<<<< HEAD
 
 	/* free the preallocation list, and return unused block numbers */
 	if (lt->prealloc != NULL)
@@ -959,8 +931,6 @@ LogicalTapeRewindForRead(LogicalTapeSet *lts, int tapenum, size_t buffer_size)
 		lt->nprealloc = 0;
 		lt->prealloc_size = 0;
 	}
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 }
 
 /*


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/sort/logtape.c

1) Commit 7fdd919 added a new function ltsInitReadBuffer to
src/backend/utils/sort/logtape.c, which was already done by commit 19cd1cf.

2) Commit c02fdc9 added new local variables heap, blocknum, heapsize, and left
to the function ltsGetFreeBlock in src/backend/utils/sort/logtape.c, which was
already done by commit 19cd1cf, but with different indentations.

3) Commit c02fdc9 changed the end of the ltsGetFreeBlock function in
src/backend/utils/sort/logtape.c, while the earlier commit 19cd1cf had already
added the new ltsGetPreallocBlock function afterward.

4) Commit c02fdc9 added new local variables heap and parent to the
ltsReleaseBlock function in src/backend/utils/sort/logtape.c, while the earlier
commit 19cd1cf had already done this, but with different indentation.

5) Commit 7fdd919 removed some code at the end of the LogicalTapeRewindForRead
function in src/backend/utils/sort/logtape.c, while the earlier commit 19cd1cf
had already added other code to the same location.