### PR TITLE
Fix conflicts in 'src/include/storage/fd.h'

### DIFF
--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -161,12 +161,8 @@ extern void fsync_fname(const char *fname, bool isdir);
 extern int	fsync_fname_ext(const char *fname, bool isdir, bool ignore_perm, int elevel);
 extern int	durable_rename(const char *oldfile, const char *newfile, int loglevel);
 extern int	durable_unlink(const char *fname, int loglevel);
-<<<<<<< HEAD
-extern int	durable_link_or_rename(const char *oldfile, const char *newfile, int loglevel);
-extern void SyncAllXLogFiles(void);
-=======
 extern int	durable_rename_excl(const char *oldfile, const char *newfile, int loglevel);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+extern void SyncAllXLogFiles(void);
 extern void SyncDataDirectory(void);
 extern int	data_sync_elevel(int elevel);
 


### PR DESCRIPTION
Fix conflicts in 'src/include/storage/fd.h'

Commit aaa3aeddee51dd0058d38469907865052706a590 renames and changes function
durable_link_or_rename to durable_rename_excl. Keep the same place for new
function in the fd.h.
