### PR TITLE
Fix conflicts in src/backend/executor/execMain.c

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1620,7 +1620,6 @@ ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 		if (get_rel_relkind(rte->relid) == RELKIND_FOREIGN_TABLE)
 			continue;
 
-<<<<<<< HEAD
 		if (isTempNamespace(get_rel_namespace(rte->relid)))
 		{
 			ExecutorMarkTransactionDoesWrites();
@@ -1649,10 +1648,7 @@ ExecCheckXactReadOnly(PlannedStmt *plannedstmt)
 				continue;
         }
 
-		PreventCommandIfReadOnly(CreateCommandTag((Node *) plannedstmt));
-=======
 		PreventCommandIfReadOnly(CreateCommandName((Node *) plannedstmt));
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 	}
 
 	if (plannedstmt->commandType != CMD_SELECT || plannedstmt->hasModifyingCTE)


### PR DESCRIPTION
Fix conflicts in src/backend/executor/execMain.c

Commit 2f96613 replaced the CreateCommandTag function call in the
ExecCheckXactReadOnly function in src/backend/executor/execMain.c with a call
to the CreateCommandName function. However, the earlier commit 6b0e52b had
already added GPDB-specific code before this location.