### PR TITLE
Fix ALTER TYPE statement

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -176,6 +176,7 @@ ClassifyUtilityCommandAsReadOnly(Node *parsetree)
 		case T_AlterTableMoveAllStmt:
 		case T_AlterTableSpaceOptionsStmt:
 		case T_AlterTableStmt:
+		case T_AlterTypeStmt:
 		case T_AlterUserMappingStmt:
 		case T_CommentStmt:
 		case T_CompositeTypeStmt:


### PR DESCRIPTION
Fix ALTER TYPE statement

Commit 2eb34ac36974 added function 'ClassifyUtilityCommandAsReadOnly()', but
'T_AlterTypeStmt' wasn't handled there. Therefore, some tests failed when trying
to execute the 'alter type' command with "ERROR:  unrecognized node type: 733".
Affected tests:
 - column_compression;
 - AOCO_Compression;
 - zstd_column_compression.

This patch adds handling for 'T_AlterTypeStmt' into
'ClassifyUtilityCommandAsReadOnly()' function.