### PR TITLE
Fix conflicts in doc/src/sgml/ref/alter_type.sgml

### DIFF
--- a/doc/src/sgml/ref/alter_type.sgml
+++ b/doc/src/sgml/ref/alter_type.sgml
@@ -31,7 +31,6 @@ ALTER TYPE <replaceable class="parameter">name</replaceable> <replaceable class=
 ALTER TYPE <replaceable class="parameter">name</replaceable> ADD VALUE [ IF NOT EXISTS ] <replaceable class="parameter">new_enum_value</replaceable> [ { BEFORE | AFTER } <replaceable class="parameter">neighbor_enum_value</replaceable> ]
 ALTER TYPE <replaceable class="parameter">name</replaceable> RENAME VALUE <replaceable class="parameter">existing_enum_value</replaceable> TO <replaceable class="parameter">new_enum_value</replaceable>
 ALTER TYPE <replaceable class="parameter">name</replaceable> SET ( <replaceable class="parameter">property</replaceable> = <replaceable class="parameter">value</replaceable> [, ... ] )
-ALTER TYPE <replaceable class="parameter">name</replaceable> SET DEFAULT ENCODING ( storage_directive )
 
 <phrase>where <replaceable class="parameter">action</replaceable> is one of:</phrase>
 

--- a/doc/src/sgml/ref/alter_type.sgml
+++ b/doc/src/sgml/ref/alter_type.sgml
@@ -30,8 +30,8 @@ ALTER TYPE <replaceable class="parameter">name</replaceable> RENAME ATTRIBUTE <r
 ALTER TYPE <replaceable class="parameter">name</replaceable> <replaceable class="parameter">action</replaceable> [, ... ]
 ALTER TYPE <replaceable class="parameter">name</replaceable> ADD VALUE [ IF NOT EXISTS ] <replaceable class="parameter">new_enum_value</replaceable> [ { BEFORE | AFTER } <replaceable class="parameter">neighbor_enum_value</replaceable> ]
 ALTER TYPE <replaceable class="parameter">name</replaceable> RENAME VALUE <replaceable class="parameter">existing_enum_value</replaceable> TO <replaceable class="parameter">new_enum_value</replaceable>
-ALTER TYPE <replaceable class="parameter">name</replaceable> SET DEFAULT ENCODING ( storage_directive )
 ALTER TYPE <replaceable class="parameter">name</replaceable> SET ( <replaceable class="parameter">property</replaceable> = <replaceable class="parameter">value</replaceable> [, ... ] )
+ALTER TYPE <replaceable class="parameter">name</replaceable> SET DEFAULT ENCODING ( storage_directive )
 
 <phrase>where <replaceable class="parameter">action</replaceable> is one of:</phrase>
 

--- a/doc/src/sgml/ref/alter_type.sgml
+++ b/doc/src/sgml/ref/alter_type.sgml
@@ -30,11 +30,8 @@ ALTER TYPE <replaceable class="parameter">name</replaceable> RENAME ATTRIBUTE <r
 ALTER TYPE <replaceable class="parameter">name</replaceable> <replaceable class="parameter">action</replaceable> [, ... ]
 ALTER TYPE <replaceable class="parameter">name</replaceable> ADD VALUE [ IF NOT EXISTS ] <replaceable class="parameter">new_enum_value</replaceable> [ { BEFORE | AFTER } <replaceable class="parameter">neighbor_enum_value</replaceable> ]
 ALTER TYPE <replaceable class="parameter">name</replaceable> RENAME VALUE <replaceable class="parameter">existing_enum_value</replaceable> TO <replaceable class="parameter">new_enum_value</replaceable>
-<<<<<<< HEAD
 ALTER TYPE <replaceable class="parameter">name</replaceable> SET DEFAULT ENCODING ( storage_directive )
-=======
 ALTER TYPE <replaceable class="parameter">name</replaceable> SET ( <replaceable class="parameter">property</replaceable> = <replaceable class="parameter">value</replaceable> [, ... ] )
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 <phrase>where <replaceable class="parameter">action</replaceable> is one of:</phrase>
 


### PR DESCRIPTION
Commit bd4c789 added the GPDB specific line with `... DEFAULT ENCODING`
in the help. The next merge, and later commit 675ac583, reworked this area.
Conflicting commit fe30e7e added the line `... SET ( property =`
in the same place, so they conflicted.

We decided to remove GPDB-specific documentation if there are conflicts.
So `... DEFAULT ENCODING` was removed.

Resulting behavior:
```
\h ALTER TYPE

Command:     ALTER TYPE
Description: change the definition of a type
...
ALTER TYPE name SET ( property = value [, ... ] )
...
```
