### PR TITLE
Fix conflicts in 'src/include/access/tupmacs.h'

### DIFF
--- a/src/include/access/tupmacs.h
+++ b/src/include/access/tupmacs.h
@@ -14,13 +14,8 @@
 #ifndef TUPMACS_H
 #define TUPMACS_H
 
-<<<<<<< HEAD
 #include "catalog/pg_magic_oid.h"
 #include "catalog/pg_type.h"
-=======
-#include "catalog/pg_type_d.h"	/* for TYPALIGN macros */
-
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 /*
  * Check a tuple's null bitmap to determine whether the attribute is null.


### PR DESCRIPTION
Fix conflicts in 'src/include/access/tupmacs.h'

Commit 3ed2005ff595 added include of file 'catalog/pg_type_d.h' into
'src/include/access/tupmacs.h', while earlier 6b0e52beadd6 also added includes
in the same place. This patch resolves the conflict by leaving the existing
include of 'catalog/pg_type.h', which internally includes 'catalog/pg_type_d.h'.