### PR TITLE
Fix conflicts in src/backend/utils/adt/genfile.c

### DIFF
--- a/src/backend/utils/adt/genfile.c
+++ b/src/backend/utils/adt/genfile.c
@@ -547,7 +547,6 @@ pg_ls_dir_1arg(PG_FUNCTION_ARGS)
 	return pg_ls_dir(fcinfo);
 }
 
-<<<<<<< HEAD
 /* ------------------------------------
  * pg_file_write_internal - Workhorse for pg_file_write functions.
  *
@@ -1017,15 +1016,12 @@ pg_logdir_ls_v1_1(PG_FUNCTION_ARGS)
 	return (pg_logdir_ls_internal(fcinfo));
 }
 
-/* Generic function to return a directory listing of files */
-=======
 /*
  * Generic function to return a directory listing of files.
  *
  * If the directory isn't there, silently return an empty set if missing_ok.
  * Other unreadable-directory cases throw an error.
  */
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 static Datum
 pg_ls_dir_files(FunctionCallInfo fcinfo, const char *dir, bool missing_ok)
 {


### PR DESCRIPTION
Fix conflicts in src/backend/utils/adt/genfile.c

Commit 085b6b6 expanded the comment before the pg_ls_dir_files function in
src/backend/utils/adt/genfile.c. Earlier commits (6b0e52b, df20745, 006d761,
19cd1cf, cdfe191, 2134a2d) had already added the GPDB-specific functions
pg_file_write_internal, pg_file_write, pg_file_write_v1_1,
pg_file_rename_internal, pg_file_rename, pg_file_rename_v1_1, pg_file_unlink,
pg_file_length, pg_logdir_ls_internal, pg_logdir_ls, pg_logdir_ls_v1_1 before
this place.