### PR TITLE
Fix 'gp_tablespace_with_faults' regress test

### DIFF
--- a/src/test/regress/input/gp_tablespace_with_faults.source
+++ b/src/test/regress/input/gp_tablespace_with_faults.source
@@ -9,11 +9,9 @@
 -- start_ignore
 \! gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
 \! gpstop -u;
--- end_ignore
-
 
 create or replace language plpython3u;
-
+-- end_ignore
 
 create or replace function remove_tablespace_location_directory(tablespace_location_dir text) returns void as $$
 	import shutil

--- a/src/test/regress/output/gp_tablespace_with_faults.source
+++ b/src/test/regress/output/gp_tablespace_with_faults.source
@@ -17,7 +17,6 @@
 20190628:12:33:29:008863 gpstop:Adams-MBP:adamberlin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.479.gb6a83cfcde build dev'
 20190628:12:33:29:008863 gpstop:Adams-MBP:adamberlin-[INFO]:-Signalling all postmaster processes to reload
 -- end_ignore
-create or replace language plpython3u;
 create or replace function remove_tablespace_location_directory(tablespace_location_dir text) returns void as $$
 	import shutil
 	import os


### PR DESCRIPTION
Fix 'gp_tablespace_with_faults' regress test

Test 'gp_tablespace_with_faults' failed due to a 'notice' message when creating
plpython3u language, as now the language is already created by some other test.
This patch fixes the issue by moving the 'create language' command into the
ignore section.
