### PR TITLE
Fix conflicts in src/backend/jit/llvm/llvmjit_expr.c

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -2176,7 +2176,6 @@ llvm_compile_expr(ExprState *state)
 					break;
 				}
 
-<<<<<<< HEAD
 			case EEOP_AGG_PLAIN_PERGROUP_NULLCHECK:
 				{
 					int				 jumpnull;
@@ -2216,10 +2215,8 @@ llvm_compile_expr(ExprState *state)
 					break;
 				}
 
-=======
 			case EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYVAL:
 			case EEOP_AGG_PLAIN_TRANS_STRICT_BYVAL:
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 			case EEOP_AGG_PLAIN_TRANS_BYVAL:
 			case EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYREF:
 			case EEOP_AGG_PLAIN_TRANS_STRICT_BYREF:


### PR DESCRIPTION
Fix conflicts in src/backend/jit/llvm/llvmjit_expr.c

Commit 2742c45 replaced the EEOP_AGG_INIT_TRANS and EEOP_AGG_STRICT_TRANS_CHECK
case handling in the llvm_compile_expr function in
src/backend/jit/llvm/llvmjit_expr.c with EEOP_AGG_PLAIN_TRANS_INIT_STRICT_BYVAL
and EEOP_AGG_PLAIN_TRANS_STRICT_BYVAL. However, the earlier commit 19cd1cf had
already added handling for the GPDB-specific EEOP_AGG_PLAIN_PERGROUP_NULLCHECK
case before this point.