### PR TITLE
Fix test output in src/test/regress/expected/opr_sanity.out

### DIFF
--- a/src/test/regress/expected/opr_sanity.out
+++ b/src/test/regress/expected/opr_sanity.out
@@ -2182,6 +2182,7 @@ ORDER BY 1, 2, 3;
  btvarstrequalimage | text_ops         | text_ops         | text
  btvarstrequalimage | text_ops         | varchar_ops      | text
                     | array_ops        | array_ops        | anyarray
+                    | complex_ops      | complex_ops      | complex
                     | float_ops        | float4_ops       | real
                     | float_ops        | float8_ops       | double precision
                     | jsonb_ops        | jsonb_ops        | jsonb


### PR DESCRIPTION
PostgreSQL commit 612a1ab added the equalimage B-tree support functions and 
updated the related test in opr_sanity.out.

The test fails in GPDB because GPDB has a custom type complex (see
src/include/utils/complex_type.h), which is not present in upstream PostgreSQL
and therefore was not included in that commit.

Should we add deduplication support for this GPDB-specific type? This is 
supposed to guarantee that values considered equal by the operator class are
also bitwise identical.

I think no: since the complex type uses floating-point components, it cannot
guarantee that logical equality implies identical byte representation.
PostgreSQL’s own float4 and float8 types are also marked as not
equalimage-compatible for the same reason.

Therefore, just update the test result by keeping the first column (proc) empty
for complex_ops, indicating that it does not support btvarstrequalimage.
