### PR TITLE
Resolve conflicts in src/test/regress/pg_regress.c

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -90,13 +90,9 @@ char	   *exclude_tests_file = "";
 char	   *prehook = "";
 char	   *bindir = PGBINDIR;
 char	   *launcher = NULL;
-<<<<<<< HEAD
 bool        print_failure_diffs_is_enabled = false;
 bool 		optimizer_enabled = false;
 bool 		resgroup_enabled = false;
-static _stringlist *loadlanguage = NULL;
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 static _stringlist *loadextension = NULL;
 static int	max_connections = 0;
 static int	max_concurrent_tests = 0;


### PR DESCRIPTION
Resolve conflicts in src/test/regress/pg_regress.c

Commit 751c63c removed the global variable loadlanguage from
src/test/regress/pg_regress.c, while earlier commits b536501, 6b0e52b, and
e1eed83 had already added the GPDB-specific global variables
print_failure_diffs_is_enabled, optimizer_enabled, and resgroup_enabled to the
same location.