### PR TITLE
Fix compilation in src/backend/commands/explain.c

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2748,8 +2748,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		case T_Sequence:
 			ExplainMemberNodes(((SequenceState *) planstate)->subplans,
 							   ((SequenceState *) planstate)->numSubplans,
-							   list_length(((Sequence *) plan)->subplans),
-										   ancestors, es);
+							   ancestors, es);
 			break;
 		case T_BitmapAnd:
 			ExplainMemberNodes(((BitmapAndState *) planstate)->bitmapplans,


### PR DESCRIPTION
Fix compilation in src/backend/commands/explain.c

Commit 7d91b60 removed the nsubnodes argument in the ExplainMemberNodes
function in src/backend/commands/explain.c, while an earlier commit, 5ec5c30,
added handling for the GPDB-specific T_Sequence case to the ExplainNode
function.