### PR TITLE
Fix conflicts in src/backend/postmaster/autovacuum.c

### DIFF
--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -1758,13 +1758,8 @@ AutoVacWorkerMain(int argc, char *argv[])
 		 */
 		InitPostgres(NULL, dbid, NULL, InvalidOid, dbname, false);
 		SetProcessingMode(NormalProcessing);
-<<<<<<< HEAD
-		set_ps_display(dbname, false);
-		ereport(LOG,
-=======
 		set_ps_display(dbname);
-		ereport(DEBUG1,
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
+		ereport(LOG,
 				(errmsg("autovacuum: processing database \"%s\"", dbname)));
 
 #ifdef FAULT_INJECTOR


### PR DESCRIPTION
Fix conflicts in src/backend/postmaster/autovacuum.c

Commit bf68b79 removed the false argument in the AutoVacWorkerMain function
when calling set_ps_display in src/backend/postmaster/autovacuum.c. However, an
earlier commit by dfdfd14 had already changed the logging level from DEBUG1 to
LOG after this point.