### PR TITLE
Fix 'gin' regress test

### DIFF
--- a/src/test/regress/expected/gin.out
+++ b/src/test/regress/expected/gin.out
@@ -41,6 +41,11 @@ insert into gin_test_tbl select array[1, 3, g] from generate_series(1, 1000) g;
 delete from gin_test_tbl where i @> array[2];
 vacuum gin_test_tbl;
 -- Test optimization of empty queries
+-- In a plan Orca can invert the order of operands in condition, so use matchsubs to fix it.
+-- start_matchsubs
+-- m/Recheck Cond: \(i @> '\{0\}'::integer\[\]\)/
+-- s/Recheck Cond: \(i @> '\{0\}'::integer\[\]\)/Recheck Cond: \('\{0\}'::integer\[\] <@ i\)/
+-- end_matchsubs
 create temp table t_gin_test_tbl(i int4[], j int4[]);
 create index on t_gin_test_tbl using gin (i, j);
 insert into t_gin_test_tbl
@@ -58,13 +63,15 @@ values
 set enable_seqscan = off;
 explain (costs off)
 select * from t_gin_test_tbl where array[0] <@ i;
-                    QUERY PLAN                     
----------------------------------------------------
- Bitmap Heap Scan on t_gin_test_tbl
-   Recheck Cond: ('{0}'::integer[] <@ i)
-   ->  Bitmap Index Scan on t_gin_test_tbl_i_j_idx
-         Index Cond: (i @> '{0}'::integer[])
-(4 rows)
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on t_gin_test_tbl
+         Recheck Cond: ('{0}'::integer[] <@ i)
+         ->  Bitmap Index Scan on t_gin_test_tbl_i_j_idx
+               Index Cond: (i @> '{0}'::integer[])
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select * from t_gin_test_tbl where array[0] <@ i;
  i | j 
@@ -78,13 +85,15 @@ select * from t_gin_test_tbl where array[0] <@ i and '{}'::int4[] <@ j;
 
 explain (costs off)
 select * from t_gin_test_tbl where i @> '{}';
-                    QUERY PLAN                     
----------------------------------------------------
- Bitmap Heap Scan on t_gin_test_tbl
-   Recheck Cond: (i @> '{}'::integer[])
-   ->  Bitmap Index Scan on t_gin_test_tbl_i_j_idx
-         Index Cond: (i @> '{}'::integer[])
-(4 rows)
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on t_gin_test_tbl
+         Recheck Cond: (i @> '{}'::integer[])
+         ->  Bitmap Index Scan on t_gin_test_tbl_i_j_idx
+               Index Cond: (i @> '{}'::integer[])
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select * from t_gin_test_tbl where i @> '{}';
    i   |  j   
@@ -133,8 +142,8 @@ $$;
 -- check number of rows returned by index and removed by recheck
 select
   query,
-  js->0->'Plan'->'Plans'->0->'Actual Rows' as "return by index",
-  js->0->'Plan'->'Rows Removed by Index Recheck' as "removed by recheck",
+  js->0->'Plan'->'Actual Rows' as "return by index",
+  js->0->'Plan'->'Plans'->0->'Rows Removed by Index Recheck' as "removed by recheck",
   (res_index = res_heap) as "match"
 from
   (values
@@ -150,8 +159,8 @@ from
     ($$ i @> '{1}' and j @> '{10}' $$)
   ) q(query),
   lateral explain_query_json($$select * from t_gin_test_tbl where $$ || query) js,
-  lateral execute_text_query_index($$select string_agg((i, j)::text, ' ') from t_gin_test_tbl where $$ || query) res_index,
-  lateral execute_text_query_heap($$select string_agg((i, j)::text, ' ') from t_gin_test_tbl where $$ || query) res_heap;
+  lateral execute_text_query_index($$select string_agg((i, j)::text, ' ' order by i,j) from t_gin_test_tbl where $$ || query) res_index,
+  lateral execute_text_query_heap($$select string_agg((i, j)::text, ' ' order by i,j) from t_gin_test_tbl where $$ || query) res_heap;
                    query                   | return by index | removed by recheck | match 
 -------------------------------------------+-----------------+--------------------+-------
   i @> '{}'                                | 7               | 0                  | t

--- a/src/test/regress/sql/gin.sql
+++ b/src/test/regress/sql/gin.sql
@@ -37,6 +37,11 @@ delete from gin_test_tbl where i @> array[2];
 vacuum gin_test_tbl;
 
 -- Test optimization of empty queries
+-- In a plan Orca can invert the order of operands in condition, so use matchsubs to fix it.
+-- start_matchsubs
+-- m/Recheck Cond: \(i @> '\{0\}'::integer\[\]\)/
+-- s/Recheck Cond: \(i @> '\{0\}'::integer\[\]\)/Recheck Cond: \('\{0\}'::integer\[\] <@ i\)/
+-- end_matchsubs
 create temp table t_gin_test_tbl(i int4[], j int4[]);
 create index on t_gin_test_tbl using gin (i, j);
 insert into t_gin_test_tbl
@@ -100,8 +105,8 @@ $$;
 -- check number of rows returned by index and removed by recheck
 select
   query,
-  js->0->'Plan'->'Plans'->0->'Actual Rows' as "return by index",
-  js->0->'Plan'->'Rows Removed by Index Recheck' as "removed by recheck",
+  js->0->'Plan'->'Actual Rows' as "return by index",
+  js->0->'Plan'->'Plans'->0->'Rows Removed by Index Recheck' as "removed by recheck",
   (res_index = res_heap) as "match"
 from
   (values
@@ -117,8 +122,8 @@ from
     ($$ i @> '{1}' and j @> '{10}' $$)
   ) q(query),
   lateral explain_query_json($$select * from t_gin_test_tbl where $$ || query) js,
-  lateral execute_text_query_index($$select string_agg((i, j)::text, ' ') from t_gin_test_tbl where $$ || query) res_index,
-  lateral execute_text_query_heap($$select string_agg((i, j)::text, ' ') from t_gin_test_tbl where $$ || query) res_heap;
+  lateral execute_text_query_index($$select string_agg((i, j)::text, ' ' order by i,j) from t_gin_test_tbl where $$ || query) res_index,
+  lateral execute_text_query_heap($$select string_agg((i, j)::text, ' ' order by i,j) from t_gin_test_tbl where $$ || query) res_heap;
 
 reset enable_seqscan;
 reset enable_bitmapscan;


### PR DESCRIPTION
Fix 'gin' regress test

Commit 4b754d6c16e1 added new test cases to 'gin' test. These new test cases
failed on GPDB. This patch:
 - updates the output of explain command (as the plan on GPDB contains 'gather'
motion);
 - updates json handling in the test query, when data is retrieved from the json
explain output (as the structure of plan is different in GPDB);
 - adds sorting inside string_agg in the test query, otherwise its output is not
stable;
 - adds matchsubs to handle plans created by Orca.