### PR TITLE
Fix isolation2 tests broken by updated error messages for constraint checks

### DIFF
--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -304,7 +304,7 @@ ALTER
 END
 -- after 1 commit, 2 can go on and it should fail
 2<:  <... completed>
-ERROR:  check constraint "mychk" is violated by some row  (seg1 127.0.1.1:7003 pid=39163)
+ERROR:  check constraint "mychk" of relation "t_alter_snapshot_test" is violated by some row  (seg1 127.0.1.1:7003 pid=39163)
 
 drop table t_alter_snapshot_test;
 DROP


### PR DESCRIPTION
Fix isolation2 tests broken by updated error messages for constraint checks

Commit 05f18c6 added the relation name in the error messages for constraint
checks. The relation names should be added to the expected output of isolation2
test 'distributed_snapshot'.
