### PR TITLE
Fix conflicts in src/test/regress/sql/create_type.sql

### DIFF
--- a/src/test/regress/expected/create_type.out
+++ b/src/test/regress/expected/create_type.out
@@ -225,7 +225,6 @@ select format_type('bpchar'::regtype, -1);
  bpchar
 (1 row)
 
-<<<<<<< HEAD
 -- Create & Drop type as non-superuser
 CREATE USER user_bob;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
@@ -236,7 +235,6 @@ CREATE TYPE compfoo as (f1 int, f2 text);
 DROP TYPE compfoo;
 RESET SESSION AUTHORIZATION;
 DROP USER user_bob;
-=======
 --
 -- Test CREATE/ALTER TYPE using a type that's compatible with varchar,
 -- so we can re-use those support functions
@@ -315,4 +313,3 @@ drop cascades to function myvarcharout(myvarchar)
 drop cascades to function myvarcharsend(myvarchar)
 drop cascades to function myvarcharrecv(internal,oid,integer)
 drop cascades to type myvarchardom
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9

--- a/src/test/regress/sql/create_type.sql
+++ b/src/test/regress/sql/create_type.sql
@@ -167,7 +167,7 @@ select format_type('bpchar'::regtype, null);
 -- this behavior difference is intentional
 select format_type('bpchar'::regtype, -1);
 
-<<<<<<< HEAD
+
 -- Create & Drop type as non-superuser
 CREATE USER user_bob;
 SET SESSION AUTHORIZATION user_bob;
@@ -176,7 +176,7 @@ CREATE TYPE compfoo as (f1 int, f2 text);
 DROP TYPE compfoo;
 RESET SESSION AUTHORIZATION;
 DROP USER user_bob;
-=======
+
 --
 -- Test CREATE/ALTER TYPE using a type that's compatible with varchar,
 -- so we can re-use those support functions
@@ -233,4 +233,3 @@ DROP FUNCTION myvarcharsend(myvarchar);  -- fail
 DROP TYPE myvarchar;  -- fail
 
 DROP TYPE myvarchar CASCADE;
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9

--- a/src/test/regress/sql/create_type.sql
+++ b/src/test/regress/sql/create_type.sql
@@ -167,7 +167,6 @@ select format_type('bpchar'::regtype, null);
 -- this behavior difference is intentional
 select format_type('bpchar'::regtype, -1);
 
-
 -- Create & Drop type as non-superuser
 CREATE USER user_bob;
 SET SESSION AUTHORIZATION user_bob;


### PR DESCRIPTION
Fix conflicts in src/test/regress/sql/create_type.sql

Commit fe30e7ebfa38 added new tests to the end of file, but commit 6b0e52beadd6
added another test to the end of file. Keep both of tests.
