### PR TITLE
Fix conflicts in 'src/backend/commands/createas.c'

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -453,7 +453,6 @@ ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *stmt,
 		/* run the plan to completion */
 		ExecutorRun(queryDesc, ForwardScanDirection, 0L, true);
 
-<<<<<<< HEAD
 		/* and clean up */
 		ExecutorFinish(queryDesc);
 		ExecutorEnd(queryDesc);
@@ -471,16 +470,9 @@ ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *stmt,
 		/* get object address that intorel_startup saved for us */
 		address = ((DR_intorel *) dest)->reladdr;
 
-		/* save the rowcount if we're given a completionTag to fill */
-		if (completionTag)
-			snprintf(completionTag, COMPLETION_TAG_BUFSIZE,
-					 "SELECT " UINT64_FORMAT,
-					 queryDesc->es_processed);
-=======
 		/* save the rowcount if we're given a qc to fill */
 		if (qc)
-			SetQueryCompletion(qc, CMDTAG_SELECT, queryDesc->estate->es_processed);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+			SetQueryCompletion(qc, CMDTAG_SELECT, queryDesc->estate->es_processed)
 
 		/* MPP-14001: Running auto_stats */
 		if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -472,7 +472,7 @@ ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *stmt,
 
 		/* save the rowcount if we're given a qc to fill */
 		if (qc)
-			SetQueryCompletion(qc, CMDTAG_SELECT, queryDesc->estate->es_processed)
+			SetQueryCompletion(qc, CMDTAG_SELECT, queryDesc->estate->es_processed);
 
 		/* MPP-14001: Running auto_stats */
 		if (Gp_role == GP_ROLE_DISPATCH)


### PR DESCRIPTION
Fix conflicts in 'src/backend/commands/createas.c'

Commit 2f9661311b83 changes command completion tag to structure, but at one
place this commit can not be applied, because lines upper was changed. Patch
applies this commit as it was in original patch.
