### PR TITLE
Fix linking error for the unit tests

### DIFF
--- a/src/backend/mock.mk
+++ b/src/backend/mock.mk
@@ -48,7 +48,6 @@ EXCL_OBJS+=\
 	src/backend/utils/adt/geo_selfuncs.o \
 	src/backend/utils/adt/gp_optimizer_functions.o \
 	src/backend/utils/adt/interpolate.o \
-	src/backend/utils/adt/jsonfuncs.o \
 	src/backend/utils/adt/like.o \
 	src/backend/utils/adt/like_match.o \
 	src/backend/utils/adt/mac.o \


### PR DESCRIPTION
Fix linking error for the unit tests

Commit 73ce2a03f30b moved some functions from jsonapi.c to jsonfuncs.c. File
jsonfuncs.o was excluded from linking of unit tests, which caused error. This
patch enables linking for jsonfuncs.o.