### PR TITLE
Fix conflicts in src/test/modules/test_extensions/sql/test_extdepend.sql

### DIFF
--- a/src/test/modules/test_extensions/sql/test_extdepend.sql
+++ b/src/test/modules/test_extensions/sql/test_extdepend.sql
@@ -27,13 +27,9 @@ COPY test_extdep_commands FROM stdin WITH DELIMITER ',';
 \.
 SELECT command FROM test_extdep_commands ORDER BY i;
 -- First, test that dependent objects go away when the extension is dropped.
-<<<<<<< HEAD
 SELECT command FROM test_extdep_commands ORDER BY i \gexec
-=======
-SELECT * FROM test_extdep_commands \gexec
 -- A dependent object made dependent again has no effect
 ALTER FUNCTION test_ext.b() DEPENDS ON EXTENSION test_ext5;
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 -- make sure we have the right dependencies on the extension
 SELECT deptype, p.*
   FROM pg_depend, pg_identify_object(classid, objid, objsubid) AS p


### PR DESCRIPTION
Fix conflicts in src/test/modules/test_extensions/sql/test_extdepend.sql

Commit 899a04f added a new test to
src/test/modules/test_extensions/sql/test_extdepend.sql, although earlier
commit 38d8815 had already changed the previous test. The remaining tests will
be fixed in the GPDB-specific commit 7d64697.