### PR TITLE
Fix tests in src/bin/pg_upgrade

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -147,7 +147,8 @@ ExecVacuum(ParseState *pstate, VacuumStmt *vacstmt, bool isTopLevel, bool auto_s
 	params.truncate = VACOPT_TERNARY_DEFAULT;
 
 	/* By default parallel vacuum is enabled */
-	params.nworkers = 0;
+	/* VACUUM option "parallel" not supported in GPDB */
+	params.nworkers = -1;
 
 	/* Parse options list */
 	foreach(lc, vacstmt->options)


### PR DESCRIPTION
Fix tests in src/bin/pg_upgrade

Commit 40d964e allowed the vacuum command to process indexes in parallel,
although GPDB does not support parallel background worker processes.