### PR TITLE
Fix 'tsearch' regress test

### DIFF
--- a/src/test/regress/expected/tsearch.out
+++ b/src/test/regress/expected/tsearch.out
@@ -350,14 +350,17 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
 -- Test optimization of non-empty GIN_SEARCH_MODE_ALL queries
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
-                     QUERY PLAN                      
------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on test_tsvector
-         Recheck Cond: (a @@ '!''qh'''::tsquery)
-         ->  Bitmap Index Scan on wowidx
-               Index Cond: (a @@ '!''qh'''::tsquery)
-(5 rows)
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_tsvector
+                     Recheck Cond: (a @@ '!''qh'''::tsquery)
+                     ->  Bitmap Index Scan on wowidx
+                           Index Cond: (a @@ '!''qh'''::tsquery)
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
  count 
@@ -367,14 +370,17 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr' AND a @@ '!qh';
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on test_tsvector
-         Recheck Cond: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
-         ->  Bitmap Index Scan on wowidx
-               Index Cond: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
-(5 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_tsvector
+                     Recheck Cond: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
+                     ->  Bitmap Index Scan on wowidx
+                           Index Cond: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr' AND a @@ '!qh';
  count 

--- a/src/test/regress/expected/tsearch_optimizer.out
+++ b/src/test/regress/expected/tsearch_optimizer.out
@@ -345,6 +345,43 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
    508
 (1 row)
 
+-- Test optimization of non-empty GIN_SEARCH_MODE_ALL queries
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_tsvector
+                     Filter: (a @@ '!''qh'''::tsquery)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
+ count 
+-------
+   410
+(1 row)
+
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM test_tsvector WHERE a @@ 'wr' AND a @@ '!qh';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on test_tsvector
+                     Filter: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'wr' AND a @@ '!qh';
+ count 
+-------
+    60
+(1 row)
+
 RESET enable_seqscan;
 INSERT INTO test_tsvector VALUES ('???', 'DFG:1A,2B,6C,10 FGH');
 SELECT * FROM ts_stat('SELECT a FROM test_tsvector') ORDER BY ndoc DESC, nentry DESC, word LIMIT 10;


### PR DESCRIPTION
Fix 'tsearch' regress test

Commit 4b754d6c16e1 added new test cases into 'tsearch' regress test. The test
failed on GPDB due to different explain output of these new test cases. This
patch updates explain output for them and adds explain output into
'tsearch_optimizer.out' file.