### PR TITLE
Fix 'portals_updatable' regression test with JIT

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -1543,7 +1543,7 @@ llvm_compile_expr(ExprState *state)
 
 			case EEOP_CURRENTOFEXPR:
 				build_EvalXFunc(b, mod, "ExecEvalCurrentOfExpr",
-								v_state, op);
+								v_state, op, v_econtext);
 				LLVMBuildBr(b, opblocks[opno + 1]);
 				break;
 


### PR DESCRIPTION
Fix 'portals_updatable' regression test with JIT

Problem description:
Regression test 'portals_updatable' failed with JIT enabled with the error:
'parameter mismatch: ExecEvalCurrentOfExpr expects 3 passed 2'. Function
'ExecEvalCurrentOfExpr()' expects 3 parameters: 'state', 'op' and 'econtext'.
But only 'state' and 'op' were supplied.

Fix:
Pass also 'v_econtext' as 3rd parameter to 'ExecEvalCurrentOfExpr()' in
'llvm_compile_expr()'.