### PR TITLE
Fix conflicts in 'src/backend/access/tablesample/bernoulli.c'

### DIFF
--- a/src/backend/access/tablesample/bernoulli.c
+++ b/src/backend/access/tablesample/bernoulli.c
@@ -31,6 +31,7 @@
 #include "common/hashfn.h"
 #include "optimizer/optimizer.h"
 #include "utils/builtins.h"
+
 #include "optimizer/cost.h"
 
 

--- a/src/backend/access/tablesample/bernoulli.c
+++ b/src/backend/access/tablesample/bernoulli.c
@@ -31,11 +31,7 @@
 #include "common/hashfn.h"
 #include "optimizer/optimizer.h"
 #include "utils/builtins.h"
-<<<<<<< HEAD
-
 #include "optimizer/cost.h"
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 
 /* Private state */


### PR DESCRIPTION
Fix conflicts in 'src/backend/access/tablesample/bernoulli.c'

Commit 05d8449 removed the last include, even though we had a GPDB-specific
include nearby. It shouldn't be lumped together with upstream includes.