### PR TITLE
Fix GPDB jit functions

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -1841,13 +1841,13 @@ llvm_compile_expr(ExprState *state)
 
 			case EEOP_SCALARARRAYOP_FAST_INT:
 				build_EvalXFunc(b, mod, "ExecEvalScalarArrayOpFastInt",
-								v_state, v_econtext, op);
+								v_state, op);
 				LLVMBuildBr(b, opblocks[opno + 1]);
 				break;
 
 			case EEOP_SCALARARRAYOP_FAST_STR:
 				build_EvalXFunc(b, mod, "ExecEvalScalarArrayOpFastStr",
-								v_state, v_econtext, op);
+								v_state, op);
 				LLVMBuildBr(b, opblocks[opno + 1]);
 				break;
 

--- a/src/backend/jit/llvm/llvmjit_types.c
+++ b/src/backend/jit/llvm/llvmjit_types.c
@@ -124,6 +124,8 @@ void	   *referenced_functions[] =
 	ExecEvalRowNull,
 	ExecEvalSQLValueFunction,
 	ExecEvalScalarArrayOp,
+	ExecEvalScalarArrayOpFastInt,
+	ExecEvalScalarArrayOpFastStr,
 	ExecEvalSubPlan,
 	ExecEvalSubscriptingRef,
 	ExecEvalSubscriptingRefAssign,


### PR DESCRIPTION
Fix GPDB jit functions

Commit b059d2f added many functions to the referenced_functions list in
src/backend/jit/llvm/llvmjit_types.c. An earlier commit, 19cd1cf, added the
GPDB-specific functions ExecEvalScalarArrayOpFastInt and
ExecEvalScalarArrayOpFastStr, which should now also be in this list. They have
two arguments, just like the similar function ExecEvalScalarArrayOp.