### PR TITLE
Fix tests broken by updated error messages for constraint checks

### DIFF
--- a/src/test/regress/expected/alter_table_ao.out
+++ b/src/test/regress/expected/alter_table_ao.out
@@ -136,14 +136,14 @@ create table ao1(col1 varchar(2), col2 int) WITH (APPENDONLY=TRUE) distributed r
 insert into ao1 values('a', 1); 
 -- should fail
 alter table ao1 add column col3 char(1) not null default NULL; 
-ERROR:  column "col3" contains null values  (seg2 rh55-qavm63:18508 pid=26649)
+ERROR:  column "col3" of relation "ao1" contains null values  (seg2 rh55-qavm63:18508 pid=26649)
 drop table if exists ao1;
 create table ao1(col1 varchar(2), col2 int) WITH (APPENDONLY=TRUE) distributed randomly;
 -- should pass
 alter table ao1 add column col3 char(1) not null default NULL; 
 -- this should fail (same behavior as heap tables)
 insert into ao1(col1, col2) values('a', 10);
-ERROR:  null value in column "col3" violates not-null constraint  (seg1 127.0.0.1:25433 pid=17664)
+ERROR:  null value in column "col3" of relation "ao1" violates not-null constraint  (seg1 127.0.0.1:25433 pid=17664)
 DETAIL:  Failing row contains (a, 10, null).
 ---
 --- alter add with no default should continue to fail
@@ -263,11 +263,11 @@ insert into aoco1 values('a', 1);
 alter table aoco1 add column col3 char(1) not null default NULL; 
 ERROR:  column "col3" contains null values  (seg0 usxxreddyr3mbp1.corp.emc.com:40000 pid=87838)
 alter table aoco1 add column c5 int check (c5 IS NOT NULL) default NULL;
-ERROR:  check constraint "aoco1_c5_check" is violated by some row
+ERROR:  check constraint "aoco1_c5_check" of relation "aoco1" is violated by some row
 -- should fail (rewrite needs to do constraint checking) 
 insert into aoco1(col1, col2) values('a', NULL);
 alter table aoco1 alter column col2 set not null; 
-ERROR:  column "col2" contains null values  (seg0 usxxreddyr3mbp1.corp.emc.com:40000 pid=87838)
+ERROR:  column "col2" of relation "aoco1" contains null values  (seg0 usxxreddyr3mbp1.corp.emc.com:40000 pid=87838)
 -- should pass (rewrite needs to do constraint checking) 
 alter table aoco1 alter column col2 type int; 
 drop table if exists aoco1;
@@ -277,7 +277,7 @@ WITH (APPENDONLY=TRUE, ORIENTATION=column) distributed randomly;
 alter table aoco1 add column col3 char(1) not null default NULL; 
 -- this should fail (same behavior as heap tables)
 insert into aoco1 (col1, col2) values('a', 10);
-ERROR:  null value in column "col3" violates not-null constraint  (seg1 127.0.0.1:25433 pid=17664)
+ERROR:  null value in column "col3" of relation "aoco1" violates not-null constraint  (seg1 127.0.0.1:25433 pid=17664)
 DETAIL:  Failing row contains (a, 10, null).
 drop table if exists aoco1;
 create table aoco1(col1 varchar(2), col2 int not null)

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -468,7 +468,7 @@ select count(*) as added_col5 from pg_attribute pa, pg_class pc where pa.attreli
 -- @description AOCO multivarblock table : add column with constraint and default value non NULL
 -- Negative test
 alter table multivarblock_tab add column added_col66 int CONSTRAINT multivarblock_tab_check1 CHECK (added_col66 < 10)  default 30;
-ERROR:  check constraint "multivarblock_tab_check1" is violated by some row  (seg1 rh55-qa02.sanmateo.greenplum.com:30000 pid=8212)
+ERROR:  check constraint "multivarblock_tab_check1" of relation "multivarblock_tab" is violated by some row  (seg1 rh55-qa02.sanmateo.greenplum.com:30000 pid=8212)
 select count(*) as added_col66 from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='multivarblock_tab' and attname='added_col66';
  added_col66 
 -------------

--- a/src/test/regress/expected/catcache.out
+++ b/src/test/regress/expected/catcache.out
@@ -56,7 +56,7 @@ explain update dml_14027_union_s set a = (select null union select null)::numeri
 -- Should not raise error due to stale catcache in reader gang.
 -- eg: ERROR: expected partdefid 134733, but got 0
 update dml_14027_union_s set a = (select null union select null)::numeric;
-ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.1.1:7002 pid=27795)
+ERROR:  null value in column "a" of relation "dml_14027_union_s_1_prt_2" violates not-null constraint  (seg0 127.0.1.1:7002 pid=27795)
 DETAIL:  Failing row contains (null, 1).
 drop table dml_14027_union_s;
 reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/catcache_optimizer.out
+++ b/src/test/regress/expected/catcache_optimizer.out
@@ -75,7 +75,7 @@ explain update dml_14027_union_s set a = (select null union select null)::numeri
 -- Should not raise error due to stale catcache in reader gang.
 -- eg: ERROR: expected partdefid 134733, but got 0
 update dml_14027_union_s set a = (select null union select null)::numeric;
-ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.1.1:7002 pid=27466)
+ERROR:  null value in column "a" of relation "dml_14027_union_s_1_prt_2" violates not-null constraint  (seg0 127.0.1.1:7002 pid=27466)
 DETAIL:  Failing row contains (null, 1).
 drop table dml_14027_union_s;
 reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gp_constraints.out
+++ b/src/test/regress/expected/gp_constraints.out
@@ -97,7 +97,7 @@ INSERT INTO PRIMARY_TBL VALUES (5, 'five');
 DELETE FROM tmp;
 INSERT INTO tmp (t) VALUES ('six');
 INSERT INTO PRIMARY_TBL SELECT * FROM tmp;
-ERROR:  null value in column "i" violates not-null constraint
+ERROR:  null value in column "i" of relation "primary_tbl" violates not-null constraint
 DETAIL:  Failing row contains (null, six).
 SELECT '' AS four, * FROM PRIMARY_TBL;
  four | i |  t   

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -387,11 +387,11 @@ insert into bar_p values(6);
 insert into bar_p values(100);
 -- should fail
 alter table foo_p exchange partition for(6) with table bar_p;
-ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=9703)
+ERROR:  partition constraint of relation "bar_p" is violated by some row  (seg2 127.0.1.1:7004 pid=9703)
 alter table foo_p exchange partition for(6) with table bar_p without
 validation;
 NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
-ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=4691)
+ERROR:  partition constraint of relation "bar_p" is violated by some row  (seg2 127.0.1.1:7004 pid=4691)
 analyze foo_p;
 select * from foo_p;
  i 

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2814,10 +2814,10 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO exchange_tbl VALUES (100);
 ALTER TABLE validation_syntax_tbl EXCHANGE PARTITION p1 WITH TABLE exchange_tbl WITH VALIDATION;
 NOTICE:  specifying "WITH VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
-ERROR:  partition constraint is violated by some row  (seg2 127.0.0.1:40002 pid=26267)
+ERROR:  partition constraint of relation "exchange_tbl" is violated by some row  (seg2 127.0.0.1:40002 pid=26267)
 ALTER TABLE validation_syntax_tbl EXCHANGE PARTITION p1 WITH TABLE exchange_tbl WITHOUT VALIDATION;
 NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
-ERROR:  partition constraint is violated by some row  (seg2 127.0.0.1:40002 pid=26267)
+ERROR:  partition constraint of relation "exchange_tbl" is violated by some row  (seg2 127.0.0.1:40002 pid=26267)
 DROP TABLE exchange_tbl;
 DROP TABLE validation_syntax_tbl;
 --

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -387,11 +387,11 @@ insert into bar_p values(6);
 insert into bar_p values(100);
 -- should fail
 alter table foo_p exchange partition for(6) with table bar_p;
-ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=9703)
+ERROR:  partition constraint of relation "bar_p" is violated by some row  (seg2 127.0.1.1:7004 pid=9703)
 alter table foo_p exchange partition for(6) with table bar_p without
 validation;
 NOTICE:  specifying "WITHOUT VALIDATION" acts as no operation. If the new partition is a regular table, validation is performed to make sure all the rows obey partition constraint. If the new partition is external or foreign table, no validation is performed.
-ERROR:  partition constraint is violated by some row  (seg2 127.0.1.1:7004 pid=4691)
+ERROR:  partition constraint of relation "bar_p" is violated by some row  (seg2 127.0.1.1:7004 pid=4691)
 analyze foo_p;
 select * from foo_p;
  i 

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -281,7 +281,7 @@ SELECT COUNT(*) FROM dml_ao_check_s;
 (1 row)
 
 INSERT INTO dml_ao_check_s values(default,1,'nn',1.0000);
-ERROR:  null value in column "a" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
+ERROR:  null value in column "a" of relation "dml_ao_check_s_1_prt_def" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
 DETAIL:  Failing row contains (null, 1, nn, 1.0000).
 SELECT COUNT(*) FROM dml_ao_check_s;
  count 
@@ -303,7 +303,7 @@ SELECT COUNT(*) FROM (SELECT dml_ao_check_r.a + 110 , 0, dml_ao_check_r.c, NULL 
 (1 row)
 
 INSERT INTO dml_ao_check_r SELECT dml_ao_check_r.a + 110 , 0, dml_ao_check_r.c, NULL FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a;
-ERROR:  null value in column "d" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
+ERROR:  null value in column "d" of relation "dml_ao_check_r_1_prt_def" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
 DETAIL:  Failing row contains (138, 0, r, null).
 SELECT COUNT(*) FROM dml_ao_check_r;
  count 
@@ -1130,7 +1130,7 @@ SELECT COUNT(*) FROM dml_co_check_s;
 (1 row)
 
 INSERT INTO dml_co_check_s values(default,1,'nn',1.0000);
-ERROR:  null value in column "a" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
+ERROR:  null value in column "a" of relation "dml_co_check_s_1_prt_def" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
 DETAIL:  Failing row contains (null, 1, nn, 1.0000).
 SELECT COUNT(*) FROM dml_co_check_s;
  count 
@@ -1174,7 +1174,7 @@ SELECT COUNT(*) FROM (SELECT dml_co_check_r.a + 110 , 0, dml_co_check_r.c, NULL 
 (1 row)
 
 INSERT INTO dml_co_check_r SELECT dml_co_check_r.a + 110 , 0, dml_co_check_r.c, NULL FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.a;
-ERROR:  null value in column "d" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
+ERROR:  null value in column "d" of relation "dml_co_check_r_1_prt_def" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
 DETAIL:  Failing row contains (117, 0, r, null).
 SELECT COUNT(*) FROM dml_co_check_r;
  count 
@@ -2001,7 +2001,7 @@ SELECT COUNT(*) FROM dml_heap_check_s;
 (1 row)
 
 INSERT INTO dml_heap_check_s values(default,1,'nn',1.0000);
-ERROR:  null value in column "a" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
+ERROR:  null value in column "a" of relation "dml_heap_check_s_1_prt_def" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
 DETAIL:  Failing row contains (null, 1, nn, 1.0000).
 SELECT COUNT(*) FROM dml_heap_check_s;
  count 
@@ -2045,7 +2045,7 @@ SELECT COUNT(*) FROM (SELECT dml_heap_check_r.a + 110 , 0, dml_heap_check_r.c, N
 (1 row)
 
 INSERT INTO dml_heap_check_r SELECT dml_heap_check_r.a + 110 , 0, dml_heap_check_r.c, NULL FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.a;
-ERROR:  null value in column "d" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
+ERROR:  null value in column "d" of relation "dml_heap_check_r_1_prt_def" violates not-null constraint  (seg0 172.17.0.2:25432 pid=290285)
 DETAIL:  Failing row contains (117, 0, r, null).
 SELECT COUNT(*) FROM dml_heap_check_r;
  count 

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -281,7 +281,7 @@ SELECT COUNT(*) FROM dml_ao_check_s;
 (1 row)
 
 INSERT INTO dml_ao_check_s values(default,1,'nn',1.0000);
-ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.0.1:40000 pid=18972)
+ERROR:  null value in column "a" of relation "dml_ao_check_s_1_prt_def" violates not-null constraint  (seg0 127.0.0.1:40000 pid=18972)
 DETAIL:  Failing row contains (null, 1, nn, 1.0000).
 SELECT COUNT(*) FROM dml_ao_check_s;
  count 
@@ -303,7 +303,7 @@ SELECT COUNT(*) FROM (SELECT dml_ao_check_r.a + 110 , 0, dml_ao_check_r.c, NULL 
 (1 row)
 
 INSERT INTO dml_ao_check_r SELECT dml_ao_check_r.a + 110 , 0, dml_ao_check_r.c, NULL FROM dml_ao_check_r, dml_ao_check_s WHERE dml_ao_check_r.a = dml_ao_check_s.a;
-ERROR:  null value in column "d" violates not-null constraint
+ERROR:  null value in column "d" of relation "dml_ao_check_r_1_prt_def" violates not-null constraint
 DETAIL:  Failing row contains (118, 0, r, null).
 SELECT COUNT(*) FROM dml_ao_check_r;
  count 
@@ -1130,7 +1130,7 @@ SELECT COUNT(*) FROM dml_co_check_s;
 (1 row)
 
 INSERT INTO dml_co_check_s values(default,1,'nn',1.0000);
-ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.0.1:40000 pid=18972)
+ERROR:  null value in column "a" of relation "dml_co_check_s_1_prt_def" violates not-null constraint  (seg0 127.0.0.1:40000 pid=18972)
 DETAIL:  Failing row contains (null, 1, nn, 1.0000).
 SELECT COUNT(*) FROM dml_co_check_s;
  count 
@@ -1174,7 +1174,7 @@ SELECT COUNT(*) FROM (SELECT dml_co_check_r.a + 110 , 0, dml_co_check_r.c, NULL 
 (1 row)
 
 INSERT INTO dml_co_check_r SELECT dml_co_check_r.a + 110 , 0, dml_co_check_r.c, NULL FROM dml_co_check_r, dml_co_check_s WHERE dml_co_check_r.a = dml_co_check_s.a;
-ERROR:  null value in column "d" violates not-null constraint
+ERROR:  null value in column "d" of relation "dml_co_check_r_1_prt_def" violates not-null constraint
 DETAIL:  Failing row contains (118, 0, r, null).
 SELECT COUNT(*) FROM dml_co_check_r;
  count 
@@ -2001,7 +2001,7 @@ SELECT COUNT(*) FROM dml_heap_check_s;
 (1 row)
 
 INSERT INTO dml_heap_check_s values(default,1,'nn',1.0000);
-ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.0.1:40000 pid=18972)
+ERROR:  null value in column "a" of relation "dml_heap_check_s_1_prt_def" violates not-null constraint  (seg0 127.0.0.1:40000 pid=18972)
 DETAIL:  Failing row contains (null, 1, nn, 1.0000).
 SELECT COUNT(*) FROM dml_heap_check_s;
  count 
@@ -2045,7 +2045,7 @@ SELECT COUNT(*) FROM (SELECT dml_heap_check_r.a + 110 , 0, dml_heap_check_r.c, N
 (1 row)
 
 INSERT INTO dml_heap_check_r SELECT dml_heap_check_r.a + 110 , 0, dml_heap_check_r.c, NULL FROM dml_heap_check_r, dml_heap_check_s WHERE dml_heap_check_r.a = dml_heap_check_s.a;
-ERROR:  null value in column "d" violates not-null constraint
+ERROR:  null value in column "d" of relation "dml_heap_check_r_1_prt_def" violates not-null constraint
 DETAIL:  Failing row contains (111, 0, r, null).
 SELECT COUNT(*) FROM dml_heap_check_r;
  count 

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -626,7 +626,7 @@ SELECT COUNT(*) FROM ( SELECT * FROM (SELECT * FROM dml_union_r EXCEPT SELECT * 
 (1 row)
 
 INSERT INTO dml_union_s SELECT * FROM (SELECT * FROM dml_union_r EXCEPT SELECT * FROM dml_union_s) foo WHERE c='text';
-ERROR:  null value in column "b" violates not-null constraint  (seg1 172.17.0.2:25433 pid=278765)
+ERROR:  null value in column "b" of relation "dml_union_s_1_prt_def" violates not-null constraint  (seg1 172.17.0.2:25433 pid=278765)
 DETAIL:  Failing row contains (null, null, text, null).
 --SELECT COUNT(*) FROM dml_union_r;
 -- @description union_test28: Negative tests MORE THAN ONE ROW RETURNED
@@ -1707,7 +1707,7 @@ SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
 (1 row)
 
 UPDATE dml_union_s SET b = (SELECT NULL UNION SELECT NULL)::numeric;
-ERROR:  null value in column "b" violates not-null constraint  (seg1 10.152.10.75:25433 pid=19531)
+ERROR:  null value in column "b" of relation "dml_union_s_1_prt_2" violates not-null constraint  (seg1 10.152.10.75:25433 pid=19531)
 DETAIL:  Failing row contains (5, null, s, 5).
 --SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
 --SELECT DISTINCT(b) FROM dml_union_s;

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -626,7 +626,7 @@ SELECT COUNT(*) FROM ( SELECT * FROM (SELECT * FROM dml_union_r EXCEPT SELECT * 
 (1 row)
 
 INSERT INTO dml_union_s SELECT * FROM (SELECT * FROM dml_union_r EXCEPT SELECT * FROM dml_union_s) foo WHERE c='text';
-ERROR:  null value in column "b" violates not-null constraint
+ERROR:  null value in column "b" of relation "dml_union_s_1_prt_def" violates not-null constraint
 DETAIL:  Failing row contains (null, null, text, null).
 --SELECT COUNT(*) FROM dml_union_r;
 -- @description union_test28: Negative tests MORE THAN ONE ROW RETURNED
@@ -1708,7 +1708,7 @@ SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
 (1 row)
 
 UPDATE dml_union_s SET b = (SELECT NULL UNION SELECT NULL)::numeric;
-ERROR:  null value in column "b" violates not-null constraint  (seg0 127.0.0.1:7002 pid=31287)
+ERROR:  null value in column "b" of relation "dml_union_s_1_prt_2" violates not-null constraint  (seg0 127.0.0.1:7002 pid=31287)
 DETAIL:  Failing row contains (1, null, s, 1).
 --SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
 --SELECT DISTINCT(b) FROM dml_union_s;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1140,7 +1140,7 @@ relname='tenk_renamed'));
 ALTER TABLE tenk_renamed ALTER COLUMN twothousand SET NOT NULL;
 ALTER TABLE tenk_renamed ADD COLUMN sercol serial; -- MPP-10015
 ALTER TABLE tenk_renamed ADD COLUMN newcol2 int NOT NULL; -- should fail
-ERROR:  column "newcol2" contains null values  (seg1 127.0.0.1:40001 pid=10274)
+ERROR:  column "newcol2" of relation "tenk_renamed" contains null values  (seg1 127.0.0.1:40001 pid=10274)
 SELECT count(*) FROM tenk_renamed;
  count 
 -------

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -517,7 +517,7 @@ COPY errcopy to '/tmp/errcopy.csv' csv null '';
 TRUNCATE errcopy;
 ALTER table errcopy ALTER c SET NOT null;
 COPY errcopy from '/tmp/errcopy.csv' csv null '' log errors segment reject limit 10 rows;
-ERROR:  null value in column "c" violates not-null constraint
+ERROR:  null value in column "c" of relation "errcopy" violates not-null constraint
 DETAIL:  Failing row contains (5, 5, null).
 CONTEXT:  COPY errcopy, line 7
 SELECT * FROM errcopy;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_constraint.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_constraint.source
@@ -157,7 +157,7 @@ set gp_select_invisible = false;
 -- Some negative testing.
 alter table sto_alt_uao2_constraint ADD COLUMN added_col10 character varying(35)
 default NULL constraint added_col10 NOT NULL;
-ERROR:  column "added_col10" contains null values  (seg0 127.0.0.1:25432 pid=30602)
+ERROR:  column "added_col10" of relation "sto_alt_uao2_constraint" contains null values  (seg0 127.0.0.1:25432 pid=30602)
 alter table sto_alt_uao2_constraint ADD COLUMN added_col12 character varying(35)
 -- Mask out "by some row" printed by row-oriented AO tables
 -- start_matchsubs

--- a/src/test/regress/output/uao_ddl/alter_ao_table_setdefault.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_setdefault.source
@@ -61,7 +61,7 @@ Alter Table sto_alt_uao1_default ALTER COLUMN text_col SET NOT NULL;
 -- s/.//gs
 -- end_matchsubs
 insert into sto_alt_uao1_default values (5, '5_zero', 5, 5, 5, '{5}', 5, 5, '1-1-2002', 5);
-ERROR:  null value in column "text_col" violates not-null constraint  (seg0 127.0.0.1:25432 pid=38194)
+ERROR:  null value in column "text_col" of relation "sto_alt_uao1_default" violates not-null constraint  (seg0 127.0.0.1:25432 pid=38194)
 DETAIL:  Failing row contains (5, 5_zero, 5, 5, 5, {5}, 5, 5, 01-01-2002, 5, null).
 select * from sto_alt_uao1_default order by bigint_col;
  bigint_col | char_vary_col | numeric_col | int_col | float_col | int_array_col | before_rename_col | change_datatype_col | date_column | col_set_default |   text_col   


### PR DESCRIPTION
Fix tests broken by updated error messages for constraint checks

Commit 05f18c6 added the relation name in the error messages for constraint
checks. The relation names should be added to the expected output of tests:
 - gp_constraints;
 - gpcopy;
 - alter_table_ao;
 - catcache;
 - qp_dml_joins;
 - qp_union_intersect;
 - uao_ddl/alter_ao_table_setdefault_row;
 - uao_ddl/alter_ao_table_constraint_row;
 - uao_ddl/alter_ao_table_setdefault_column;
 - appendonly;
 - partition;
 - partition1;
 - alter_table_aocs2.