### PR TITLE
Fix tests in src/pl/plperl/expected/plperl_setup.out

### DIFF
--- a/src/pl/plperl/expected/plperl_setup.out
+++ b/src/pl/plperl/expected/plperl_setup.out
@@ -5,7 +5,9 @@
 -- a non-superuser is allowed to install plperl (but not plperlu) when
 -- suitable permissions have been granted.
 CREATE USER regress_user1;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE USER regress_user2;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE regress_user1;
 CREATE EXTENSION plperl;  -- fail
 ERROR:  permission denied to create extension "plperl"


### PR DESCRIPTION
Fix tests in src/pl/plperl/expected/plperl_setup.out

Commit 50fc694e4374 added new 'plperl_setup' test. It failed on GPDB due to
GPDB-specific notices emitted during the test. This patch updates the expected
output with these GPDB-specific notices.
