### PR TITLE
Added relation name in error messages for constraint checks for AO tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6316,8 +6316,10 @@ ATAocsWriteSegFileNewColumns(
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_NOT_NULL_VIOLATION),
-								 errmsg("column \"%s\" contains null values",
-										NameStr(attr->attname))));
+								 errmsg("column \"%s\" of relation \"%s\" contains null values",
+										NameStr(attr->attname),
+										RelationGetRelationName(idesc->rel)),
+								 errtablecol(idesc->rel, newval->attnum)));
 					}
 				}
 				foreach (l, tab->constraints)
@@ -6329,8 +6331,10 @@ ATAocsWriteSegFileNewColumns(
 							if(!ExecCheck(con->qualstate, econtext))
 								ereport(ERROR,
 										(errcode(ERRCODE_CHECK_VIOLATION),
-										 errmsg("check constraint \"%s\" is violated by some row",
-											con->name)));
+										 errmsg("check constraint \"%s\" of relation \"%s\" is violated by some row",
+												con->name,
+												RelationGetRelationName(idesc->rel)),
+										 errtableconstraint(idesc->rel, con->name)));
 							break;
 						case CONSTR_FOREIGN:
 							/* Nothing to do */


### PR DESCRIPTION
Added relation name in error messages for constraint checks for AO tables

Commit 05f18c6b6b6e4b44302ee20a042cedc664532aa2 added the relation name in the
error messages for constraint checks. But this change didn't affect AO column
oriented tables. Therefore, when the file 
'uao_ddl/alter_ao_table_constraint.source' was updated to fix
'uao_ddl/alter_ao_table_constraint_row' test, the test
'uao_ddl/alter_ao_table_constraint_column' became broken (as they use the same
.source template). This patch updates adds relation name in error messages for
constraint checks for AO tables in the same way as it was done for other tables
in 05f18c6b6b6e4b44302ee20a042cedc664532aa2.