### PR TITLE
Fix conflicts in src/backend/postmaster/postmaster.c

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4946,20 +4946,11 @@ BackendInitialize(Port *port)
 	 */
 	initStringInfo(&ps_data);
 	if (am_walsender)
-<<<<<<< HEAD
-		init_ps_display(pgstat_get_backend_desc(B_WAL_SENDER), port->user_name, remote_ps_data,
-						update_process_title ? "authentication" : "");
-	else if (am_ftshandler)
-		init_ps_display("fts handler process", port->user_name, remote_ps_data,
-						update_process_title ? "authentication" : "");
-	else if (am_faulthandler)
-		init_ps_display("fault handler process", port->user_name, remote_ps_data,
-						update_process_title ? "authentication" : "");
-	else
-		init_ps_display(port->user_name, port->database_name, remote_ps_data,
-						update_process_title ? "authentication" : "");
-=======
 		appendStringInfo(&ps_data, "%s ", GetBackendTypeDesc(B_WAL_SENDER));
+	else if (am_ftshandler)
+		appendStringInfoString(&ps_data, "fts handler process ");
+	else if (am_faulthandler)
+		appendStringInfoString(&ps_data, "fault handler process ");
 	appendStringInfo(&ps_data, "%s ", port->user_name);
 	if (!am_walsender)
 		appendStringInfo(&ps_data, "%s ", port->database_name);
@@ -4971,7 +4962,6 @@ BackendInitialize(Port *port)
 	pfree(ps_data.data);
 
 	set_ps_display("initializing");
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 	/*
 	 * Disable the timeout, and prevent SIGTERM/SIGQUIT again.

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4948,9 +4948,9 @@ BackendInitialize(Port *port)
 	if (am_walsender)
 		appendStringInfo(&ps_data, "%s ", GetBackendTypeDesc(B_WAL_SENDER));
 	else if (am_ftshandler)
-		appendStringInfoString(&ps_data, "fts handler process ");
+		appendStringInfo(&ps_data, "%s ", GetBackendTypeDesc(B_FTS_HANDLER_PROCESS));
 	else if (am_faulthandler)
-		appendStringInfoString(&ps_data, "fault handler process ");
+		appendStringInfo(&ps_data, "%s ", GetBackendTypeDesc(B_FAULT_HADLER_PROCESS));
 	appendStringInfo(&ps_data, "%s ", port->user_name);
 	if (!am_walsender)
 		appendStringInfo(&ps_data, "%s ", port->database_name);

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -248,6 +248,12 @@ GetBackendTypeDesc(BackendType backendType)
 		case B_LOGGER:
 			backendDesc = "logger";
 			break;
+		case B_FTS_HANDLER_PROCESS:
+			backendDesc = "fts handler process";
+			break;
+		case B_FAULT_HADLER_PROCESS:
+			backendDesc = "fault handler process";
+			break;
 	}
 
 	return backendDesc;

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -421,6 +421,8 @@ typedef enum BackendType
 	B_ARCHIVER,
 	B_STATS_COLLECTOR,
 	B_LOGGER,
+	B_FTS_HANDLER_PROCESS,
+	B_FAULT_HADLER_PROCESS,
 } BackendType;
 
 extern BackendType MyBackendType;


### PR DESCRIPTION
Fix conflicts in src/backend/postmaster/postmaster.c

Commit bf68b79 changed the current backend status output in the
BackendInitialize function of src/backend/postmaster/postmaster.c from a
conditional call to init_ps_display to a conditional call to appendStringInfo
and a single call to init_ps_display. Earlier commits 6b0e52b, f86af5e,
7a1ce37, 89791f1, and 34457fc had already added GPDB-specific code for
displaying the FTS and fault handler process to the same location.