### PR TITLE
Adjust bfv_legacy test

### DIFF
--- a/src/test/regress/expected/bfv_legacy.out
+++ b/src/test/regress/expected/bfv_legacy.out
@@ -7,6 +7,7 @@ create or replace language plpython3u;
 -- the language exists already (we had a little bug at one point, where
 -- the "OR REPLACE" was not dispatched to segments, and this failed)
 create or replace language plpython3u;
+NOTICE:  extension "plpython3u" already exists, skipping
 --start_ignore
 drop schema if exists bfv_legacy cascade;
 NOTICE:  schema "bfv_legacy" does not exist, skipping

--- a/src/test/regress/expected/bfv_legacy.out
+++ b/src/test/regress/expected/bfv_legacy.out
@@ -2,12 +2,6 @@
 -- SETUP: Helper functions for query plan verification
 --
 -- The helper functions are written in python.
-create or replace language plpython3u;
--- While we're at it, test that CREATE OR REPLACE LANGUAGE works when
--- the language exists already (we had a little bug at one point, where
--- the "OR REPLACE" was not dispatched to segments, and this failed)
-create or replace language plpython3u;
-NOTICE:  extension "plpython3u" already exists, skipping
 --start_ignore
 drop schema if exists bfv_legacy cascade;
 NOTICE:  schema "bfv_legacy" does not exist, skipping

--- a/src/test/regress/expected/bfv_legacy_optimizer.out
+++ b/src/test/regress/expected/bfv_legacy_optimizer.out
@@ -7,6 +7,7 @@ create or replace language plpython3u;
 -- the language exists already (we had a little bug at one point, where
 -- the "OR REPLACE" was not dispatched to segments, and this failed)
 create or replace language plpython3u;
+NOTICE:  extension "plpython3u" already exists, skipping
 --start_ignore
 drop schema if exists bfv_legacy cascade;
 NOTICE:  schema "bfv_legacy" does not exist, skipping

--- a/src/test/regress/expected/bfv_legacy_optimizer.out
+++ b/src/test/regress/expected/bfv_legacy_optimizer.out
@@ -2,12 +2,6 @@
 -- SETUP: Helper functions for query plan verification
 --
 -- The helper functions are written in python.
-create or replace language plpython3u;
--- While we're at it, test that CREATE OR REPLACE LANGUAGE works when
--- the language exists already (we had a little bug at one point, where
--- the "OR REPLACE" was not dispatched to segments, and this failed)
-create or replace language plpython3u;
-NOTICE:  extension "plpython3u" already exists, skipping
 --start_ignore
 drop schema if exists bfv_legacy cascade;
 NOTICE:  schema "bfv_legacy" does not exist, skipping

--- a/src/test/regress/sql/bfv_legacy.sql
+++ b/src/test/regress/sql/bfv_legacy.sql
@@ -2,17 +2,10 @@
 -- SETUP: Helper functions for query plan verification
 --
 
--- start_ignore
-drop extension if exists plpython3u cascade;
--- end_ignore
-
 -- The helper functions are written in python.
+-- start_ignore
 create or replace language plpython3u;
-
--- While we're at it, test that CREATE OR REPLACE LANGUAGE works when
--- the language exists already (we had a little bug at one point, where
--- the "OR REPLACE" was not dispatched to segments, and this failed)
-create or replace language plpython3u;
+-- end_ignore
 
 --start_ignore
 drop schema if exists bfv_legacy cascade;

--- a/src/test/regress/sql/bfv_legacy.sql
+++ b/src/test/regress/sql/bfv_legacy.sql
@@ -2,6 +2,10 @@
 -- SETUP: Helper functions for query plan verification
 --
 
+-- start_ignore
+drop extension if exists plpython3u;
+-- end_ignore
+
 -- The helper functions are written in python.
 create or replace language plpython3u;
 

--- a/src/test/regress/sql/bfv_legacy.sql
+++ b/src/test/regress/sql/bfv_legacy.sql
@@ -3,7 +3,7 @@
 --
 
 -- start_ignore
-drop extension if exists plpython3u;
+drop extension if exists plpython3u cascade;
 -- end_ignore
 
 -- The helper functions are written in python.


### PR DESCRIPTION
Commit 50fc694 in particular changed semantic of the CREATE OR REPLACE LANGUAGE.
Now as stated in comment in gram.y: "OR REPLACE" is silently translated to 
"IF NOT EXISTS", which isn't quite the same, but seems more useful than 
throwing an error.

So now when language exists, CREATE OR REPLACE LANGUAGE emits a notice.

This commit adjusts the test bfv_legacy to see this notice. Also we now drop 
language if it is exists in the beginning of the test, so test is independent of
language was loaded or not in previous tests.