### PR TITLE
Fix conflicts in nodes/parsenodes.h, commands/typecmds.c and tcop/utility.c

### DIFF
--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -3787,13 +3787,12 @@ AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 }
 
 /*
-<<<<<<< HEAD
  * Currently, we only land here if the user has issued:
  *
  * ALTER TYPE <typname> SET DEFAULT ENCODING (...)
  */
 void
-AlterType(AlterTypeStmt *stmt)
+AlterTypeSetDefaultEnc(AlterTypeStmtSetDefaultEnc *stmt)
 {
 	TypeName   *typname;
 	Oid			typid;
@@ -3832,7 +3831,9 @@ AlterType(AlterTypeStmt *stmt)
 									DF_NEED_TWO_PHASE,
 									NIL,
 									NULL);
-=======
+}
+
+/*
  * AlterType
  *		ALTER TYPE <type> SET (option = ...)
  *
@@ -4178,5 +4179,4 @@ AlterTypeRecurse(Oid typeOid, HeapTuple tup, Relation catalog,
 	}
 
 	systable_endscan(scan);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -193,12 +193,8 @@ DefineType(ParseState *pstate, List *names, List *parameters)
 	char	   *array_type;
 	Oid			array_oid;
 	Oid			typoid;
-<<<<<<< HEAD
-	Oid			resulttype;
 	Datum		typoptions = 0;
 	List	   *encoding = NIL;
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 	ListCell   *pl;
 	ObjectAddress address;
 
@@ -245,52 +241,7 @@ DefineType(ParseState *pstate, List *names, List *parameters)
 	{
 		if (moveArrayTypeName(typoid, typeName, typeNamespace))
 			typoid = InvalidOid;
-<<<<<<< HEAD
-	}
-
-	/*
-	 * If it doesn't exist, create it as a shell, so that the OID is known for
-	 * use in the I/O function definitions.
-	 */
-	if (!OidIsValid(typoid))
-	{
-		address = TypeShellMake(typeName, typeNamespace, GetUserId());
-		typoid = address.objectId;
-		/* Make new shell type visible for modification below */
-		CommandCounterIncrement();
-
-		/*
-		 * If the command was a parameterless CREATE TYPE, we're done ---
-		 * creating the shell type was all we're supposed to do.
-		 */
-		if (parameters == NIL)
-		{
-			/* Must dispatch shell type creation */
-			if (Gp_role == GP_ROLE_DISPATCH)
-			{
-				DefineStmt * stmt = makeNode(DefineStmt);
-				stmt->kind = OBJECT_TYPE;
-				stmt->oldstyle = false; /*?*/
-				stmt->defnames = names;
-				stmt->args = NIL;
-				stmt->definition = NIL;
-				CdbDispatchUtilityStatement((Node *) stmt,
-											DF_CANCEL_ON_ERROR|
-											DF_WITH_SNAPSHOT|
-											DF_NEED_TWO_PHASE,
-											GetAssignedOidsForDispatch(),
-											NULL);
-			}
-			return address;
-		}
-	}
-	else
-	{
-		/* Complain if dummy CREATE TYPE and entry already exists */
-		if (parameters == NIL)
-=======
 		else
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
 					 errmsg("type \"%s\" already exists", typeName)));
@@ -308,6 +259,23 @@ DefineType(ParseState *pstate, List *names, List *parameters)
 					 errmsg("type \"%s\" already exists", typeName)));
 
 		address = TypeShellMake(typeName, typeNamespace, GetUserId());
+
+		/* Must dispatch shell type creation */
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			DefineStmt * stmt = makeNode(DefineStmt);
+			stmt->kind = OBJECT_TYPE;
+			stmt->oldstyle = false; /*?*/
+			stmt->defnames = names;
+			stmt->args = NIL;
+			stmt->definition = NIL;
+			CdbDispatchUtilityStatement((Node *) stmt,
+										DF_CANCEL_ON_ERROR|
+										DF_WITH_SNAPSHOT|
+										DF_NEED_TWO_PHASE,
+										GetAssignedOidsForDispatch(),
+										NULL);
+		}
 		return address;
 	}
 

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -5355,10 +5355,10 @@ _copyTableValueExpr(const TableValueExpr *from)
 	return newnode;
 }
 
-static AlterTypeStmt *
-_copyAlterTypeStmt(const AlterTypeStmt *from)
+static AlterTypeStmtSetDefaultEnc *
+_copyAlterTypeStmtSetDefaultEnc(const AlterTypeStmtSetDefaultEnc *from)
 {
-	AlterTypeStmt *newnode = makeNode(AlterTypeStmt);
+	AlterTypeStmtSetDefaultEnc *newnode = makeNode(AlterTypeStmtSetDefaultEnc);
 
 	COPY_NODE_FIELD(typeName);
 	COPY_NODE_FIELD(encoding);
@@ -6818,8 +6818,8 @@ copyObjectImpl(const void *from)
 		case T_TableValueExpr:
 			retval = _copyTableValueExpr(from);
 			break;
-		case T_AlterTypeStmt:
-			retval = _copyAlterTypeStmt(from);
+		case T_AlterTypeStmtSetDefaultEnc:
+			retval = _copyAlterTypeStmtSetDefaultEnc(from);
 			break;
 
 		case T_DenyLoginInterval:

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -3092,7 +3092,7 @@ _equalTableValueExpr(const TableValueExpr *a, const TableValueExpr *b)
 }
 
 static bool
-_equalAlterTypeStmt(const AlterTypeStmt *a, const AlterTypeStmt *b)
+_equalAlterTypeStmtSetDefaultEnc(const AlterTypeStmtSetDefaultEnc *a, const AlterTypeStmtSetDefaultEnc *b)
 {
 	COMPARE_NODE_FIELD(typeName);
 	COMPARE_NODE_FIELD(encoding);
@@ -4060,8 +4060,8 @@ equal(const void *a, const void *b)
 		case T_DenyLoginPoint:
 			retval = _equalDenyLoginPoint(a, b);
 			break;
-		case T_AlterTypeStmt:
-			retval = _equalAlterTypeStmt(a, b);
+		case T_AlterTypeStmtSetDefaultEnc:
+			retval = _equalAlterTypeStmtSetDefaultEnc(a, b);
 			break;
 		case T_DistributedBy:
 			retval = _equalDistributedBy(a, b);

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1733,8 +1733,8 @@ _outNode(StringInfo str, void *obj)
 				_outDenyLoginPoint(str, obj);
 				break;
 
-			case T_AlterTypeStmt:
-				_outAlterTypeStmt(str, obj);
+			case T_AlterTypeStmtSetDefaultEnc:
+				_outAlterTypeStmtSetDefaultEnc(str, obj);
 				break;
 			case T_AlterExtensionStmt:
 				_outAlterExtensionStmt(str, obj);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -5301,9 +5301,9 @@ _outTableValueExpr(StringInfo str, const TableValueExpr *node)
 }
 
 static void
-_outAlterTypeStmt(StringInfo str, const AlterTypeStmt *node)
+_outAlterTypeStmtSetDefaultEnc(StringInfo str, const AlterTypeStmtSetDefaultEnc *node)
 {
-	WRITE_NODE_TYPE("ALTERTYPESTMT");
+	WRITE_NODE_TYPE("ALTERTYPESTMTSETDEFAULTENC");
 
 	WRITE_NODE_FIELD(typeName);
 	WRITE_NODE_FIELD(encoding);
@@ -6503,8 +6503,8 @@ outNode(StringInfo str, const void *obj)
 				_outDenyLoginPoint(str, obj);
 				break;
 
-			case T_AlterTypeStmt:
-				_outAlterTypeStmt(str, obj);
+			case T_AlterTypeStmtSetDefaultEnc:
+				_outAlterTypeStmtSetDefaultEnc(str, obj);
 				break;
 			case T_AlterExtensionStmt:
 				_outAlterExtensionStmt(str, obj);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2479,8 +2479,8 @@ readNodeBinary(void)
 				return_value = _readTableValueExpr();
 				break;
 
-			case T_AlterTypeStmt:
-				return_value = _readAlterTypeStmt();
+			case T_AlterTypeStmtSetDefaultEnc:
+				return_value = _readAlterTypeStmtSetDefaultEnc();
 				break;
 			case T_AlterExtensionStmt:
 				return_value = _readAlterExtensionStmt();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -4288,10 +4288,10 @@ _readTableValueExpr(void)
 	READ_DONE();
 }
 
-static AlterTypeStmt *
-_readAlterTypeStmt(void)
+static AlterTypeStmtSetDefaultEnc *
+_readAlterTypeStmtSetDefaultEnc(void)
 {
-	READ_LOCALS(AlterTypeStmt);
+	READ_LOCALS(AlterTypeStmtSetDefaultEnc);
 
 	READ_NODE_FIELD(typeName);
 	READ_NODE_FIELD(encoding);
@@ -4781,8 +4781,8 @@ parseNodeString(void)
 		return_value = _readAlterDatabaseStmt();
 	else if (MATCHX("ALTERTABLESTMT"))
 		return_value = _readAlterTableStmt();
-	else if (MATCHX("ALTERTYPESTMT"))
-		return_value = _readAlterTypeStmt();
+	else if (MATCHX("ALTERTYPESTMTSETDEFAULTENC"))
+		return_value = _readAlterTypeStmtSetDefaultEnc();
 	else if (MATCHX("CDBPROCESS"))
 		return_value = _readCdbProcess();
 	else if (MATCHX("CLUSTERSTMT"))

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -300,7 +300,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 		RetrieveStmt
 
 /* GPDB-specific commands */
-%type <node>	AlterTypeStmt AlterQueueStmt AlterResourceGroupStmt
+%type <node>	AlterTypeStmtSetDefaultEnc AlterQueueStmt AlterResourceGroupStmt
 		CreateExternalStmt
 		CreateQueueStmt CreateResourceGroupStmt
 		DropQueueStmt DropResourceGroupStmt
@@ -1312,7 +1312,7 @@ stmt :
 			| AlterStatsStmt
 			| AlterTSConfigurationStmt
 			| AlterTSDictionaryStmt
-			| AlterTypeStmt
+			| AlterTypeStmtSetDefaultEnc
 			| AlterUserMappingStmt
 			| AnalyzeStmt
 			| CallStmt
@@ -11074,9 +11074,9 @@ reindex_option_elem:
  *
  * Used to set storage parameter defaults for types.
  */
-AlterTypeStmt: ALTER TYPE_P any_name SET DEFAULT ENCODING definition
+AlterTypeStmtSetDefaultEnc: ALTER TYPE_P any_name SET DEFAULT ENCODING definition
 				{
-					AlterTypeStmt *n = makeNode(AlterTypeStmt);
+					AlterTypeStmtSetDefaultEnc *n = makeNode(AlterTypeStmtSetDefaultEnc);
 
 					n->typeName = $3;
 					n->encoding = $7;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -176,6 +176,7 @@ ClassifyUtilityCommandAsReadOnly(Node *parsetree)
 		case T_AlterTableSpaceOptionsStmt:
 		case T_AlterTableStmt:
 		case T_AlterTypeStmt:
+		case T_AlterTypeStmtSetDefaultEnc:
 		case T_AlterUserMappingStmt:
 		case T_CommentStmt:
 		case T_CompositeTypeStmt:
@@ -2043,8 +2044,8 @@ ProcessUtilitySlow(ParseState *pstate,
 				commandCollected = true;
 				break;
 
-			case T_AlterTypeStmt:
-				AlterType((AlterTypeStmt *) parsetree);
+			case T_AlterTypeStmtSetDefaultEnc:
+				AlterTypeSetDefaultEnc((AlterTypeStmtSetDefaultEnc *) parsetree);
 				break;
 
 			case T_DropStmt:
@@ -3573,7 +3574,7 @@ CreateCommandTag(Node *parsetree)
 			}
 			break;
 
-		case T_AlterTypeStmt:
+		case T_AlterTypeStmtSetDefaultEnc:
 			tag = "ALTER TYPE";
 			break;
 

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -55,7 +55,7 @@ extern Oid AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 									  bool isImplicitArray,
 									  bool errorOnTableType,
 									  ObjectAddresses *objsMoved);
-extern void AlterType(AlterTypeStmt *stmt);
+extern void AlterTypeSetDefaultEnc(AlterTypeStmtSetDefaultEnc *stmt);
 
 extern ObjectAddress AlterType(AlterTypeStmt *stmt);
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -517,7 +517,7 @@ typedef enum NodeTag
 	T_TableValueExpr,
 	T_DenyLoginInterval,
 	T_DenyLoginPoint,
-	T_AlterTypeStmt,
+	T_AlterTypeStmtSetDefaultEnc,
 	T_AlteredTableInfo,
 	T_NewConstraint,
 	T_NewColumnValue,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3464,20 +3464,17 @@ typedef struct AlterOwnerStmt
 	RoleSpec   *newowner;		/* the new owner */
 } AlterOwnerStmt;
 
-<<<<<<< HEAD
 /* ----------------------
  * ALTER TYPE ... SET DEFAULT ENCODING ()
  * ----------------------
  */
-typedef struct AlterTypeStmt
+typedef struct AlterTypeStmtSetDefaultEnc
 {
 	NodeTag		type;
 	List	   *typeName;
 	List	   *encoding;
-} AlterTypeStmt;
+} AlterTypeStmtSetDefaultEnc;
 
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 /* ----------------------
  *		Alter Operator Set ( this-n-that )
  * ----------------------


### PR DESCRIPTION
Fix conflicts in nodes/parsenodes.h, commands/typecmds.c and tcop/utility.c

1. Commit fe30e7ebfa38 added 'ALTER TYPE <type> SET (option = ...)' command,
while GPDB already had its specific 'ALTER TYPE <typname> SET DEFAULT ENCODING'.
Both used the same NodeTag enum value (T_AlterTypeStmt), same struct name
for parse tree node (AlterTypeStmt) and etc. This patch resolves the conflicts 
by renaming GPDB-specific structures, functions, etc (adding 'SetDefaultEnc'
postfix), and, therefore, keeping both commands.

2. In the file 'src/backend/commands/typecmds.c' commit bb03010b9f07 removed
'resulttype' local variable from DefineType() function, while earlier
6b0e52beadd6 added 'typoptions' and 'encoding' right above it. Resolve this
conflict by keeping GPDB-specific vars.

3. In the file 'src/backend/commands/typecmds.c' commit bb03010b9f07 removed
part of code in DefineType() function, while earlier 6b0e52beadd6 added
dispatching of utility statement for a type creation in that part of code.
Resolve this conflict by moving the GPDB-specific dispatch code into an
equivalent location right after TypeShellMake() (similar to previous logic).
