### PR TITLE
Resolve conflicts in doc/src/sgml/ref/grant.sgml

### DIFF
--- a/doc/src/sgml/ref/grant.sgml
+++ b/doc/src/sgml/ref/grant.sgml
@@ -89,15 +89,6 @@ GRANT <replaceable class="parameter">role_name</replaceable> [, ...] TO <replace
   | PUBLIC
   | CURRENT_USER
   | SESSION_USER
-<<<<<<< HEAD
-
-GRANT <replaceable class="parameter">role_name</replaceable> [, ...] TO <replaceable class="parameter">role_name</replaceable> [, ...] [ WITH ADMIN OPTION ]
-
-GRANT { SELECT | INSERT | ALL [PRIVILEGES] } 
-    ON PROTOCOL <replaceable>protocolname</replaceable>
-    TO <replaceable class="parameter">username</replaceable>
-=======
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 </synopsis>
  </refsynopsisdiv>
 


### PR DESCRIPTION
Resolve conflicts in doc/src/sgml/ref/grant.sgml

Commit dce9881 reformatted the GRANT TO option documentation in
doc/src/sgml/ref/grant.sgml, although earlier commits 6b0e52b and 675ac58 had
already added GPDB-specific documentation to this location. Remove
GPDB-specific documentation, as it is maintained by a separate project.