### PR TITLE
Fix compilation in src/backend/utils/hash/dynahash.c

### DIFF
--- a/src/backend/utils/hash/dynahash.c
+++ b/src/backend/utils/hash/dynahash.c
@@ -90,7 +90,6 @@
 #include "storage/shmem.h"
 #include "storage/spin.h"
 #include "utils/dynahash.h"
-#include "utils/hashutils.h"
 #include "utils/memutils.h"
 
 


### PR DESCRIPTION
Fix compilation in src/backend/utils/hash/dynahash.c

Commit 9341c78 added the utils/hashutils.h include to
src/backend/utils/hash/dynahash.c, although the earlier commit 5d3dc2e had
already renamed this include to common/hashfn.h.