### PR TITLE
Fix conflicts in src/common/hashfn.c

### DIFF
--- a/src/common/hashfn.c
+++ b/src/common/hashfn.c
@@ -11,16 +11,6 @@
  *
  * IDENTIFICATION
  *	  src/common/hashfn.c
-<<<<<<< HEAD
- *
- * NOTES
- *	  It is expected that every bit of a hash function's 32-bit result is
- *	  as random as every other; failure to ensure this is likely to lead
- *	  to poor performance of hash tables.  In most cases a hash
- *	  function should use hash_bytes() or its variant hash_bytes_uint32(),
- *	  or the wrappers hash_any() and hash_uint32 defined in hashfn.h.
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
  *
  * NOTES
  *	  It is expected that every bit of a hash function's 32-bit result is
@@ -32,7 +22,6 @@
  *-------------------------------------------------------------------------
  */
 
-<<<<<<< HEAD
 /*
  * GPDB: We carry a dependency on pthread_win32.h in elog.h, which causes
  * compilation errors when building Windows clients (as elog.h is included by
@@ -44,8 +33,6 @@
 #include "postgres.h"
 #endif
 
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 #include "common/hashfn.h"
 
 


### PR DESCRIPTION
Fix conflicts in src/common/hashfn.c

Commit a91e2fa added a comment to src/backend/utils/hash/hashfn.c, while
earlier commit 9b6de72 had already done so, and commit 031d8a6 added
GPDB-specific conditions with a comment around the postgres.h include.