### PR TITLE
Fix conflicts in src/backend/catalog/dependency.c

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -81,11 +81,8 @@
 #include "parser/parsetree.h"
 #include "rewrite/rewriteRemove.h"
 #include "storage/lmgr.h"
-<<<<<<< HEAD
-#include "utils/builtins.h"
-=======
 #include "utils/acl.h"
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+#include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"


### PR DESCRIPTION
Fix conflicts in src/backend/catalog/dependency.c

Commit 3c173a5 added a new include utils/acl.h to
src/backend/catalog/dependency.c, while the earlier commit ea4686e had already
added an include utils/builtins.h to the same location.