### PR TITLE
Fix conflicts in 'configure' and 'configure.in'

### DIFF
--- a/configure
+++ b/configure
@@ -580,21 +580,12 @@ MFLAGS=
 MAKEFLAGS=
 
 # Identity of this package.
-<<<<<<< HEAD
 PACKAGE_NAME='Greenplum Database'
 PACKAGE_TARNAME='greenplum-database'
 PACKAGE_VERSION='8.0.0-alpha.0'
 PACKAGE_STRING='Greenplum Database 8.0.0-alpha.0'
 PACKAGE_BUGREPORT='support@greenplum.org'
 PACKAGE_URL=''
-=======
-PACKAGE_NAME='PostgreSQL'
-PACKAGE_TARNAME='postgresql'
-PACKAGE_VERSION='13devel'
-PACKAGE_STRING='PostgreSQL 13devel'
-PACKAGE_BUGREPORT='pgsql-bugs@lists.postgresql.org'
-PACKAGE_URL='https://www.postgresql.org/'
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 ac_unique_file="src/backend/access/common/heaptuple.c"
 ac_default_prefix=/usr/local/gpdb
@@ -1675,12 +1666,7 @@ Some influential environment variables:
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
 
-<<<<<<< HEAD
 Report bugs to <support@greenplum.org>.
-=======
-Report bugs to <pgsql-bugs@lists.postgresql.org>.
-PostgreSQL home page: <https://www.postgresql.org/>.
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 _ACEOF
 ac_status=$?
 fi
@@ -2885,13 +2871,9 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-<<<<<<< HEAD
 PG_MAJORVERSION=`expr "$PG_PACKAGE_VERSION" : '\([0-9][0-9]*\)'`
-=======
-PG_MAJORVERSION=`expr "$PACKAGE_VERSION" : '\([0-9][0-9]*\)'`
-PG_MINORVERSION=`expr "$PACKAGE_VERSION" : '.*\.\([0-9][0-9]*\)'`
+PG_MINORVERSION=`expr "$PG_PACKAGE_VERSION" : '.*\.\([0-9][0-9]*\)'`
 test -n "$PG_MINORVERSION" || PG_MINORVERSION=0
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 
 cat >>confdefs.h <<_ACEOF
@@ -2899,9 +2881,6 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-<<<<<<< HEAD
-PG_VERSION="$PG_PACKAGE_VERSION"
-=======
 cat >>confdefs.h <<_ACEOF
 #define PG_MAJORVERSION_NUM $PG_MAJORVERSION
 _ACEOF
@@ -2912,7 +2891,7 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+PG_VERSION="$PG_PACKAGE_VERSION"
 
 
 
@@ -21593,12 +21572,7 @@ _ACEOF
 
 # Supply a numeric version string for use by 3rd party add-ons
 # awk -F is a regex on some platforms, and not on others, so make "." a tab
-<<<<<<< HEAD
-PG_VERSION_NUM="`echo "$PG_PACKAGE_VERSION" | sed 's/[A-Za-z].*$//' |
-tr '.' '	' |
-=======
 PG_VERSION_NUM="`echo $PG_MAJORVERSION $PG_MINORVERSION |
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 $AWK '{printf "%d%04d", $1, $2}'`"
 
 cat >>confdefs.h <<_ACEOF
@@ -22265,12 +22239,7 @@ $config_links
 Configuration commands:
 $config_commands
 
-<<<<<<< HEAD
 Report bugs to <support@greenplum.org>."
-=======
-Report bugs to <pgsql-bugs@lists.postgresql.org>.
-PostgreSQL home page: <https://www.postgresql.org/>."
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 _ACEOF
 cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1

--- a/configure
+++ b/configure
@@ -585,7 +585,7 @@ PACKAGE_TARNAME='greenplum-database'
 PACKAGE_VERSION='8.0.0-alpha.0'
 PACKAGE_STRING='Greenplum Database 8.0.0-alpha.0'
 PACKAGE_BUGREPORT='support@greenplum.org'
-PACKAGE_URL=''
+PACKAGE_URL='https://greengagedb.org/'
 
 ac_unique_file="src/backend/access/common/heaptuple.c"
 ac_default_prefix=/usr/local/gpdb
@@ -1667,6 +1667,7 @@ Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
 
 Report bugs to <support@greenplum.org>.
+Greenplum Database home page: <https://greengagedb.org/>.
 _ACEOF
 ac_status=$?
 fi
@@ -22239,7 +22240,8 @@ $config_links
 Configuration commands:
 $config_commands
 
-Report bugs to <support@greenplum.org>."
+Report bugs to <support@greenplum.org>.
+Greenplum Database home page: <https://greengagedb.org/>."
 
 _ACEOF
 cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1

--- a/configure.in
+++ b/configure.in
@@ -17,16 +17,12 @@ dnl Read the Autoconf manual for details.
 dnl
 m4_pattern_forbid(^PGAC_)dnl to catch undefined macros
 
-<<<<<<< HEAD
 dnl The PACKAGE_VERSION from upstream PostgreSQL is maintained in the
 dnl PG_PACKAGE_VERSION variable, when merging make sure to update this
 dnl variable with the merge conflict from the AC_INIT() statement.
 AC_INIT([Greenplum Database], [8.0.0-alpha.0], [support@greenplum.org])
 [PG_PACKAGE_VERSION=13alpha0]
 AC_SUBST(PG_PACKAGE_VERSION)
-=======
-AC_INIT([PostgreSQL], [13devel], [pgsql-bugs@lists.postgresql.org], [], [https://www.postgresql.org/])
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 dnl m4_if(m4_defn([m4_PACKAGE_VERSION]), [2.69], [], [m4_fatal([Autoconf version 2.69 is required.
 dnl Untested combinations of 'autoconf' and PostgreSQL versions are not
@@ -38,13 +34,9 @@ AC_CONFIG_AUX_DIR(config)
 AC_PREFIX_DEFAULT(/usr/local/gpdb)
 AC_DEFINE_UNQUOTED(CONFIGURE_ARGS, ["$ac_configure_args"], [Saved arguments from configure])
 
-<<<<<<< HEAD
 [PG_MAJORVERSION=`expr "$PG_PACKAGE_VERSION" : '\([0-9][0-9]*\)'`]
-=======
-[PG_MAJORVERSION=`expr "$PACKAGE_VERSION" : '\([0-9][0-9]*\)'`]
-[PG_MINORVERSION=`expr "$PACKAGE_VERSION" : '.*\.\([0-9][0-9]*\)'`]
+[PG_MINORVERSION=`expr "$PG_PACKAGE_VERSION" : '.*\.\([0-9][0-9]*\)'`]
 test -n "$PG_MINORVERSION" || PG_MINORVERSION=0
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 AC_SUBST(PG_MAJORVERSION)
 AC_DEFINE_UNQUOTED(PG_MAJORVERSION, "$PG_MAJORVERSION", [PostgreSQL major version as a string])
 AC_DEFINE_UNQUOTED(PG_MAJORVERSION_NUM, $PG_MAJORVERSION, [PostgreSQL major version number])
@@ -95,11 +87,7 @@ PostgreSQL has apparently not been ported to your platform yet.
 To try a manual configuration, look into the src/template directory
 for a similar platform and use the '--with-template=' option.
 
-<<<<<<< HEAD
 Please also contact <bugs@greenplum.org> to see about
-=======
-Please also contact <]AC_PACKAGE_BUGREPORT[> to see about
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 rectifying this.  Include the above 'checking host system type...'
 line.
 *******************************************************************
@@ -2776,12 +2764,7 @@ AC_DEFINE_UNQUOTED(PG_VERSION_STR,
 
 # Supply a numeric version string for use by 3rd party add-ons
 # awk -F is a regex on some platforms, and not on others, so make "." a tab
-<<<<<<< HEAD
-[PG_VERSION_NUM="`echo "$PG_PACKAGE_VERSION" | sed 's/[A-Za-z].*$//' |
-tr '.' '	' |
-=======
 [PG_VERSION_NUM="`echo $PG_MAJORVERSION $PG_MINORVERSION |
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 $AWK '{printf "%d%04d", $1, $2}'`"]
 AC_DEFINE_UNQUOTED(PG_VERSION_NUM, $PG_VERSION_NUM, [PostgreSQL version as a number])
 AC_SUBST(PG_VERSION_NUM)

--- a/configure.in
+++ b/configure.in
@@ -20,7 +20,7 @@ m4_pattern_forbid(^PGAC_)dnl to catch undefined macros
 dnl The PACKAGE_VERSION from upstream PostgreSQL is maintained in the
 dnl PG_PACKAGE_VERSION variable, when merging make sure to update this
 dnl variable with the merge conflict from the AC_INIT() statement.
-AC_INIT([Greenplum Database], [8.0.0-alpha.0], [support@greenplum.org])
+AC_INIT([Greenplum Database], [8.0.0-alpha.0], [support@greenplum.org], [], [https://greengagedb.org/])
 [PG_PACKAGE_VERSION=13alpha0]
 AC_SUBST(PG_PACKAGE_VERSION)
 


### PR DESCRIPTION
Fix conflicts in 'configure' and 'configure.in'

Fixes for 'configure.in':
1) Commit 1933ae629e7b706c6c23673a381e778819db307d adds PostgreSQL URL. Keep
GPDB email with adding URL greengagedb.org.
2) Commit 0a42a2e9ce8481a024d085f2cc526a366db8df59 adds macro PG_MINORVERSION,
which is taken from $PACKAGE_VERSION. Change $PACKAGE_VERSION to
$PG_PACKAGE_VERSION as it is for macro PG_MAJORVERSION.
3) Commit 0075c29f540274ad99700281b38c8475ef1c88f9 removes "\\" from comment,
which contains email. Keep GPDB email.

Script 'configure' was generated by autoconf-2.69 after fixing 'configure.in'.