### PR TITLE
Fix compilation in src/backend/replication/basebackup.c and src/bin/p…

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -235,7 +235,7 @@ static const struct exclude_list_item excludeFiles[] =
 	{"postmaster.opts", false},
 
 	/* GPDB: Default gpbackup directory (top-level directory) */
-	"backups",
+	{"backups", false},
 
 	/* end of list */
 	{NULL, false}

--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -125,10 +125,10 @@ static const struct exclude_list_item excludeFiles[] =
 	{"postmaster.pid", false},
 	{"postmaster.opts", false},
 
-	GP_INTERNAL_AUTO_CONF_FILE_NAME,
+	{GP_INTERNAL_AUTO_CONF_FILE_NAME, false},
 
 	/* GPDB: Default gpbackup directory (top-level directory) */
-	"backups",
+	{"backups", false},
 
 	/* end of list */
 	{NULL, false}


### PR DESCRIPTION
Fix compilation in src/backend/replication/basebackup.c and src/bin/pg_rewind/filemap.c

Commit bf883b2 changed the excludeFiles array type in
src/backend/replication/basebackup.c and src/bin/pg_rewind/filemap.c. Earlier
commits b56a317 and 1a18639 had already added GPDB-specific "backups" values
to these arrays, and earlier commit c238563 had already added the
GP_INTERNAL_AUTO_CONF_FILE_NAME value to these arrays.