### PR TITLE
Fix conflicts in src/backend/nodes/tidbitmap.c

### DIFF
--- a/src/backend/nodes/tidbitmap.c
+++ b/src/backend/nodes/tidbitmap.c
@@ -33,14 +33,9 @@
 
 #include "access/htup.h"
 #include "access/htup_details.h"
-<<<<<<< HEAD
 #include "access/bitmap.h"		/* XXX: remove once pull_stream is generic */
 #include "common/hashfn.h"
 #include "executor/instrument.h"	/* Instrumentation */
-=======
-#include "common/hashfn.h"
-#include "nodes/bitmapset.h"
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 #include "nodes/tidbitmap.h"
 #include "storage/lwlock.h"
 #include "utils/dsa.h"


### PR DESCRIPTION
Fix conflicts in src/backend/nodes/tidbitmap.c

Commit 05d8449 replaced the utils/hashutils.h include in
src/backend/nodes/tidbitmap.c with the common/hashfn.h include. The earlier
commit 5d3dc2e had already done this, and commit cdfe191 added the
access/bitmap.h and executor/instrument.h includes around it.