### PR TITLE
Fix compilation in src/backend/catalog/pg_cast.c

### DIFF
--- a/src/backend/catalog/pg_cast.c
+++ b/src/backend/catalog/pg_cast.c
@@ -27,6 +27,7 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
+#include "catalog/oid_dispatch.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbvars.h"
 
@@ -122,16 +123,6 @@ CastCreate(Oid sourcetypeid, Oid targettypeid, Oid funcid, char castcontext,
 	heap_freetuple(tuple);
 
 	table_close(relation, RowExclusiveLock);
-
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		CdbDispatchUtilityStatement((Node *) stmt,
-									DF_CANCEL_ON_ERROR|
-									DF_WITH_SNAPSHOT|
-									DF_NEED_TWO_PHASE,
-									GetAssignedOidsForDispatch(),
-									NULL);
-	}
 
 	return myself;
 }

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -76,7 +76,6 @@
 #include "utils/typcache.h"
 
 #include "catalog/heap.h"
-#include "catalog/oid_dispatch.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbvars.h"
 
@@ -2105,6 +2104,17 @@ CreateCast(CreateCastStmt *stmt)
 
 	myself = CastCreate(sourcetypeid, targettypeid, funcid, castcontext,
 						castmethod, DEPENDENCY_NORMAL);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		CdbDispatchUtilityStatement((Node *) stmt,
+									DF_CANCEL_ON_ERROR|
+									DF_WITH_SNAPSHOT|
+									DF_NEED_TWO_PHASE,
+									GetAssignedOidsForDispatch(),
+									NULL);
+	}
+
 	return myself;
 }
 


### PR DESCRIPTION
Fix compilation in src/backend/catalog/pg_cast.c

Commit 6412ddc incorrectly resolved conflicts in src/backend/catalog/pg_cast.c
by moving the GPDB-specific call to the CdbDispatchUtilityStatement function to
the CastCreate function, which doesn't have CreateCastStmt. Revert it back and
add the missing include.