### PR TITLE
Fix src/backend/commands/event_trigger.c

### DIFF
--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -78,67 +78,6 @@ typedef struct
 	bool		supported;
 } event_trigger_support_data;
 
-<<<<<<< HEAD
-typedef enum
-{
-	EVENT_TRIGGER_COMMAND_TAG_OK,
-	EVENT_TRIGGER_COMMAND_TAG_NOT_SUPPORTED,
-	EVENT_TRIGGER_COMMAND_TAG_NOT_RECOGNIZED
-} event_trigger_command_tag_check_result;
-
-/* XXX merge this with ObjectTypeMap? */
-static const event_trigger_support_data event_trigger_support[] = {
-	{"ACCESS METHOD", true},
-	{"AGGREGATE", true},
-	{"CAST", true},
-	{"CONSTRAINT", true},
-	{"COLLATION", true},
-	{"CONVERSION", true},
-	{"DATABASE", false},
-	{"DOMAIN", true},
-	{"EXTENSION", true},
-	{"EVENT TRIGGER", false},
-	{"FOREIGN DATA WRAPPER", true},
-	{"FOREIGN TABLE", true},
-	{"FUNCTION", true},
-	{"INDEX", true},
-	{"LANGUAGE", true},
-	{"MATERIALIZED VIEW", true},
-	{"OPERATOR", true},
-	{"OPERATOR CLASS", true},
-	{"OPERATOR FAMILY", true},
-	{"POLICY", true},
-	{"PROCEDURE", true},
-	{"PUBLICATION", true},
-	{"ROLE", false},
-	{"ROUTINE", true},
-	{"RULE", true},
-	{"SCHEMA", true},
-	{"SEQUENCE", true},
-	{"SERVER", true},
-	{"STATISTICS", true},
-	{"SUBSCRIPTION", true},
-	{"TABLE", true},
-	{"TABLESPACE", false},
-	{"TRANSFORM", true},
-	{"TRIGGER", true},
-	{"TEXT SEARCH CONFIGURATION", true},
-	{"TEXT SEARCH DICTIONARY", true},
-	{"TEXT SEARCH PARSER", true},
-	{"TEXT SEARCH TEMPLATE", true},
-	{"TYPE", true},
-	{"USER MAPPING", true},
-	{"VIEW", true},
-
-	/* GPDB additions */
-	{"EXTERNAL TABLE", true},
-	{"PROTOCOL", true},
-
-	{NULL, false}
-};
-
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 /* Support for dropped objects */
 typedef struct SQLDropObject
 {

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -2860,8 +2860,6 @@ ec_member_foreign_arg
 ec_member_matches_arg
 emit_log_hook_type
 eval_const_expressions_context
-event_trigger_command_tag_check_result
-event_trigger_support_data
 exec_thread_arg
 execution_state
 explain_get_index_name_hook_type


### PR DESCRIPTION
Commit 2f96613 has removed event_trigger_command_tag_check_result struct
and event_trigger_support array, while this array had GPDB additions.

Commit 5cbfce5 has removed event_trigger_command_tag_check_result and
event_trigger_support from src/tools/pgindent/typedefs.list which was 
added previously by commit 9af4159. 

Suggest to keep it consistent and make onle PR to this related stuff.
