### PR TITLE
Fix conflicts in src/backend/utils/sort/logtape.c

### DIFF
--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -212,13 +212,8 @@ struct LogicalTapeSet
 	Size		freeBlocksLen;	/* current allocated length of freeBlocks[] */
 
 	/* The array of logical tapes. */
-<<<<<<< HEAD
-	int			nTapes;			/* # of logical tapes in set */
-	LogicalTape *tapes;			/* has nTapes nentries */
-=======
 	int				nTapes;	/* # of logical tapes in set */
 	LogicalTape	   *tapes;	/* has nTapes nentries */
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 };
 
 static void ltsWriteBlock(LogicalTapeSet *lts, long blocknum, void *buffer);
@@ -621,24 +616,6 @@ ltsConcatWorkerTapes(LogicalTapeSet *lts, TapeShare *shared,
 static void
 ltsInitTape(LogicalTape *lt)
 {
-<<<<<<< HEAD
-	lt->writing = true;
-	lt->frozen = false;
-	lt->dirty = false;
-	lt->firstBlockNumber = -1L;
-	lt->curBlockNumber = -1L;
-	lt->nextBlockNumber = -1L;
-	lt->offsetBlockNumber = 0L;
-	lt->buffer = NULL;
-	lt->buffer_size = 0;
-	/* palloc() larger than MaxAllocSize would fail */
-	lt->max_size = MaxAllocSize;
-	lt->pos = 0;
-	lt->nbytes = 0;
-	lt->prealloc = NULL;
-	lt->nprealloc = 0;
-	lt->prealloc_size = 0;
-=======
 	lt->writing           = true;
 	lt->frozen            = false;
 	lt->dirty             = false;
@@ -652,7 +629,9 @@ ltsInitTape(LogicalTape *lt)
 	lt->max_size          = MaxAllocSize;
 	lt->pos               = 0;
 	lt->nbytes            = 0;
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+	lt->prealloc          = NULL;
+	lt->nprealloc         = 0;
+	lt->prealloc_size     = 0;
 }
 
 /*
@@ -1123,15 +1102,6 @@ LogicalTapeFreeze(LogicalTapeSet *lts, int tapenum, TapeShare *share)
 void
 LogicalTapeSetExtend(LogicalTapeSet *lts, int nAdditional)
 {
-<<<<<<< HEAD
-	int			i;
-	int			nTapesOrig = lts->nTapes;
-
-	lts->nTapes += nAdditional;
-
-	lts->tapes = (LogicalTape *) repalloc(lts->tapes,
-										  lts->nTapes * sizeof(LogicalTape));
-=======
 	int     i;
 	int		nTapesOrig = lts->nTapes;
 
@@ -1139,7 +1109,6 @@ LogicalTapeSetExtend(LogicalTapeSet *lts, int nAdditional)
 
 	lts->tapes = (LogicalTape *) repalloc(
 		lts->tapes, lts->nTapes * sizeof(LogicalTape));
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 	for (i = nTapesOrig; i < lts->nTapes; i++)
 		ltsInitTape(&lts->tapes[i]);


### PR DESCRIPTION
Fix conflicts in src/backend/utils/sort/logtape.c

1) Commit 24d8595 changed the tapes field type and the indentation of the
nTapes field in the LogicalTapeSet structure in
src/backend/utils/sort/logtape.c. An earlier commit, 19cd1cf, had already done
this, but with different indentation.

2) Commit 24d8595 added a new ltsInitTape function to
src/backend/utils/sort/logtape.c. An earlier commit, 19cd1cf, had already done
this, but with different indentation and initialization of the prealloc,
nprealloc, and prealloc_size fields.

3) Commit 24d8595 added a new function LogicalTapeSetExtend to
src/backend/utils/sort/logtape.c, while the earlier commit 19cd1cf already did
this, but with different indents.