### PR TITLE
Fix _bt_initmetapage compilation

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -131,7 +131,8 @@ _bitmap_create_lov_heapandindex(Relation rel,
 		btree_metabuf = _bt_getbuf(lovIndex, P_NEW, BT_WRITE);
 		Assert (BTREE_METAPAGE == BufferGetBlockNumber(btree_metabuf));
 		btree_metapage = BufferGetPage(btree_metabuf);
-		_bt_initmetapage(btree_metapage, P_NONE, 0);
+		_bt_initmetapage(btree_metapage, P_NONE, 0,
+						 _bt_allequalimage(rel, false));
 
 		/* XLOG the metapage */
 


### PR DESCRIPTION
Fix _bt_initmetapage compilation

Commit 0d861bb added a new argument, allequalimage, to the _bt_initmetapage
function. Add it in GPDB-specific places.