### PR TITLE
Resolve conflicts in src/backend/catalog/.gitignore and src/bin/psql/.gitignore

### DIFF
--- a/src/backend/catalog/.gitignore
+++ b/src/backend/catalog/.gitignore
@@ -1,10 +1,7 @@
 /postgres.bki
-<<<<<<< HEAD
 /postgres.description
 /postgres.shdescription
 /cdb_init.sql
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 /schemapg.h
 /pg_*_d.h
 /gp_*_d.h

--- a/src/backend/catalog/.gitignore
+++ b/src/backend/catalog/.gitignore
@@ -1,6 +1,4 @@
 /postgres.bki
-/postgres.description
-/postgres.shdescription
 /cdb_init.sql
 /schemapg.h
 /pg_*_d.h

--- a/src/bin/psql/.gitignore
+++ b/src/bin/psql/.gitignore
@@ -1,13 +1,9 @@
 /psqlscanslash.c
 /sql_help.h
 /sql_help.c
-<<<<<<< HEAD
 /dumputils.c
 /keywords.c
 /kwlookup.c
 /lex.backup
-
-=======
->>>>>>> 1281a5c907b41e992a66deb13c3aa61888a62268
 /psql
 /tmp_check/


### PR DESCRIPTION
Resolve conflicts in src/backend/catalog/.gitignore and src/bin/psql/.gitignore

1) Commit 7aaefad removed the /postgres.description and /postgres.shdescription
lines from src/backend/catalog/.gitignore, while an earlier commit, 6b0e52b,
had already added GPDB-specific lines to the same location.

2) Commit 7c01504 removed the empty line from src/bin/psql/.gitignore and added
the /tmp_check/ line, while an earlier commit, 6b0e52b, had already added
GPDB-specific lines to the same location.