### PR TITLE
Fix conflicts in src/backend/utils/cache/plancache.c

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -164,12 +164,7 @@ InitPlanCache(void)
  *
  * raw_parse_tree: output of raw_parser(), or NULL if empty query
  * query_string: original query text
-<<<<<<< HEAD
- * commandTag: compile-time-constant tag for query, or NULL if empty query
- * sourceTag: GPDB specific.
-=======
  * commandTag: command tag for query, or UNKNOWN if empty query
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
  */
 CachedPlanSource *
 CreateCachedPlan(RawStmt *raw_parse_tree,


### PR DESCRIPTION
Fix conflicts in src/backend/utils/cache/plancache.c

Commit 2f96613 updated the comment before the CreateCachedPlan function in
src/backend/utils/cache/plancache.c, while earlier commit 598f4b0 had already
added a GPDB-specific comment in the same location.