### PR TITLE
Fix conflicts in src/backend/utils/mmgr/portalmem.c

### DIFF
--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -301,12 +301,8 @@ void
 PortalDefineQuery(Portal portal,
 				  const char *prepStmtName,
 				  const char *sourceText,
-<<<<<<< HEAD
 				  NodeTag	  sourceTag,
-				  const char *commandTag,
-=======
 				  CommandTag commandTag,
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 				  List *stmts,
 				  CachedPlan *cplan)
 {
@@ -318,12 +314,9 @@ PortalDefineQuery(Portal portal,
 
 	portal->prepStmtName = prepStmtName;
 	portal->sourceText = sourceText;
-<<<<<<< HEAD
 	portal->sourceTag = sourceTag;
-=======
 	portal->qc.commandTag = commandTag;
 	portal->qc.nprocessed = 0;
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 	portal->commandTag = commandTag;
 	portal->stmts = stmts;
 	portal->cplan = cplan;


### PR DESCRIPTION
Fix conflicts in src/backend/utils/mmgr/portalmem.c

Commit 2f96613 replaced the string command tag with a structure in the
PortalDefineQuery function in src/backend/utils/mmgr/portalmem.c, while the
earlier commit 6b0e52b had already added the GPDB-specific sourceTag argument.