### PR TITLE
Fix 'parallel_retrieve_cursor' isolation2 tests

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -287,6 +287,7 @@ ClassifyUtilityCommandAsReadOnly(Node *parsetree)
 		case T_PrepareStmt:
 		case T_UnlistenStmt:
 		case T_VariableSetStmt:
+		case T_RetrieveStmt:
 			{
 				/*
 				 * These modify only backend-local state, so they're OK to


### PR DESCRIPTION
Fix 'parallel_retrieve_cursor' isolation2 tests

Commit 2eb34ac36974 added function 'ClassifyUtilityCommandAsReadOnly()', but
GPDB-specific 'T_RetrieveStmt' wasn't handled there. Therefore, many
'parallel_retrieve_cursor' isolation2 tests failed with
"ERROR:  unrecognized node type: 1002". This patch adds handling for
'T_RetrieveStmt' into 'ClassifyUtilityCommandAsReadOnly()' function.
