### PR TITLE
Fix tests 'alter_table_aocs' and 'alter_table_ao', broken by 37e89070

### DIFF
--- a/src/test/regress/expected/alter_table_ao.out
+++ b/src/test/regress/expected/alter_table_ao.out
@@ -261,7 +261,7 @@ WITH (APPENDONLY=TRUE, ORIENTATION=column) distributed randomly;
 insert into aoco1 values('a', 1); 
 -- should fail (rewrite needs to do null checking) 
 alter table aoco1 add column col3 char(1) not null default NULL; 
-ERROR:  column "col3" contains null values  (seg0 usxxreddyr3mbp1.corp.emc.com:40000 pid=87838)
+ERROR:  column "col3" of relation "aoco1" contains null values  (seg0 usxxreddyr3mbp1.corp.emc.com:40000 pid=87838)
 alter table aoco1 add column c5 int check (c5 IS NOT NULL) default NULL;
 ERROR:  check constraint "aoco1_c5_check" of relation "aoco1" is violated by some row
 -- should fail (rewrite needs to do constraint checking) 
@@ -293,7 +293,7 @@ select * from aoco1;
 (2 rows)
 
 alter table aoco1 add column col4 char(1) not NULL default NULL;
-ERROR:  column "col4" contains null values  (seg1 usxxreddyr3mbp1.corp.emc.com:40001 pid=90925)
+ERROR:  column "col4" of relation "aoco1" contains null values  (seg1 usxxreddyr3mbp1.corp.emc.com:40001 pid=90925)
 select * from aoco1;
  col1 | col2 | col3 
 ------+------+------

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -467,7 +467,7 @@ alter table addcol1 rename to addcol1_renamed;
 alter table addcol1_renamed add column new_column int default 10;
 alter table addcol1_renamed alter column new_column set not null;
 alter table addcol1_renamed add column new_column2 int not null; -- should fail
-ERROR:  column "new_column2" contains null values
+ERROR:  column "new_column2" of relation "addcol1_renamed" contains null values
 select count(*) from addcol1_renamed;
  count 
 -------


### PR DESCRIPTION
Fix tests 'alter_table_aocs' and 'alter_table_ao', broken by 37e89070

Commit 37e890705115cbc58158e3b711dd13fdb3d792f4 added relation name in the error
messages for constraint checks for AO tables. This patch provides related
updates to tests 'alter_table_aocs' and 'alter_table_ao'.
