### PR TITLE
Fix 'pg_trgm' test

### DIFF
--- a/contrib/pg_trgm/expected/pg_trgm.out
+++ b/contrib/pg_trgm/expected/pg_trgm.out
@@ -3504,14 +3504,17 @@ select count(*) from test_trgm where t ~ '[qwerty]{2}-?[qwerty]{2}';
 -- check handling of indexquals that generate no searchable conditions
 explain (costs off)
 select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
-         ->  Bitmap Index Scan on trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
-(5 rows)
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+                     ->  Bitmap Index Scan on trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
  count 
@@ -3521,14 +3524,17 @@ select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
 
 explain (costs off)
 select count(*) from test_trgm where t like '%99%' and t like '%qw%';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
-         ->  Bitmap Index Scan on trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
-(5 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+                     ->  Bitmap Index Scan on trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 select count(*) from test_trgm where t like '%99%' and t like '%qw%';
  count 
@@ -3542,14 +3548,17 @@ create index t_trgm_idx on t_test_trgm using gin (t gin_trgm_ops);
 insert into t_test_trgm values ('qwerty99'), ('qwerty01');
 explain (costs off)
 select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on t_test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
-         ->  Bitmap Index Scan on t_trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
-(5 rows)
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on t_test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+                     ->  Bitmap Index Scan on t_trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
  count 
@@ -3559,14 +3568,17 @@ select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
 
 explain (costs off)
 select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
-                               QUERY PLAN                                
--------------------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on t_test_trgm
-         Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
-         ->  Bitmap Index Scan on t_trgm_idx
-               Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
-(5 rows)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on t_test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+                     ->  Bitmap Index Scan on t_trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
  count 

--- a/contrib/pg_trgm/expected/pg_trgm_optimizer.out
+++ b/contrib/pg_trgm/expected/pg_trgm_optimizer.out
@@ -3504,6 +3504,121 @@ select count(*) from test_trgm where t ~ '[qwerty]{2}-?[qwerty]{2}';
   1000
 (1 row)
 
+-- check handling of indexquals that generate no searchable conditions
+explain (costs off)
+select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+                     ->  Bitmap Index Scan on trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
+ count 
+-------
+    19
+(1 row)
+
+explain (costs off)
+select count(*) from test_trgm where t like '%99%' and t like '%qw%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+                     ->  Bitmap Index Scan on trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select count(*) from test_trgm where t like '%99%' and t like '%qw%';
+ count 
+-------
+    19
+(1 row)
+
+-- ensure that pending-list items are handled correctly, too
+create temp table t_test_trgm(t text COLLATE "C");
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index t_trgm_idx on t_test_trgm using gin (t gin_trgm_ops);
+insert into t_test_trgm values ('qwerty99'), ('qwerty01');
+explain (costs off)
+select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on t_test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+                     ->  Bitmap Index Scan on t_trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qwerty%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
+ count 
+-------
+     1
+(1 row)
+
+explain (costs off)
+select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on t_test_trgm
+                     Recheck Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+                     ->  Bitmap Index Scan on t_trgm_idx
+                           Index Cond: ((t ~~ '%99%'::text) AND (t ~~ '%qw%'::text))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
+ count 
+-------
+     1
+(1 row)
+
+-- run the same queries with sequential scan to check the results
+set enable_bitmapscan=off;
+set enable_seqscan=on;
+select count(*) from test_trgm where t like '%99%' and t like '%qwerty%';
+ count 
+-------
+    19
+(1 row)
+
+select count(*) from test_trgm where t like '%99%' and t like '%qw%';
+ count 
+-------
+    19
+(1 row)
+
+select count(*) from t_test_trgm where t like '%99%' and t like '%qwerty%';
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from t_test_trgm where t like '%99%' and t like '%qw%';
+ count 
+-------
+     1
+(1 row)
+
+reset enable_bitmapscan;
 create table test2(t text COLLATE "C");
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 't' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.


### PR DESCRIPTION
Fix 'pg_trgm' test

Commit 4b754d6c16e1 added new test cases into 'contrib/pg_trgm/sql/pg_trgm.sql'
test. This new test case failed on GPDB due to different explain output. This
patch updates the explain output in the expected output file and adds the
expected output to the 'pg_trgm_optimizer.out' file.