### PR TITLE
Fix compilation of src/bin/pg_dump/pg_dump.c

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12148,7 +12148,7 @@ format_table_function_columns(Archive *fout, const FuncInfo *finfo, int nallargs
 		if (argmodes[j][0] == PROARGMODE_TABLE)
 		{
 			typid = allargtypes ? atooid(allargtypes[j]) : finfo->argtypes[j];
-			typname = getFormattedTypeName(fout, typid, zeroAsOpaque);
+			typname = getFormattedTypeName(fout, typid, zeroIsError);
 
 			/* column's name is always NOT NULL (checked in gram.y) */
 			appendPQExpBuffer(&fn, "%s%s %s",


### PR DESCRIPTION
Fix compilation of src/bin/pg_dump/pg_dump.c

Commit bb03010 removed the zeroAsOpaque value from the OidOptions enumeration
and replaced its use in src/bin/pg_dump/pg_dump.c with zeroIsError. Replace its
use in GPDB-specific code.