### PR TITLE
Fix conflicts for index.c and lsyscache.c

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -3578,16 +3578,6 @@ reindex_index(Oid indexId, bool skip_constraint_checks, char persistence,
 				 errmsg("cannot reindex temporary tables of other sessions")));
 
 	/*
-<<<<<<< HEAD
-	 * Two-phase commit is not supported for transactions that change
-	 * relfilenode mappings. We can get away without two-phase commit, if
-	 * we're not already running in a transaction block, but if we are,
-	 * we won't be able to commit. To get a more descriptive error message,
-	 * check for that now, rather than let the COMMIT fail.
-	 */
-	if (Gp_role == GP_ROLE_DISPATCH && RelationIsMapped(heapRelation))
-		PreventInTransactionBlock(true, "REINDEX of a catalog table");
-=======
 	 * Don't allow reindex of an invalid index on TOAST table.  This is a
 	 * leftover from a failed REINDEX CONCURRENTLY, and if rebuilt it would
 	 * not be possible to drop it anymore.
@@ -3597,7 +3587,16 @@ reindex_index(Oid indexId, bool skip_constraint_checks, char persistence,
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot reindex invalid index on TOAST table")));
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+
+	/*
+	 * Two-phase commit is not supported for transactions that change
+	 * relfilenode mappings. We can get away without two-phase commit, if
+	 * we're not already running in a transaction block, but if we are,
+	 * we won't be able to commit. To get a more descriptive error message,
+	 * check for that now, rather than let the COMMIT fail.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH && RelationIsMapped(heapRelation))
+		PreventInTransactionBlock(true, "REINDEX of a catalog table");
 
 	/*
 	 * Also check for active uses of the index in the current transaction; we

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -4555,7 +4555,6 @@ get_index_column_opclass(Oid index_oid, int attno)
 	return opclass;
 }
 
-<<<<<<< HEAD
 /* GPDB_12_MERGE_FIXME: only used by ORCA. Fix the callers to check
  * Relation->relkind == RELKIND_PARTITIONED_TABLE instead. They should
  * have the relcache entry at hand anyway.
@@ -4601,7 +4600,8 @@ relation_get_leaf_partitions(Oid oid)
 			leaves = lappend_oid(leaves, descendant);
 	}
 	return leaves;
-=======
+}
+
 /*
  * get_index_isreplident
  *
@@ -4646,5 +4646,4 @@ get_index_isvalid(Oid index_oid)
 	ReleaseSysCache(tuple);
 
 	return isvalid;
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }


### PR DESCRIPTION
Commit 61d7c7b added one more error check to the src/backend/catalog/index.c, 
while GPDB has specific addition at this place.

Placing the check before GPDB code.

Also this commit 61d7c7b added function get_index_isvalid to this file 
and later commit 1cc9c24 added function get_index_isreplident just above 
this code while GPDB had additions to the end of file.
 