### PR TITLE
Resolve conflicts in src/test/perl/PostgresNode.pm

### DIFF
--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -731,11 +731,7 @@ sub init_from_backup
 
 	$params{has_streaming} = 0 unless defined $params{has_streaming};
 	$params{has_restoring} = 0 unless defined $params{has_restoring};
-<<<<<<< HEAD
-	$params{standby}       = 1 unless defined $params{standby};
-=======
 	$params{standby} = 1 unless defined $params{standby};
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 
 	print
 	  "# Initializing node \"$node_name\" from backup \"$backup_name\" of node \"$root_name\"\n";
@@ -766,12 +762,7 @@ port = $port
 			"unix_socket_directories = '$host'");
 	}
 	$self->enable_streaming($root_node) if $params{has_streaming};
-<<<<<<< HEAD
-	$self->enable_restoring($root_node, $params{standby})
-	  if $params{has_restoring};
-=======
 	$self->enable_restoring($root_node, $params{standby}) if $params{has_restoring};
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 	return;
 }
 
@@ -1048,17 +1039,10 @@ restore_command = '$copy_command'
 
 =pod
 
-<<<<<<< HEAD
-
-=item $node->set_recovery_mode()
-
-Place recovery.signal file.
-=======
 =item $node->set_recovery_mode()
 
 Place recovery.signal file.
 
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 =cut
 
 sub set_recovery_mode


### PR DESCRIPTION
Resolve conflicts in src/test/perl/PostgresNode.pm

1) Commit dc78866 added the init_from_backup function to the standby parameters
in src/test/perl/PostgresNode.pm, which was already done by commit 7bc7f6d.

2) Commit dc78866 added a call to the set_recovery_mode function in
src/test/perl/PostgresNode.pm, which was already done by commit 7bc7f6d.