### PR TITLE
Fix tests in src/test/regress/sql/strings.sql

### DIFF
--- a/src/test/regress/expected/strings.out
+++ b/src/test/regress/expected/strings.out
@@ -1932,36 +1932,6 @@ select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, '
 (1 row)
 
 --
--- test unicode escape
---
-select E'A\u0041' as f1, E'\u0127' as f2;
- f1 | f2 
-----+----
- AA | ħ
-(1 row)
-
-select E'\u0000';
-ERROR:  invalid Unicode escape value at or near "E'\u0000"
-LINE 1: select E'\u0000';
-               ^
-select E'\udsfs';
-ERROR:  invalid Unicode escape
-LINE 1: select E'\udsfs';
-               ^
-HINT:  Unicode escapes must be full-length: \uXXXX or \UXXXXXXXX.
-select E'\uD843\uE001';
-ERROR:  invalid Unicode surrogate pair at or near "E'\uD843\uE001"
-LINE 1: select E'\uD843\uE001';
-               ^
-select E'\uDC01';
-ERROR:  invalid Unicode surrogate pair at or near "E'\uDC01"
-LINE 1: select E'\uDC01';
-               ^
-select E'\uD834';
-ERROR:  invalid Unicode surrogate pair at or near "E'\uD834'"
-LINE 1: select E'\uD834';
-               ^
---
 -- Additional string functions
 --
 SET bytea_output TO escape;

--- a/src/test/regress/sql/strings.sql
+++ b/src/test/regress/sql/strings.sql
@@ -669,16 +669,6 @@ set standard_conforming_strings = off;
 select 'a\\bcd' as f1, 'a\\b\'cd' as f2, 'a\\b\'''cd' as f3, 'abcd\\'   as f4, 'ab\\\'cd' as f5, '\\\\' as f6;
 
 --
--- test unicode escape
---
-select E'A\u0041' as f1, E'\u0127' as f2;
-select E'\u0000';
-select E'\udsfs';
-select E'\uD843\uE001';
-select E'\uDC01';
-select E'\uD834';
-
---
 -- Additional string functions
 --
 SET bytea_output TO escape;


### PR DESCRIPTION
Postgres commit a652558, among other things, fixed Unicode error display and 
added matching tests. But GPDB already had its own tests added in commit
6b0e52b, which were not updated. Remove the GPDB tests to avoid future
conflicts, since they duplicate the PostgreSQL tests.
