### PR TITLE
Fix assertion in src/backend/executor/execExpr.c

### DIFF
--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -3646,16 +3646,6 @@ ExecBuildAggTransCall(ExprState *state, AggState *aggstate,
 		Assert(as->d.agg_plain_pergroup_nullcheck.jumpnull == -1);
 		as->d.agg_plain_pergroup_nullcheck.jumpnull = state->steps_len;
 	}
-
-	/* fix up jumpnull */
-	if (adjust_jumpnull != -1)
-	{
-		ExprEvalStep *as = &state->steps[adjust_jumpnull];
-
-		Assert(as->opcode == EEOP_AGG_PLAIN_PERGROUP_NULLCHECK);
-		Assert(as->d.agg_plain_pergroup_nullcheck.jumpnull == -1);
-		as->d.agg_plain_pergroup_nullcheck.jumpnull = state->steps_len;
-	}
 }
 
 /*


### PR DESCRIPTION
Fix assertion in src/backend/executor/execExpr.c

Commit c954d49 added additional code to src/backend/executor/execExpr.c at the
end of the ExecBuildAggTransCall function. However, the earlier commit 19cd1cf
had already done the same, creating duplicate code.