### PR TITLE
Fix conflicts in 'src/include/catalog/catversion.h'

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302511051
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202003051
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+#define CATALOG_VERSION_NO	302511211
 
 #endif


### PR DESCRIPTION
Fix conflicts in 'src/include/catalog/catversion.h'

Commit bb03010b9f07 updated CATALOG_VERSION_NO, while earlier commit
db2a79816e3c also did the same. This patch resolves the conflict by setting
CATALOG_VERSION_NO to today's date.
