### PR TITLE
Fix compilation of set_ps_display

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -633,14 +633,14 @@ DtxRecoveryMain(Datum main_arg)
 	 */
 	if (!*shmDtmStarted)
 	{
-		set_ps_display("recovering", false);
+		set_ps_display("recovering");
 
 		StartTransactionCommand();
 		recoverTM();
 		CommitTransactionCommand();
 		DisconnectAndDestroyAllGangs(true);
 
-		set_ps_display("", false);
+		set_ps_display("");
 	}
 
 	/* Fetch the gxid batch in advance. */

--- a/src/backend/storage/ipc/standby.c
+++ b/src/backend/storage/ipc/standby.c
@@ -286,7 +286,7 @@ ResolveRecoveryConflictWithVirtualXIDs(VirtualTransactionId *waitlist,
 		/* Reset ps display if we changed it */
 		if (new_status)
 		{
-			set_ps_display(new_status, false);
+			set_ps_display(new_status);
 			pfree(new_status);
 		}
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1332,7 +1332,7 @@ exec_mpp_query(const char *query_string,
 			commandTag = "MPPEXEC";
 
 
-		set_ps_display(commandTag, false);
+		set_ps_display(commandTag);
 
 		BeginCommand(commandTag, dest);
 
@@ -1544,7 +1544,7 @@ exec_mpp_dtx_protocol_command(DtxProtocolCommand dtxProtocolCommand,
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),"exec_mpp_dtx_protocol_command received the dtxProtocolCommand = %d (%s) gid = %s",
 		 dtxProtocolCommand, loggingStr, gid);
 
-	set_ps_display(commandTag, false);
+	set_ps_display(commandTag);
 
 	if (Debug_dtm_action == DEBUG_DTM_ACTION_FAIL_BEGIN_COMMAND &&
 		CheckDebugDtmActionProtocol(dtxProtocolCommand, contextInfo))
@@ -4748,7 +4748,7 @@ PostgresMain(int argc, char *argv[],
 	PostmasterPriority = getpriority(PRIO_PROCESS, 0);
 #endif
 
-	set_ps_display("startup", false);
+	set_ps_display("startup");
 
 	SetProcessingMode(InitProcessing);
 
@@ -5564,7 +5564,7 @@ PostgresMain(int argc, char *argv[],
 							// UNDONE: HACK
 							pgstat_report_activity(STATE_RUNNING, "BEGIN");
 
-							set_ps_display("BEGIN", false);
+							set_ps_display("BEGIN");
 
 							BeginCommand("BEGIN", dest);
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -5008,7 +5008,7 @@ elog_debug_linger(ErrorData *edata)
 				 "error exit in %dm %ds",
 				 minutes_left,
 				 seconds_left - minutes_left * 60);
-		set_ps_display(buf, true);
+		set_ps_display(buf);
 
 		/* Sleep. */
 		sleep_seconds = Min(seconds_left, setproctitle_seconds);

--- a/src/backend/utils/misc/test/ps_status_test.c
+++ b/src/backend/utils/misc/test/ps_status_test.c
@@ -24,8 +24,8 @@ test__set_ps_display(void **state)
 	gp_command_count = 1024;
 	currentSliceId = 40;
 
-	set_ps_display("testing activity", true);
-	set_ps_display("testing activity", false);
+	set_ps_display("testing activity");
+	set_ps_display("testing activity");
 
 	assert_true(ps_buffer[32] == 0x7f);
 	free(ps_buffer);
@@ -53,7 +53,7 @@ test__set_ps_display__real_act_prefix_size_overflow(void **state)
 	gp_command_count = 964;
 	currentSliceId = -1;
 
-	set_ps_display("testing activity", true);
+	set_ps_display("testing activity");
 	assert_true(real_act_prefix_size <= ps_buffer_size);
 
 	get_real_act_ps_display(&len);
@@ -85,7 +85,7 @@ test__set_ps_display__real_act_prefix_size(void **state)
 	gp_command_count = 964;
 	currentSliceId = -1;
 
-	set_ps_display(activity, true);
+	set_ps_display(activity);
 	assert_true(real_act_prefix_size <= ps_buffer_size);
 
 	assert_true(strcmp(activity, get_real_act_ps_display(&len)) == 0);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2918,7 +2918,7 @@ waitOnGroup(ResGroupData *group, bool isMoveQuery)
 		new_status = (char *) palloc(len + strlen(queueStr) + 1);
 		memcpy(new_status, old_status, len);
 		strcpy(new_status + len, queueStr);
-		set_ps_display(new_status, false);
+		set_ps_display(new_status);
 		/* truncate off " queuing" */
 		new_status[len] = '\0';
 	}
@@ -2977,7 +2977,7 @@ waitOnGroup(ResGroupData *group, bool isMoveQuery)
 		/* reset ps status */
 		if (update_process_title)
 		{
-			set_ps_display(new_status, false);
+			set_ps_display(new_status);
 			pfree(new_status);
 		}
 
@@ -2991,7 +2991,7 @@ waitOnGroup(ResGroupData *group, bool isMoveQuery)
 	/* reset ps status */
 	if (update_process_title)
 	{
-		set_ps_display(new_status, false);
+		set_ps_display(new_status);
 		pfree(new_status);
 	}
 }

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1090,7 +1090,7 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 		len = Min(len, sizeof(new_status) - 9);
 		snprintf(new_status, sizeof(new_status), "%.*s queuing",
 				 len, old_status);
-		set_ps_display(new_status, false);
+		set_ps_display(new_status);
 
 		/* Truncate off " queuing" */
 		new_status[len] = '\0';
@@ -1118,7 +1118,7 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 	/* Report change to non-waiting status */
 	if (update_process_title)
 	{
-		set_ps_display(new_status, false);
+		set_ps_display(new_status);
 	}
 
 	return;


### PR DESCRIPTION
Fix compilation of set_ps_display

Commit bf68b79 removed the second argument, "force," from the set_ps_display
function. Remove it in GPDB-specific locations.