### PR TITLE
Fix conflicts in 'execExpr.h' and 'execExprInterp.c'

### DIFF
--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -444,15 +444,9 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 		&&CASE_EEOP_AGG_DESERIALIZE,
 		&&CASE_EEOP_AGG_STRICT_INPUT_CHECK_ARGS,
 		&&CASE_EEOP_AGG_STRICT_INPUT_CHECK_NULLS,
-<<<<<<< HEAD
-		&&CASE_EEOP_AGG_INIT_TRANS,
-		&&CASE_EEOP_AGG_STRICT_TRANS_CHECK,
-		&&CASE_EEOP_AGG_PLAIN_PERGROUP_NULLCHECK,
-=======
 		&&CASE_EEOP_AGG_PLAIN_PERGROUP_NULLCHECK,
 		&&CASE_EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYVAL,
 		&&CASE_EEOP_AGG_PLAIN_TRANS_STRICT_BYVAL,
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 		&&CASE_EEOP_AGG_PLAIN_TRANS_BYVAL,
 		&&CASE_EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYREF,
 		&&CASE_EEOP_AGG_PLAIN_TRANS_STRICT_BYREF,
@@ -1677,33 +1671,6 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 
 		/*
 		 * Check for a NULL pointer to the per-group states.
-<<<<<<< HEAD
-		 */
-
-		EEO_CASE(EEOP_AGG_PLAIN_PERGROUP_NULLCHECK)
-		{
-			AggState   *aggstate = castNode(AggState, state->parent);
-			AggStatePerGroup pergroup_allaggs = aggstate->all_pergroups
-				[op->d.agg_plain_pergroup_nullcheck.setoff];
-
-			if (pergroup_allaggs == NULL)
-				EEO_JUMP(op->d.agg_plain_pergroup_nullcheck.jumpnull);
-
-			EEO_NEXT();
-		}
-
-		/*
-		 * Different types of aggregate transition functions are implemented
-		 * as different types of steps, to avoid incurring unnecessary
-		 * overhead.  There's a step type for each valid combination of having
-		 * a by value / by reference transition type, [not] needing to the
-		 * initialize the transition value for the first row in a group from
-		 * input, and [not] strict transition function.
-		 *
-		 * Could optimize further by splitting off by-reference for
-		 * fixed-length types, but currently that doesn't seem worth it.
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 		 */
 
 		EEO_CASE(EEOP_AGG_PLAIN_PERGROUP_NULLCHECK)

--- a/src/include/executor/execExpr.h
+++ b/src/include/executor/execExpr.h
@@ -231,15 +231,9 @@ typedef enum ExprEvalOp
 	EEOP_AGG_DESERIALIZE,
 	EEOP_AGG_STRICT_INPUT_CHECK_ARGS,
 	EEOP_AGG_STRICT_INPUT_CHECK_NULLS,
-<<<<<<< HEAD
-	EEOP_AGG_INIT_TRANS,
-	EEOP_AGG_STRICT_TRANS_CHECK,
-	EEOP_AGG_PLAIN_PERGROUP_NULLCHECK,
-=======
 	EEOP_AGG_PLAIN_PERGROUP_NULLCHECK,
 	EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYVAL,
 	EEOP_AGG_PLAIN_TRANS_STRICT_BYVAL,
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 	EEOP_AGG_PLAIN_TRANS_BYVAL,
 	EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYREF,
 	EEOP_AGG_PLAIN_TRANS_STRICT_BYREF,
@@ -687,28 +681,8 @@ typedef struct ExprEvalStep
 			int			jumpnull;
 		}			agg_plain_pergroup_nullcheck;
 
-<<<<<<< HEAD
-		/* for EEOP_AGG_PLAIN_PERGROUP_NULLCHECK */
-		struct
-		{
-			int			setoff;
-			int			jumpnull;
-		}			agg_plain_pergroup_nullcheck;
-
-		/* for EEOP_AGG_STRICT_TRANS_CHECK */
-		struct
-		{
-			int			setno;
-			int			transno;
-			int			setoff;
-			int			jumpnull;
-		}			agg_strict_trans_check;
-
-		/* for EEOP_AGG_{PLAIN,ORDERED}_TRANS* */
-=======
 		/* for EEOP_AGG_PLAIN_TRANS_[INIT_][STRICT_]{BYVAL,BYREF} */
 		/* for EEOP_AGG_ORDERED_TRANS_{DATUM,TUPLE} */
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 		struct
 		{
 			AggStatePerTrans pertrans;


### PR DESCRIPTION
Fix conflicts in 'execExpr.h' and 'execExprInterp.c'

1. In file 'src/include/executor/execExpr.h' commit 2742c4508007 replaced enum 
ExprEvalOp values EEOP_AGG_INIT_TRANS with 
EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYVAL, and EEOP_AGG_STRICT_TRANS_CHECK with 
EEOP_AGG_PLAIN_TRANS_STRICT_BYVAL. Commit c954d4904650 added new 
EEOP_AGG_PLAIN_PERGROUP_NULLCHECK enum value above these renamed values, while 
commit 19cd1cf4b68f also added the same EEOP_AGG_PLAIN_PERGROUP_NULLCHECK, but 
below the values before the renaming. This patch resolves the conflict by 
keeping the upstream version. The same change is done in the conflict in array 
'dispatch_table' inside function 'ExecInterpExpr()' in 
'src/backend/executor/execExprInterp.c'. 

2. In file 'src/include/executor/execExpr.h' commit 2742c4508007 replaced nested 
structs 'agg_init_trans' and 'agg_strict_trans_check' with comments in the 
struct ExprEvalStep, while earlier 19cd1cf4b68f added 
`agg_plain_pergroup_nullcheck` above the removed structs. This patch resolves 
the conflict by keeping the upstream version. 

3. In file 'src/backend/executor/execExprInterp.c' commit c954d4904650 added 
handling for EEOP_AGG_PLAIN_PERGROUP_NULLCHECK, while earlier commit 
19cd1cf4b68f also added the same code. This patch resolves the conflict by 
keeping the upstream version. 