### PR TITLE
Fix conflicts in src/bin/pg_dump/pg_dump_sort.c

### DIFF
--- a/src/bin/pg_dump/pg_dump_sort.c
+++ b/src/bin/pg_dump/pg_dump_sort.c
@@ -93,7 +93,6 @@ enum dbObjectTypePriorities
 /* This table is indexed by enum DumpableObjectType */
 static const int dbObjectTypePriority[] =
 {
-<<<<<<< HEAD
 	PRIO_NAMESPACE,				/* DO_NAMESPACE */
 	PRIO_EXTENSION,				/* DO_EXTENSION */
 	PRIO_TYPE,					/* DO_TYPE */
@@ -141,52 +140,6 @@ static const int dbObjectTypePriority[] =
 	PRIO_PUBLICATION,			/* DO_PUBLICATION */
 	PRIO_PUBLICATION_REL,		/* DO_PUBLICATION_REL */
 	PRIO_SUBSCRIPTION			/* DO_SUBSCRIPTION */
-=======
-	1,							/* DO_NAMESPACE */
-	4,							/* DO_EXTENSION */
-	5,							/* DO_TYPE */
-	5,							/* DO_SHELL_TYPE */
-	6,							/* DO_FUNC */
-	7,							/* DO_AGG */
-	8,							/* DO_OPERATOR */
-	8,							/* DO_ACCESS_METHOD */
-	9,							/* DO_OPCLASS */
-	9,							/* DO_OPFAMILY */
-	3,							/* DO_COLLATION */
-	11,							/* DO_CONVERSION */
-	18,							/* DO_TABLE */
-	20,							/* DO_ATTRDEF */
-	28,							/* DO_INDEX */
-	29,							/* DO_INDEX_ATTACH */
-	30,							/* DO_STATSEXT */
-	31,							/* DO_RULE */
-	32,							/* DO_TRIGGER */
-	27,							/* DO_CONSTRAINT */
-	33,							/* DO_FK_CONSTRAINT */
-	2,							/* DO_PROCLANG */
-	10,							/* DO_CAST */
-	23,							/* DO_TABLE_DATA */
-	24,							/* DO_SEQUENCE_SET */
-	19,							/* DO_DUMMY_TYPE */
-	12,							/* DO_TSPARSER */
-	14,							/* DO_TSDICT */
-	13,							/* DO_TSTEMPLATE */
-	15,							/* DO_TSCONFIG */
-	16,							/* DO_FDW */
-	17,							/* DO_FOREIGN_SERVER */
-	38,							/* DO_DEFAULT_ACL --- done in ACL pass */
-	3,							/* DO_TRANSFORM */
-	21,							/* DO_BLOB */
-	25,							/* DO_BLOB_DATA */
-	22,							/* DO_PRE_DATA_BOUNDARY */
-	26,							/* DO_POST_DATA_BOUNDARY */
-	39,							/* DO_EVENT_TRIGGER --- next to last! */
-	40,							/* DO_REFRESH_MATVIEW --- last! */
-	34,							/* DO_POLICY */
-	35,							/* DO_PUBLICATION */
-	36,							/* DO_PUBLICATION_REL */
-	37							/* DO_SUBSCRIPTION */
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 };
 
 StaticAssertDecl(lengthof(dbObjectTypePriority) == (DO_SUBSCRIPTION + 1),


### PR DESCRIPTION
Fix conflicts in src/bin/pg_dump/pg_dump_sort.c

Commit 8728b2c70357 updated values in dbObjectTypePriority array, while commit
31451cb53640 cherry-picked later commit d5ab79d81578, which replaced magic
numbers in dbObjectTypePriority with enum values, and commit db2a79816e3c
updated a couple of values on top of this change. This patch resolves the
conflict by keeping GPDB version of code.
