### PR TITLE
Fix conflicts in 'src/backend/catalog/pg_publication.c'

### DIFF
--- a/src/backend/catalog/pg_publication.c
+++ b/src/backend/catalog/pg_publication.c
@@ -42,11 +42,9 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "catalog/oid_dispatch.h"
-=======
+
 static List *get_rel_publications(Oid relid);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 /*
  * Check if relation can be in given publication and throws appropriate


### PR DESCRIPTION
Fix conflicts in 'src/backend/catalog/pg_publication.c'

There was conflict at order of includes at the begging of file for our include(
which was added by commit 19cd1cf4b68f) and function's declaration (which was
added by commit 17b9e7f9fe23).