### PR TITLE
Fix '003_recovery_targets.pl' test

### DIFF
--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -838,7 +838,7 @@ sub start
 		return 0;
 	}
 
-	$self->_update_pid(1);
+	$self->_update_pid(1, $params{fail_ok});
 	$ENV{PGOPTIONS}      = '-c gp_role=utility';
 	return 1;
 }
@@ -1102,7 +1102,7 @@ archive_command = '$copy_command'
 # Internal method
 sub _update_pid
 {
-	my ($self, $is_running) = @_;
+	my ($self, $is_running, $fail_ok) = @_;
 	my $name = $self->name;
 
 	#GPDB_12_MERGE_FIXME: somehow without this fails to find the pid file
@@ -1117,7 +1117,7 @@ sub _update_pid
 		close $pidfile;
 
 		# If we found a pidfile when there shouldn't be one, complain.
-		BAIL_OUT("postmaster.pid unexpectedly present") unless $is_running;
+		BAIL_OUT("postmaster.pid unexpectedly present") unless $is_running or $fail_ok;
 		return;
 	}
 
@@ -1125,7 +1125,7 @@ sub _update_pid
 	print "# No postmaster PID for node \"$name\"\n";
 
 	# Complain if we expected to find a pidfile.
-	BAIL_OUT("postmaster.pid unexpectedly not present") if $is_running;
+	BAIL_OUT("postmaster.pid unexpectedly not present") if $is_running and !$fail_ok;
 	return;
 }
 

--- a/src/test/recovery/t/003_recovery_targets.pl
+++ b/src/test/recovery/t/003_recovery_targets.pl
@@ -155,8 +155,7 @@ $node_standby->init_from_backup($node_master, 'my_backup',
 $node_standby->append_conf('postgresql.conf',
 						   "recovery_target_name = 'does_not_exist'");
 
-run_log(['pg_ctl', '-D', $node_standby->data_dir,
-		 '-l', $node_standby->logfile, 'start']);
+$node_standby->start(fail_ok => 1);
 
 # wait up to 10 seconds for postgres to terminate
 foreach my $i (0..100)


### PR DESCRIPTION
Fix '003_recovery_targets.pl' test

Commit dc788668bb2 added a new test case into the '003_recovery_targets.pl'
test. This test case failed on GPDB. Root cause: the test used direct call of
'pg_ctl' to start a PG instance. The call was without specifying GPDB-specific
params. Therefore, postmaster failed with fatal error "contentid (from -C
option) is not specified or is invalid" before reaching the target point, the
test was interested in.

Fix: use 'start()' method of the 'PostgresNode' class. It handles all required
GPDB-specific params when invoking 'pg_ctl'. But, as the test checks a
particular error condition during recovery, postmaster is terminated soon after
its start. And it breaks the check for the postmaster.pid file in 'start()'. To
handle it, flag 'fail_ok' is propagated into the '_update_pid()' function, and
if it is set, we do not fail if there are problems with postmaster.pid.