### PR TITLE
Fix tests in src/test/regress/expected/create_index.out

### DIFF
--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -2756,18 +2756,22 @@ CREATE TEMP TABLE concur_temp_tab_1 (c1 int, c2 text)
 INSERT INTO concur_temp_tab_1 VALUES (1, 'foo'), (2, 'bar');
 CREATE INDEX concur_temp_ind_1 ON concur_temp_tab_1(c2);
 REINDEX TABLE CONCURRENTLY concur_temp_tab_1;
+ERROR:  REINDEX CONCURRENTLY is not supported
 REINDEX INDEX CONCURRENTLY concur_temp_ind_1;
+ERROR:  REINDEX CONCURRENTLY is not supported
 -- Still fails in transaction blocks
 BEGIN;
 REINDEX INDEX CONCURRENTLY concur_temp_ind_1;
-ERROR:  REINDEX CONCURRENTLY cannot run inside a transaction block
+ERROR:  REINDEX CONCURRENTLY is not supported
 COMMIT;
 -- ON COMMIT DELETE ROWS
 CREATE TEMP TABLE concur_temp_tab_2 (c1 int, c2 text)
   ON COMMIT DELETE ROWS;
 CREATE INDEX concur_temp_ind_2 ON concur_temp_tab_2(c2);
 REINDEX TABLE CONCURRENTLY concur_temp_tab_2;
+ERROR:  REINDEX CONCURRENTLY is not supported
 REINDEX INDEX CONCURRENTLY concur_temp_ind_2;
+ERROR:  REINDEX CONCURRENTLY is not supported
 -- ON COMMIT DROP
 BEGIN;
 CREATE TEMP TABLE concur_temp_tab_3 (c1 int, c2 text)
@@ -2776,7 +2780,7 @@ INSERT INTO concur_temp_tab_3 VALUES (1, 'foo'), (2, 'bar');
 CREATE INDEX concur_temp_ind_3 ON concur_temp_tab_3(c2);
 -- Fails when running in a transaction
 REINDEX INDEX CONCURRENTLY concur_temp_ind_3;
-ERROR:  REINDEX CONCURRENTLY cannot run inside a transaction block
+ERROR:  REINDEX CONCURRENTLY is not supported
 COMMIT;
 -- REINDEX SCHEMA processes all temporary relations
 CREATE TABLE reindex_temp_before AS
@@ -2785,16 +2789,17 @@ SELECT oid, relname, relfilenode, relkind, reltoastrelid
   WHERE relname IN ('concur_temp_ind_1', 'concur_temp_ind_2');
 SELECT pg_my_temp_schema()::regnamespace as temp_schema_name \gset
 REINDEX SCHEMA CONCURRENTLY :temp_schema_name;
+ERROR:  REINDEX CONCURRENTLY is not supported
 SELECT  b.relname,
         b.relkind,
         CASE WHEN a.relfilenode = b.relfilenode THEN 'relfilenode is unchanged'
         ELSE 'relfilenode has changed' END
   FROM reindex_temp_before b JOIN pg_class a ON b.oid = a.oid
   ORDER BY 1;
-      relname      | relkind |          case           
--------------------+---------+-------------------------
- concur_temp_ind_1 | i       | relfilenode has changed
- concur_temp_ind_2 | i       | relfilenode has changed
+      relname      | relkind |           case           
+-------------------+---------+--------------------------
+ concur_temp_ind_1 | i       | relfilenode is unchanged
+ concur_temp_ind_2 | i       | relfilenode is unchanged
 (2 rows)
 
 DROP TABLE concur_temp_tab_1, concur_temp_tab_2, reindex_temp_before;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -2757,6 +2757,60 @@ SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
 (1 row)
 
 DROP TABLE concur_exprs_tab;
+-- Temporary tables and on-commit actions, where CONCURRENTLY is ignored.
+-- ON COMMIT PRESERVE ROWS, the default.
+CREATE TEMP TABLE concur_temp_tab_1 (c1 int, c2 text)
+  ON COMMIT PRESERVE ROWS;
+INSERT INTO concur_temp_tab_1 VALUES (1, 'foo'), (2, 'bar');
+CREATE INDEX concur_temp_ind_1 ON concur_temp_tab_1(c2);
+REINDEX TABLE CONCURRENTLY concur_temp_tab_1;
+ERROR:  REINDEX CONCURRENTLY is not supported
+REINDEX INDEX CONCURRENTLY concur_temp_ind_1;
+ERROR:  REINDEX CONCURRENTLY is not supported
+-- Still fails in transaction blocks
+BEGIN;
+REINDEX INDEX CONCURRENTLY concur_temp_ind_1;
+ERROR:  REINDEX CONCURRENTLY is not supported
+COMMIT;
+-- ON COMMIT DELETE ROWS
+CREATE TEMP TABLE concur_temp_tab_2 (c1 int, c2 text)
+  ON COMMIT DELETE ROWS;
+CREATE INDEX concur_temp_ind_2 ON concur_temp_tab_2(c2);
+REINDEX TABLE CONCURRENTLY concur_temp_tab_2;
+ERROR:  REINDEX CONCURRENTLY is not supported
+REINDEX INDEX CONCURRENTLY concur_temp_ind_2;
+ERROR:  REINDEX CONCURRENTLY is not supported
+-- ON COMMIT DROP
+BEGIN;
+CREATE TEMP TABLE concur_temp_tab_3 (c1 int, c2 text)
+  ON COMMIT PRESERVE ROWS;
+INSERT INTO concur_temp_tab_3 VALUES (1, 'foo'), (2, 'bar');
+CREATE INDEX concur_temp_ind_3 ON concur_temp_tab_3(c2);
+-- Fails when running in a transaction
+REINDEX INDEX CONCURRENTLY concur_temp_ind_3;
+ERROR:  REINDEX CONCURRENTLY is not supported
+COMMIT;
+-- REINDEX SCHEMA processes all temporary relations
+CREATE TABLE reindex_temp_before AS
+SELECT oid, relname, relfilenode, relkind, reltoastrelid
+  FROM pg_class
+  WHERE relname IN ('concur_temp_ind_1', 'concur_temp_ind_2');
+SELECT pg_my_temp_schema()::regnamespace as temp_schema_name \gset
+REINDEX SCHEMA CONCURRENTLY :temp_schema_name;
+ERROR:  REINDEX CONCURRENTLY is not supported
+SELECT  b.relname,
+        b.relkind,
+        CASE WHEN a.relfilenode = b.relfilenode THEN 'relfilenode is unchanged'
+        ELSE 'relfilenode has changed' END
+  FROM reindex_temp_before b JOIN pg_class a ON b.oid = a.oid
+  ORDER BY 1;
+      relname      | relkind |           case           
+-------------------+---------+--------------------------
+ concur_temp_ind_1 | i       | relfilenode is unchanged
+ concur_temp_ind_2 | i       | relfilenode is unchanged
+(2 rows)
+
+DROP TABLE concur_temp_tab_1, concur_temp_tab_2, reindex_temp_before;
 --
 -- REINDEX SCHEMA
 --


### PR DESCRIPTION
Fix tests in src/test/regress/expected/create_index.out

Commit a904abe added new tests to src/test/regress/sql/create_index.sql, but
concurrent index updates are not supported in GPDB. Add the new test output for
ORCA.