### PR TITLE
Fix website and email conflicts

### DIFF
--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -379,12 +379,8 @@ help(const char *progname)
 	printf(_("\nPlease read the documentation for the complete list of run-time\n"
 			 "configuration settings and how to set them on the command line or in\n"
 			 "the configuration file.\n\n"
-<<<<<<< HEAD
-			 "Report bugs to <bugs@greenplum.org>.\n"));
-=======
 			 "Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 

--- a/src/bin/pg_basebackup/pg_receivewal.c
+++ b/src/bin/pg_basebackup/pg_receivewal.c
@@ -102,12 +102,8 @@ usage(void)
 	printf(_("\nOptional actions:\n"));
 	printf(_("      --create-slot      create a new replication slot (for the slot's name see --slot)\n"));
 	printf(_("      --drop-slot        drop the replication slot (for the slot's name see --slot)\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 static bool

--- a/src/bin/pg_config/pg_config.c
+++ b/src/bin/pg_config/pg_config.c
@@ -102,12 +102,8 @@ help(void)
 	printf(_("  --version             show the PostgreSQL version\n"));
 	printf(_("  -?, --help            show this help, then exit\n"));
 	printf(_("\nWith no arguments, all known items are shown.\n\n"));
-<<<<<<< HEAD
-	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 static void

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -42,12 +42,8 @@ usage(const char *progname)
 	printf(_("  --gp-version   output Greenplum version information, then exit\n"));
 	printf(_("\nIf no data directory (DATADIR) is specified, "
 			 "the environment variable PGDATA\nis used.\n\n"));
-<<<<<<< HEAD
-	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -2295,12 +2295,8 @@ do_help(void)
 	printf(_("  demand     start service on demand\n"));
 #endif
 
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -746,12 +746,8 @@ help(void)
 
 	printf(_("\nIf -f/--file is not used, then the SQL script will be written to the standard\n"
 			 "output.\n\n"));
-<<<<<<< HEAD
-	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 

--- a/src/bin/pg_dump/pg_restore.c
+++ b/src/bin/pg_dump/pg_restore.c
@@ -528,10 +528,6 @@ usage(const char *progname)
 			 "The options -I, -n, -N, -P, -t, -T, and --section can be combined and specified\n"
 			 "multiple times to select multiple objects.\n"));
 	printf(_("\nIf no input file name is supplied, then standard input is used.\n\n"));
-<<<<<<< HEAD
-	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/pg_resetwal/pg_resetwal.c
+++ b/src/bin/pg_resetwal/pg_resetwal.c
@@ -1548,10 +1548,6 @@ usage(void)
 	printf(_("      --next-gxid=GXID           set next distributed transaction ID\n"));
 	printf(_("      --wal-segsize=SIZE         size of WAL segments, in megabytes\n"));
 	printf(_("  -?, --help                     show this help, then exit\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -350,12 +350,8 @@ usage(void)
 			 "  C:\\> set PGBINNEW=newCluster/bin\n"
 			 "  C:\\> pg_upgrade\n"));
 #endif
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -687,14 +687,9 @@ usage(void)
 		   "  -V, --version            output version information, then exit\n"
 		   "  -?, --help               show this help, then exit\n"
 		   "\n"
-<<<<<<< HEAD
-		   "Report bugs to <bugs@greenplum.org>.\n",
-		   progname, progname);
-=======
 		   "Report bugs to <%s>.\n"
 		   "%s home page: <%s>\n",
 		   progname, progname, PACKAGE_BUGREPORT, PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 /* return whether str matches "^\s*[-+]?[0-9]+$" */

--- a/src/bin/psql/help.c
+++ b/src/bin/psql/help.c
@@ -144,12 +144,8 @@ usage(unsigned short int pager)
 	fprintf(output, _("\nFor more information, type \"\\?\" (for internal commands) or \"\\help\" (for SQL\n"
 					  "commands) from within psql, or consult the psql section in the PostgreSQL\n"
 					  "documentation.\n\n"));
-<<<<<<< HEAD
-	fprintf(output, _("Report bugs to <bugs@greenplum.org>.\n"));
-=======
 	fprintf(output, _("Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	fprintf(output, _("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 	ClosePager(output);
 }

--- a/src/bin/scripts/clusterdb.c
+++ b/src/bin/scripts/clusterdb.c
@@ -291,10 +291,6 @@ help(const char *progname)
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
 	printf(_("\nRead the description of the SQL command CLUSTER for details.\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/scripts/createdb.c
+++ b/src/bin/scripts/createdb.c
@@ -277,10 +277,6 @@ help(const char *progname)
 	printf(_("  -W, --password               force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME      alternate maintenance database\n"));
 	printf(_("\nBy default, a database with the same name as the current user is created.\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/scripts/createuser.c
+++ b/src/bin/scripts/createuser.c
@@ -375,10 +375,6 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as (not the one to create)\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/scripts/dropdb.c
+++ b/src/bin/scripts/dropdb.c
@@ -177,10 +177,6 @@ help(const char *progname)
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/scripts/dropuser.c
+++ b/src/bin/scripts/dropuser.c
@@ -175,10 +175,6 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as (not the one to drop)\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/scripts/reindexdb.c
+++ b/src/bin/scripts/reindexdb.c
@@ -778,10 +778,6 @@ help(const char *progname)
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
 	printf(_("\nRead the description of the SQL command REINDEX for details.\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/bin/scripts/vacuumdb.c
+++ b/src/bin/scripts/vacuumdb.c
@@ -949,10 +949,6 @@ help(const char *progname)
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
 	printf(_("\nRead the description of the SQL command VACUUM for details.\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }

--- a/src/interfaces/ecpg/preproc/ecpg.c
+++ b/src/interfaces/ecpg/preproc/ecpg.c
@@ -58,12 +58,8 @@ help(const char *progname)
 	printf(_("  -?, --help     show this help, then exit\n"));
 	printf(_("\nIf no output file is specified, the name is formed by adding .c to the\n"
 			 "input file name, after stripping off .pgc if present.\n"));
-<<<<<<< HEAD
-	printf(_("\nReport bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("\nReport bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 static void

--- a/src/interfaces/ecpg/preproc/pgc.l
+++ b/src/interfaces/ecpg/preproc/pgc.l
@@ -1429,11 +1429,7 @@ cppline			{space}*#([^i][A-Za-z]*|{if}|{ifdef}|{ifndef}|{import})((\/\*[^*/]*\*+
 					}
 				}
 
-<<<<<<< HEAD
-<INITIAL>{other}|\n	{ mmfatal(PARSE_ERROR, "internal error: unreachable state; please report this to <bugs@greenplum.org>"); }
-=======
 <INITIAL>{other}|\n	{ mmfatal(PARSE_ERROR, "internal error: unreachable state; please report this to <%s>", PACKAGE_BUGREPORT); }
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 %%
 

--- a/src/interfaces/ecpg/preproc/type.c
+++ b/src/interfaces/ecpg/preproc/type.c
@@ -301,11 +301,7 @@ ECPGdump_a_type(FILE *o, const char *name, struct ECPGtype *type, const int brac
 					break;
 				default:
 					if (!IS_SIMPLE_TYPE(type->u.element->type))
-<<<<<<< HEAD
-						base_yyerror("internal error: unknown datatype, please report this to <bugs@greenplum.org>");
-=======
 						base_yyerror("internal error: unknown datatype, please report this to <" PACKAGE_BUGREPORT ">");
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 					ECPGdump_a_simple(o, name,
 									  type->u.element->type,
@@ -676,11 +672,7 @@ ECPGfree_type(struct ECPGtype *type)
 						break;
 					default:
 						if (!IS_SIMPLE_TYPE(type->u.element->type))
-<<<<<<< HEAD
-							base_yyerror("internal error: unknown datatype, please report this to <bugs@greenplum.org>");
-=======
 							base_yyerror("internal error: unknown datatype, please report this to <" PACKAGE_BUGREPORT ">");
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 						free(type->u.element);
 				}

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2769,12 +2769,8 @@ help(void)
 	printf(_("The exit status is 0 if all tests passed, 1 if some tests failed, and 2\n"));
 	printf(_("if the tests could not be run for some reason.\n"));
 	printf(_("\n"));
-<<<<<<< HEAD
-	printf(_("Report bugs to <bugs@greenplum.org>.\n"));
-=======
 	printf(_("Report bugs to <%s>.\n"), PACKAGE_BUGREPORT);
 	printf(_("%s home page: <%s>\n"), PACKAGE_NAME, PACKAGE_URL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 }
 
 int


### PR DESCRIPTION
Fix website and email conflicts

Commit 8649341 added in files
- src/backend/main/main.c
- src/bin/pg_basebackup/pg_receivewal.c
- src/bin/pg_config/pg_config.c
- src/bin/pg_controldata/pg_controldata.c
- src/bin/pg_ctl/pg_ctl.c
- src/bin/pg_dump/pg_dumpall.c
- src/bin/pg_dump/pg_restore.c
- src/bin/pg_resetwal/pg_resetwal.c
- src/bin/pg_upgrade/option.c
- src/bin/pgbench/pgbench.c
- src/bin/psql/help.c
- src/bin/scripts/clusterdb.c
- src/bin/scripts/createdb.c
- src/bin/scripts/createuser.c
- src/bin/scripts/dropdb.c
- src/bin/scripts/dropuser.c
- src/bin/scripts/reindexdb.c
- src/bin/scripts/vacuumdb.c
- src/interfaces/ecpg/preproc/ecpg.c
- src/interfaces/ecpg/preproc/pgc.l
- src/interfaces/ecpg/preproc/type.c
- src/test/regress/pg_regress.c

define PACKAGE_BUGREPORT in help, and commit 1933ae6 added its use defines
PACKAGE_NAME and PACKAGE_URL in the same places, while the earlier commit
b7365f5 already added the GPDB-specific email in these same places.