### PR TITLE
Fix tests in src/test/regress/expected/brin.out

### DIFF
--- a/src/test/regress/expected/brin.out
+++ b/src/test/regress/expected/brin.out
@@ -510,10 +510,7 @@ SELECT brin_summarize_range('brin_summarize_idx', 4294967295);
 SELECT brin_summarize_range('brin_summarize_idx', -1);
 ERROR:  block number out of range: -1  (seg0 slice1 127.0.0.1:7002 pid=11998)
 SELECT brin_summarize_range('brin_summarize_idx', 4294967296);
-<<<<<<< HEAD
 ERROR:  block number out of range: 4294967296  (seg0 slice1 127.0.0.1:7002 pid=11998)
-=======
-ERROR:  block number out of range: 4294967296
 -- test value merging in add_value
 CREATE TABLE brintest_2 (n numrange);
 CREATE INDEX brinidx_2 ON brintest_2 USING brin (n);
@@ -527,13 +524,9 @@ SELECT brin_desummarize_range('brinidx', 0);
 (1 row)
 
 SELECT brin_summarize_range('brinidx', 0);
- brin_summarize_range 
-----------------------
-                    1
-(1 row)
-
+ERROR:  Greenplum could not summarize indicated page range
+CONTEXT:  SQL function "brin_summarize_range" statement 1
 DROP TABLE brintest_2;
->>>>>>> a91e2fa94180f24dd68fb6c99136cda820e02089
 -- test brin cost estimates behave sanely based on correlation of values
 -- GPDB: use more rows, and a larger statistics sample, to get the same plan
 -- as in upstream.

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -529,6 +529,21 @@ SELECT brin_summarize_range('brin_summarize_idx', -1);
 ERROR:  block number out of range: -1  (seg0 slice1 127.0.0.1:7002 pid=11998)
 SELECT brin_summarize_range('brin_summarize_idx', 4294967296);
 ERROR:  block number out of range: 4294967296  (seg0 slice1 127.0.0.1:7002 pid=11998)
+-- test value merging in add_value
+CREATE TABLE brintest_2 (n numrange);
+CREATE INDEX brinidx_2 ON brintest_2 USING brin (n);
+INSERT INTO brintest_2 VALUES ('empty');
+INSERT INTO brintest_2 VALUES (numrange(0, 2^1000::numeric));
+INSERT INTO brintest_2 VALUES ('(-1, 0)');
+SELECT brin_desummarize_range('brinidx', 0);
+ brin_desummarize_range 
+------------------------
+ 
+(1 row)
+
+SELECT brin_summarize_range('brinidx', 0);
+ERROR:  Greenplum could not summarize indicated page range
+DROP TABLE brintest_2;
 -- test brin cost estimates behave sanely based on correlation of values
 -- GPDB: use more rows, and a larger statistics sample, to get the same plan
 -- as in upstream.


### PR DESCRIPTION
Fix tests in src/test/regress/expected/brin.out

Commit 611ce85 added new tests to src/test/regress/sql/brin.sql, but the GPDB
could not summarize the indicated page range. Add the new test output for ORCA.