### PR TITLE
Resolve conflicts in src/tools/msvc/Mkvcbuild.pm

### DIFF
--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -122,14 +122,9 @@ sub mkvcbuild
 	}
 
 	our @pgcommonallfiles = qw(
-<<<<<<< HEAD
-	  base64.c config_info.c controldata_utils.c d2s.c exec.c f2s.c file_perm.c
-	  hashfn.c ip.c keywords.c kwlookup.c link-canary.c md5.c
-=======
 	  base64.c config_info.c controldata_utils.c d2s.c encnames.c exec.c
-	  f2s.c file_perm.c ip.c jsonapi.c
+	  f2s.c file_perm.c hashfn.c ip.c jsonapi.c
 	  keywords.c kwlookup.c link-canary.c md5.c
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	  pg_lzcompress.c pgfnames.c psprintf.c relpath.c rmtree.c
 	  saslprep.c scram-common.c string.c stringinfo.c unicode_norm.c username.c
 	  wait_error.c wchar.c);


### PR DESCRIPTION
Resolve conflicts in src/tools/msvc/Mkvcbuild.pm

Commit e6afa89 added encnames.c, and commit 006b9dc added jsonapi.c in
src/tools/msvc/Mkvcbuild.pm to the pgcommonallfiles variable. However, the
earlier commit 5d3dc2e had already added hashfn.c to the same variable.