### PR TITLE
Fix tests in src/test/regress/expected/vacuum.out

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -191,8 +191,11 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("VACUUM option \"%s\"not supported in GPDB", opt->defname),
+					 errmsg("VACUUM option \"parallel\" not supported in GPDB"),
 					 parser_errposition(pstate, opt->location)));
+
+#if 0
+			/* VACUUM option "parallel" not supported in GPDB */
 
 			parallel_option = true;
 			if (opt->arg == NULL)
@@ -224,6 +227,9 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 				else
 					params.nworkers = nworkers;
 			}
+
+#endif
+
 		}
 		else
 			ereport(ERROR,

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -189,6 +189,11 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 		}
 		else if (strcmp(opt->defname, "parallel") == 0)
 		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("VACUUM option \"%s\"not supported in GPDB", opt->defname),
+					 parser_errposition(pstate, opt->location)));
+
 			parallel_option = true;
 			if (opt->arg == NULL)
 			{

--- a/src/test/regress/expected/vacuum.out
+++ b/src/test/regress/expected/vacuum.out
@@ -105,26 +105,42 @@ CREATE INDEX spgist_pvactst ON pvactst USING spgist (p);
 -- VACUUM invokes parallel index cleanup
 SET min_parallel_index_scan_size to 0;
 VACUUM (PARALLEL 2) pvactst;
+ERROR:  VACUUM option "parallel"not supported in GPDB
+LINE 1: VACUUM (PARALLEL 2) pvactst;
+                ^
 -- VACUUM invokes parallel bulk-deletion
 UPDATE pvactst SET i = i WHERE i < 1000;
 VACUUM (PARALLEL 2) pvactst;
+ERROR:  VACUUM option "parallel"not supported in GPDB
+LINE 1: VACUUM (PARALLEL 2) pvactst;
+                ^
 UPDATE pvactst SET i = i WHERE i < 1000;
 VACUUM (PARALLEL 0) pvactst; -- disable parallel vacuum
+ERROR:  VACUUM option "parallel"not supported in GPDB
+LINE 1: VACUUM (PARALLEL 0) pvactst;
+                ^
 VACUUM (PARALLEL -1) pvactst; -- error
-ERROR:  parallel vacuum degree must be between 0 and 1024
+ERROR:  VACUUM option "parallel"not supported in GPDB
 LINE 1: VACUUM (PARALLEL -1) pvactst;
                 ^
 VACUUM (PARALLEL 2, INDEX_CLEANUP FALSE) pvactst;
+ERROR:  VACUUM option "parallel"not supported in GPDB
+LINE 1: VACUUM (PARALLEL 2, INDEX_CLEANUP FALSE) pvactst;
+                ^
 VACUUM (PARALLEL 2, FULL TRUE) pvactst; -- error, cannot use both PARALLEL and FULL
-ERROR:  cannot specify both FULL and PARALLEL options
+ERROR:  VACUUM option "parallel"not supported in GPDB
+LINE 1: VACUUM (PARALLEL 2, FULL TRUE) pvactst;
+                ^
 VACUUM (PARALLEL) pvactst; -- error, cannot use PARALLEL option without parallel degree
-ERROR:  parallel option requires a value between 0 and 1024
+ERROR:  VACUUM option "parallel"not supported in GPDB
 LINE 1: VACUUM (PARALLEL) pvactst;
                 ^
 CREATE TEMPORARY TABLE tmp (a int PRIMARY KEY);
 CREATE INDEX tmp_idx1 ON tmp (a);
 VACUUM (PARALLEL 1) tmp; -- disables parallel vacuum option
-WARNING:  disabling parallel option of vacuum on "tmp" --- cannot vacuum temporary tables in parallel
+ERROR:  VACUUM option "parallel"not supported in GPDB
+LINE 1: VACUUM (PARALLEL 1) tmp;
+                ^
 RESET min_parallel_index_scan_size;
 DROP TABLE pvactst;
 -- INDEX_CLEANUP option

--- a/src/test/regress/expected/vacuum.out
+++ b/src/test/regress/expected/vacuum.out
@@ -105,40 +105,40 @@ CREATE INDEX spgist_pvactst ON pvactst USING spgist (p);
 -- VACUUM invokes parallel index cleanup
 SET min_parallel_index_scan_size to 0;
 VACUUM (PARALLEL 2) pvactst;
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 2) pvactst;
                 ^
 -- VACUUM invokes parallel bulk-deletion
 UPDATE pvactst SET i = i WHERE i < 1000;
 VACUUM (PARALLEL 2) pvactst;
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 2) pvactst;
                 ^
 UPDATE pvactst SET i = i WHERE i < 1000;
 VACUUM (PARALLEL 0) pvactst; -- disable parallel vacuum
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 0) pvactst;
                 ^
 VACUUM (PARALLEL -1) pvactst; -- error
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL -1) pvactst;
                 ^
 VACUUM (PARALLEL 2, INDEX_CLEANUP FALSE) pvactst;
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 2, INDEX_CLEANUP FALSE) pvactst;
                 ^
 VACUUM (PARALLEL 2, FULL TRUE) pvactst; -- error, cannot use both PARALLEL and FULL
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 2, FULL TRUE) pvactst;
                 ^
 VACUUM (PARALLEL) pvactst; -- error, cannot use PARALLEL option without parallel degree
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL) pvactst;
                 ^
 CREATE TEMPORARY TABLE tmp (a int PRIMARY KEY);
 CREATE INDEX tmp_idx1 ON tmp (a);
 VACUUM (PARALLEL 1) tmp; -- disables parallel vacuum option
-ERROR:  VACUUM option "parallel"not supported in GPDB
+ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 1) tmp;
                 ^
 RESET min_parallel_index_scan_size;


### PR DESCRIPTION
Fix tests in src/test/regress/expected/vacuum.out

Commit 40d964e allowed the vacuum command to process indexes in parallel,
although GPDB does not support parallel background worker processes.