### PR TITLE
Fix compilation of src/backend/utils/misc/ps_status.c

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4958,6 +4958,8 @@ BackendInitialize(Port *port)
 	if (port->remote_port[0] != '\0')
 		appendStringInfo(&ps_data, "(%s)", port->remote_port);
 
+	set_ps_display_username(port->user_name);
+
 	init_ps_display(ps_data.data);
 	pfree(ps_data.data);
 

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -277,8 +277,6 @@ init_ps_display(const char *fixed_part)
 	if (!fixed_part)
 		fixed_part = GetBackendTypeDesc(MyBackendType);
 
-	StrNCpy(ps_username, username, sizeof(ps_username));    /*CDB*/
-
 #ifndef PS_USE_NONE
 	/* no ps display for stand-alone backend */
 	if (!IsUnderPostmaster)
@@ -512,7 +510,13 @@ get_ps_display(int *displen)
 }
 
 
-/* CDB: Get the "username" string saved by init_ps_display().  */
+/* GPDB: Set/Get the "username" string.  */
+void
+set_ps_display_username(const char *username)
+{
+	StrNCpy(ps_username, username, sizeof(ps_username));
+}
+
 const char *
 get_ps_display_username(void)
 {

--- a/src/include/utils/ps_status.h
+++ b/src/include/utils/ps_status.h
@@ -22,7 +22,8 @@ extern void set_ps_display(const char *activity);
 
 extern const char *get_ps_display(int *displen);
 
-/* CDB: Get the "username" string saved by init_ps_display().  */
+/* GPDB: Set/Get the "username" string.  */
+extern void set_ps_display_username(const char *username);
 extern const char *get_ps_display_username(void);
 extern const char *get_real_act_ps_display(int *displen);
 


### PR DESCRIPTION
Fix compilation of src/backend/utils/misc/ps_status.c

Commit bf68b79 replaced the username, dbname, host_info, and initial_str
arguments in the init_ps_display function with the fixed_part argument.
However, the username argument was used in the GPDB, which was set to a
non-empty string only when called from the BackendInitialize function. Add a
way to save it from this location.