### PR TITLE
Fix conflicts in postmaster/syslogger.c and utils/error/elog.c

### DIFF
--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -2068,6 +2068,7 @@ write_binary_to_file(const char *buffer, int count, FILE *fh)
  *
  * On Windows the data arriving in the pipe already has CR/LF newlines,
  * so we must send it to the file without further translation.
+ *
  * This is exported so that elog.c can call it when MyBackendType is B_LOGGER.
  * This allows the syslogger process to record elog messages of its own,
  * even though its stderr does not point at the syslog pipe.

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -267,17 +267,12 @@ SysLoggerMain(int argc, char *argv[])
 	syslogger_parseArgs(argc, argv);
 #endif							/* EXEC_BACKEND */
 
-<<<<<<< HEAD
-	am_syslogger = true;
+	MyBackendType = B_LOGGER;
 
 	if (Gp_role == GP_ROLE_DISPATCH)
-		init_ps_display("master logger process", "", "", "");
+		init_ps_display("master logger process");
 	else
-		init_ps_display("logger process", "", "", "");
-=======
-	MyBackendType = B_LOGGER;
-	init_ps_display(NULL);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+		init_ps_display("logger process");
 
 	/*
 	 * If we restarted, our stderr is already redirected into our own input
@@ -2071,14 +2066,11 @@ write_binary_to_file(const char *buffer, int count, FILE *fh)
 /*
  * Write binary data to the currently open logfile
  *
-<<<<<<< HEAD
  * On Windows the data arriving in the pipe already has CR/LF newlines,
  * so we must send it to the file without further translation.
-=======
  * This is exported so that elog.c can call it when MyBackendType is B_LOGGER.
  * This allows the syslogger process to record elog messages of its own,
  * even though its stderr does not point at the syslog pipe.
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
  */
 void write_syslogger_file_binary(const char *buffer, int count, int destination)
 {
@@ -2103,7 +2095,7 @@ void write_syslogger_file_binary(const char *buffer, int count, int destination)
 /*
  * Write text to the currently open logfile
  *
- * This is exported so that elog.c can call it when am_syslogger is true.
+ * This is exported so that elog.c can call it when MyBackendType is B_LOGGER.
  * This allows the syslogger process to record elog messages of its own,
  * even though its stderr does not point at the syslog pipe.
  */

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3573,7 +3573,7 @@ gp_write_pipe_chunk(const char *buffer, int len)
 static inline void
 append_string_to_pipe_chunk(PipeProtoChunk *buffer, const char* input)
 {
-	if(am_syslogger)
+	if(MyBackendType == B_LOGGER)
 		return;
 
 	int len = 0;
@@ -4030,7 +4030,7 @@ write_message_to_server_log(int elevel,
 	GpErrorDataFixFields fix_fields;
 	static uint64 log_line_number = 0;
 
-	Assert(!am_syslogger);
+	Assert(MyBackendType != B_LOGGER);
 
 	buffer.hdr.zero = 0;
 	buffer.hdr.len = 0;
@@ -4169,7 +4169,7 @@ send_message_to_server_log(ErrorData *edata)
 		{
 			if (redirection_done)
 			{
-				if (!am_syslogger)
+				if (MyBackendType != B_LOGGER)
 					write_message_to_server_log(edata->elevel,
 												edata->sqlerrcode,
 												edata->message,
@@ -4426,29 +4426,24 @@ send_message_to_server_log(ErrorData *edata)
 		 * If stderr redirection is active, it was OK to write to stderr above
 		 * because that's really a pipe to the syslogger process.
 		 */
-		else if (pgwin32_is_service() && (!redirection_done || am_syslogger) )
+		else if (pgwin32_is_service() && (!redirection_done || MyBackendType == B_LOGGER) )
 			write_eventlog(edata->elevel, buf.data, buf.len);
 #endif
 			/* only use the chunking protocol if we know the syslogger should
 			 * be catching stderr output, and we are not ourselves the
 			 * syslogger. Otherwise, go directly to stderr.
 			 */
-			if (redirection_done && !am_syslogger)
+			if (redirection_done && MyBackendType != B_LOGGER)
 				write_pipe_chunks(buf.data, buf.len, LOG_DESTINATION_STDERR);
 			else
 				write_console(buf.data, buf.len);
 	}
 
 	/* If in the syslogger process, try to write messages direct to file */
-<<<<<<< HEAD
-	if (am_syslogger)
+	if (MyBackendType == B_LOGGER)
 		write_syslogger_file_binary(buf.data, buf.len, LOG_DESTINATION_STDERR);
 
 	pfree(prefix.data);
-=======
-	if (MyBackendType == B_LOGGER)
-		write_syslogger_file(buf.data, buf.len, LOG_DESTINATION_STDERR);
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 	/* Write to CSV log if enabled */
 	if (Log_destination & LOG_DESTINATION_CSVLOG)
@@ -4851,7 +4846,7 @@ write_stderr(const char *fmt,...)
 
 		vsnprintf(errbuf, sizeof(errbuf), fmt, ap);
 
-		if (!am_syslogger)
+		if (MyBackendType != B_LOGGER)
 		{
 			/* Write the message in the CSV format */
 			write_message_to_server_log(LOG,


### PR DESCRIPTION
Fix conflicts in postmaster/syslogger.c and utils/error/elog.c

1) Commit 8e8a0be replaced the init_ps_display function call with the "logger"
argument in the SysLoggerMain function in src/backend/postmaster/syslogger.c
with setting MyBackendType and calling init_ps_display with a zero argument.
Earlier commits 56f9ecd, 6b0e52b, f6297b9, and e5d1779 had already added
GPDB-specific code to the same location.

2) Commit d90bd24 removed the use of the global am_syslogger variable in
src/backend/postmaster/syslogger.c, including in the comment before the
write_syslogger_file function. Earlier commit 6b0e52b added another function
write_syslogger_file_binary and comment before this location.

3) Commit d90bd24 replaced the use of the global am_syslogger variable in
src/backend/utils/error/elog.c with a condition for MyBackendType, including in
the send_message_to_server_log function when calling write_syslogger_file.
Earlier commit 6b0e52b replaced the call to write_syslogger_file_binary in this
location.