### PR TITLE
Fix tests in src/test/isolation2/expected/export_distributed_snapshot.out

### DIFF
--- a/src/test/isolation2/expected/export_distributed_snapshot.out
+++ b/src/test/isolation2/expected/export_distributed_snapshot.out
@@ -13,7 +13,7 @@ DROP FUNCTION IF EXISTS corrupt_snapshot_file(text, text);
 DROP
 DROP FUNCTION IF EXISTS snapshot_file_ds_fields_exist(text);
 DROP
-DROP LANGUAGE IF EXISTS plpython3u cascade;
+DROP EXTENSION IF EXISTS plpython3u cascade;
 DROP
 DROP TABLE IF EXISTS export_distributed_snapshot_test1;
 DROP

--- a/src/test/isolation2/sql/export_distributed_snapshot.sql
+++ b/src/test/isolation2/sql/export_distributed_snapshot.sql
@@ -11,7 +11,7 @@
 -- start_ignore
 DROP FUNCTION IF EXISTS corrupt_snapshot_file(text, text);
 DROP FUNCTION IF EXISTS snapshot_file_ds_fields_exist(text);
-DROP LANGUAGE IF EXISTS plpython3u cascade;
+DROP EXTENSION IF EXISTS plpython3u cascade;
 DROP TABLE IF EXISTS export_distributed_snapshot_test1;
 -- end_ignore
 

--- a/src/test/regress/expected/sirv_functions.out
+++ b/src/test/regress/expected/sirv_functions.out
@@ -1413,7 +1413,7 @@ select * from sirv_test12_result1;
 -- Test: test13_ctas_plpython.sql
 -- ----------------------------------------------------------------------
 --start_ignore
-drop language if exists plpython3u cascade;
+drop extension if exists plpython3u cascade;
 NOTICE:  drop cascades to function public.count_operator(text,text)
 drop table if exists sirv_test13_result1;
 NOTICE:  table "sirv_test13_result1" does not exist, skipping
@@ -1495,7 +1495,7 @@ select * from sirv_test13_result2;
 -- Test: test14_insert_select_plpython.sql
 -- ----------------------------------------------------------------------
 --start_ignore
-drop language if exists plpython3u cascade;
+drop extension if exists plpython3u cascade;
 NOTICE:  drop cascades to function sirv_test13_fun2(double precision,integer)
 NOTICE:  drop cascades to function sirv_test13_fun1()
 drop table if exists sirv_test14_result1;

--- a/src/test/regress/sql/sirv_functions.sql
+++ b/src/test/regress/sql/sirv_functions.sql
@@ -6770,7 +6770,7 @@ select * from sirv_test12_result1;
 -- ----------------------------------------------------------------------
 --start_ignore
 
-drop language if exists plpython3u cascade;
+drop extension if exists plpython3u cascade;
 
 drop table if exists sirv_test13_result1;
 drop table if exists sirv_test13_result2;
@@ -6858,7 +6858,7 @@ select * from sirv_test13_result2;
 -- ----------------------------------------------------------------------
 --start_ignore
 
-drop language if exists plpython3u cascade;
+drop extension if exists plpython3u cascade;
 
 drop table if exists sirv_test14_result1;
 


### PR DESCRIPTION
Fix tests in src/test/isolation2/expected/export_distributed_snapshot.out

Commit 50fc694 introduced trusted extensions, and DROP EXTENSION should now be
used instead of DROP LANGUAGE.
