### PR TITLE
Fix conflicts in src/backend/commands/portalcmds.c

### DIFF
--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -145,12 +145,8 @@ PerformCursorOpen(ParseState *pstate, DeclareCursorStmt *cstmt, ParamListInfo pa
 	PortalDefineQuery(portal,
 					  NULL,
 					  queryString,
-<<<<<<< HEAD
 					  T_DeclareCursorStmt,
-					  "SELECT", /* cursor's query is always a SELECT */
-=======
 					  CMDTAG_SELECT,	/* cursor's query is always a SELECT */
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 					  list_make1(plan),
 					  NULL);
 


### PR DESCRIPTION
Fix conflicts in src/backend/commands/portalcmds.c

Commit 2f96613 replaced the "SELECT" argument in the PerformCursorOpen function
in the PortalDefineQuery call to CMDTAG_SELECT in
src/backend/commands/portalcmds.c. However, the earlier commit 6b0e52b had
already added the GPDB-specific T_DeclareCursorStmt argument before this point.