### PR TITLE
Fix conflicts in src/bin/pg_dump/pg_dump.h

### DIFF
--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -706,23 +706,6 @@ typedef struct _SubscriptionInfo
 } SubscriptionInfo;
 
 /*
-<<<<<<< HEAD
-=======
- * We build an array of these with an entry for each object that is an
- * extension member according to pg_depend.
- */
-typedef struct _extensionMemberId
-{
-	CatalogId	catId;			/* tableoid+oid of some member object */
-	ExtensionInfo *ext;			/* owning extension */
-} ExtensionMemberId;
-
-/* placeholders for comment starting and ending delimiters */
-extern char g_comment_start[10];
-extern char g_comment_end[10];
-
-/*
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
  *	common utility functions
  */
 

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -642,7 +642,6 @@ ExtensibleNodeEntry
 ExtensibleNodeMethods
 ExtensionControlFile
 ExtensionInfo
-ExtensionMemberId
 ExtensionVersionInfo
 FDWCollateState
 FD_SET


### PR DESCRIPTION
Fix conflicts in src/bin/pg_dump/pg_dump.h

Commit bb03010b9f07 removed `g_opaque_type` from the file
'pg_dump.h', while that part of code had been already removed by
commit d5725632c4f8. 
