### PR TITLE
Fix conflicts in src/tools/msvc/Solution.pm

### DIFF
--- a/src/test/unit/mock/fmgrtab_mock.c
+++ b/src/test/unit/mock/fmgrtab_mock.c
@@ -8,6 +8,7 @@
  */
 #include "postgres.h"
 
+#include "fmgr.h"
 #include "utils/fmgrtab.h"
 
 const FmgrBuiltin fmgr_builtins[] = { };

--- a/src/test/unit/mock/fmgrtab_mock.c
+++ b/src/test/unit/mock/fmgrtab_mock.c
@@ -8,7 +8,6 @@
  */
 #include "postgres.h"
 
-#include "fmgr.h"
 #include "utils/fmgrtab.h"
 
 const FmgrBuiltin fmgr_builtins[] = { };

--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -160,6 +160,9 @@ sub GenerateFiles
 	{
 		if (/^AC_INIT\(\[([^\]]+)\], \[([^\]]+)\], \[([^\]]+)\], \[([^\]]*)\], \[([^\]]+)\]/)
 		{
+			$self->{gpdbver} = $1;
+			$self->{gpdbmajorver} = substr $1, 0, 1;
+
 			$ac_init_found = 1;
 
 			$package_name      = $1;
@@ -444,8 +447,8 @@ sub GenerateFiles
 		PG_INT128_TYPE      => undef,
 		PG_INT64_TYPE       => 'long long int',
 		PG_KRB_SRVNAM       => qq{"postgres"},
-		GP_VERSION          => qq{"$package_version"},
-		GP_MAJORVERSION     => qq{"$majorver"},
+		GP_VERSION          => qq{"$self->{gpdbver}"},
+		GP_MAJORVERSION     => qq{"$self->{gpdbmajorver}"},
 		PG_MAJORVERSION     => qq{"$majorver"},
 		PG_MAJORVERSION_NUM => $majorver,
 		PG_MINORVERSION_NUM => $minorver,

--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -160,24 +160,16 @@ sub GenerateFiles
 	{
 		if (/^AC_INIT\(\[([^\]]+)\], \[([^\]]+)\], \[([^\]]+)\], \[([^\]]*)\], \[([^\]]+)\]/)
 		{
-<<<<<<< HEAD
-			$self->{gpdbver} = $1;
-			$self->{gpdbmajorver} = substr $1, 0, 1;
-=======
 			$ac_init_found = 1;
 
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 			$package_name      = $1;
 			$package_bugreport = $3;
-<<<<<<< HEAD
+			#$package_tarname   = $4;
+			$package_url       = $5;
 		}
 		if (/\[PG_PACKAGE_VERSION=([^\]]+)\]/)
 		{
 			$package_version   = $1;
-=======
-			#$package_tarname   = $4;
-			$package_url       = $5;
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 
 			if ($package_version !~ /^(\d+)(?:\.(\d+))?/)
 			{
@@ -452,15 +444,11 @@ sub GenerateFiles
 		PG_INT128_TYPE      => undef,
 		PG_INT64_TYPE       => 'long long int',
 		PG_KRB_SRVNAM       => qq{"postgres"},
-<<<<<<< HEAD
-		GP_VERSION          => qq{"$self->{gpdbver}"},
-		GP_MAJORVERSION     => qq{"$self->{gpdbmajorver}"},
-		PG_MAJORVERSION     => qq{"$self->{majorver}"},
-=======
+		GP_VERSION          => qq{"$package_version"},
+		GP_MAJORVERSION     => qq{"$majorver"},
 		PG_MAJORVERSION     => qq{"$majorver"},
 		PG_MAJORVERSION_NUM => $majorver,
 		PG_MINORVERSION_NUM => $minorver,
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 		PG_PRINTF_ATTRIBUTE => undef,
 		PG_USE_STDBOOL      => 1,
 		PG_VERSION          => qq{"$package_version$extraver"},


### PR DESCRIPTION
Fix conflicts in src/tools/msvc/Solution.pm

1) Commit 1933ae6 added new variables $ac_init_found and $package_url and their
usage to src/tools/msvc/Solution.pm, although earlier commits 8a5ad4b and
c375412 had already added GPDB-specific code to these locations.

2) Commit 0a42a2e changed the setting of the PG_MAJORVERSION and PG_VERSION_NUM
variables in src/tools/msvc/Solution.pm, and added new variables
PG_MAJORVERSION_NUM and PG_MINORVERSION_NUM, while the earlier commit 89f85cc
had already added the GPDB-specific GP_VERSION and GP_MAJORVERSION variables in
the same place.