### PR TITLE
Resolve conflicts in src/test/isolation/isolation_schedule

### DIFF
--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -86,20 +86,11 @@ test: deadlock-soft-2
 #test: lock-update-delete
 #test: lock-update-traversal
 test: inherit-temp
-<<<<<<< HEAD
 #test: insert-conflict-do-nothing
 #test: insert-conflict-do-nothing-2
 #test: insert-conflict-do-update
 #test: insert-conflict-do-update-2
 #test: insert-conflict-do-update-3
-test: insert-conflict-toast
-=======
-test: insert-conflict-do-nothing
-test: insert-conflict-do-nothing-2
-test: insert-conflict-do-update
-test: insert-conflict-do-update-2
-test: insert-conflict-do-update-3
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 test: insert-conflict-specconflict
 test: delete-abort-savept
 #test: delete-abort-savept-2


### PR DESCRIPTION
Resolve conflicts in src/test/isolation/isolation_schedule

Commit 43e0841 removed the insert-conflict-toast test from
src/test/isolation/isolation_schedule, while the earlier commit 8ae22d1 had
already disabled most of the tests nearby.