### PR TITLE
Fix startup in src/include/utils/unsync_guc_name.h

### DIFF
--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -141,6 +141,7 @@
 		"extra_float_digits",
 		"from_collapse_limit",
 		"fsync",
+		"ignore_invalid_pages",
 		"full_page_writes",
 		"geqo",
 		"geqo_effort",


### PR DESCRIPTION
Fix startup in src/include/utils/unsync_guc_name.h

Commit 41c184b added a new GUC, ignore_invalid_pages, to
src/backend/utils/misc/guc.c. It should be added to the unsync_guc_names_array
array in the GPDB.