### PR TITLE
Fix conflicts in 'src/include/commands/vacuum.h'

### DIFF
--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -18,12 +18,8 @@
 #include "catalog/pg_class.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_type.h"
-<<<<<<< HEAD
 #include "fmgr.h"
-#include "nodes/parsenodes.h"
-=======
 #include "parser/parse_node.h"
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 #include "storage/buf.h"
 #include "storage/lock.h"
 #include "utils/relcache.h"


### PR DESCRIPTION
Fix conflicts in 'src/include/commands/vacuum.h'

Commit 3c173a53a825 replaced include of 'nodes/parsenodes.h' with
'parser/parse_node.h' in the file 'src/include/commands/vacuum.h', while commit
90bf1c632662 added include of 'fmgr.h' right above. This patch resolves the
conflict by keeping includes of 'fmgr.h' and 'parser/parse_node.h'.