### PR TITLE
Fix tests in src/test/regress/expected/tidscan.out

### DIFF
--- a/src/test/regress/expected/tidscan.out
+++ b/src/test/regress/expected/tidscan.out
@@ -332,6 +332,9 @@ SELECT count(*) FROM tenk1 t1 JOIN tenk1 t2 ON t1.ctid = t2.ctid and t1.gp_segme
 
 RESET enable_hashjoin;
 -- check predicate lock on CTID
+-- GPDB_13_MERGE_FEATURE_NOT_SUPPORTED: GPDB does not support serializable transactions,
+-- ignore the below test case.
+-- start_ignore
 BEGIN ISOLATION LEVEL SERIALIZABLE;
 SELECT * FROM tidscan WHERE ctid = '(0,1)';
  id 
@@ -341,10 +344,10 @@ SELECT * FROM tidscan WHERE ctid = '(0,1)';
 
 -- locktype should be 'tuple'
 SELECT locktype, mode FROM pg_locks WHERE pid = pg_backend_pid() AND mode = 'SIReadLock';
- locktype |    mode    
-----------+------------
- tuple    | SIReadLock
-(1 row)
+ locktype | mode 
+----------+------
+(0 rows)
 
 ROLLBACK;
+-- end_ignore
 DROP TABLE tidscan;

--- a/src/test/regress/expected/tidscan_optimizer.out
+++ b/src/test/regress/expected/tidscan_optimizer.out
@@ -331,4 +331,23 @@ SELECT count(*) FROM tenk1 t1 JOIN tenk1 t2 ON t1.ctid = t2.ctid and t1.gp_segme
 (1 row)
 
 RESET enable_hashjoin;
+-- check predicate lock on CTID
+-- GPDB_13_MERGE_FEATURE_NOT_SUPPORTED: GPDB does not support serializable transactions,
+-- ignore the below test case.
+-- start_ignore
+BEGIN ISOLATION LEVEL SERIALIZABLE;
+SELECT * FROM tidscan WHERE ctid = '(0,1)';
+ id 
+----
+  1
+(1 row)
+
+-- locktype should be 'tuple'
+SELECT locktype, mode FROM pg_locks WHERE pid = pg_backend_pid() AND mode = 'SIReadLock';
+ locktype | mode 
+----------+------
+(0 rows)
+
+ROLLBACK;
+-- end_ignore
 DROP TABLE tidscan;

--- a/src/test/regress/sql/tidscan.sql
+++ b/src/test/regress/sql/tidscan.sql
@@ -119,10 +119,14 @@ SELECT count(*) FROM tenk1 t1 JOIN tenk1 t2 ON t1.ctid = t2.ctid and t1.gp_segme
 RESET enable_hashjoin;
 
 -- check predicate lock on CTID
+-- GPDB_13_MERGE_FEATURE_NOT_SUPPORTED: GPDB does not support serializable transactions,
+-- ignore the below test case.
+-- start_ignore
 BEGIN ISOLATION LEVEL SERIALIZABLE;
 SELECT * FROM tidscan WHERE ctid = '(0,1)';
 -- locktype should be 'tuple'
 SELECT locktype, mode FROM pg_locks WHERE pid = pg_backend_pid() AND mode = 'SIReadLock';
 ROLLBACK;
+-- end_ignore
 
 DROP TABLE tidscan;


### PR DESCRIPTION
Fix tests in src/test/regress/expected/tidscan.out

Commit cb5b2861 added new tests to src/test/regress/sql/tidscan.sql. However,
GPDB does not support serializable transactions, so ignore the new tests. Add
the new tests to the ORCA output.