### PR TITLE
ADBDEV-8931: Avoid using gp_tablespace_segment_location in a correlated subplan

### DIFF
--- a/gpcontrib/arenadata_toolkit/Makefile
+++ b/gpcontrib/arenadata_toolkit/Makefile
@@ -3,7 +3,7 @@
 MODULES = arenadata_toolkit
 
 EXTENSION = arenadata_toolkit
-EXTENSION_VERSION = 1.7
+EXTENSION_VERSION = 1.8
 DATA = \
        arenadata_toolkit--1.0.sql \
        arenadata_toolkit--1.0--1.1.sql \
@@ -13,6 +13,7 @@ DATA = \
        arenadata_toolkit--1.4--1.5.sql \
        arenadata_toolkit--1.5--1.6.sql \
        arenadata_toolkit--1.6--1.7.sql \
+       arenadata_toolkit--1.7--1.8.sql \
 
 DATA_built = $(EXTENSION)--$(EXTENSION_VERSION).sql
 

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.7--1.8.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.7--1.8.sql
@@ -1,0 +1,32 @@
+/* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.7--1.8.sql */
+
+CREATE OR REPLACE VIEW arenadata_toolkit.__db_files_current AS
+SELECT
+	c.oid AS oid,
+	c.relname AS table_name,
+	n.nspname AS table_schema,
+	c.relkind AS type,
+	c.relstorage AS storage,
+	d.datname AS table_database,
+	t.spcname AS table_tablespace,
+	dbf.segindex AS content,
+	dbf.segment_preferred_role AS segment_preferred_role,
+	dbf.hostname AS hostname,
+	dbf.address AS address,
+	dbf.full_path AS file,
+	dbf.size AS file_size,
+	dbf.modified_dttm AS modifiedtime,
+	dbf.changed_dttm AS changedtime,
+	CASE
+		WHEN 'pg_default' = t.spcname THEN gpconf.datadir || '/base'
+		WHEN 'pg_global' = t.spcname THEN gpconf.datadir || '/global'
+		ELSE (SELECT pg_tablespace_location(oid)
+			  FROM gp_dist_random('pg_catalog.pg_tablespace')
+			  WHERE oid = t.oid and gp_segment_id = dbf.segindex)
+		END AS tablespace_location
+FROM arenadata_toolkit.__db_segment_files dbf
+LEFT JOIN pg_class c ON c.oid = dbf.reloid
+LEFT JOIN pg_namespace n ON c.relnamespace = n.oid
+LEFT JOIN pg_tablespace t ON dbf.tablespace_oid = t.oid
+LEFT JOIN pg_database d ON dbf.datoid = d.oid
+LEFT JOIN gp_segment_configuration gpconf ON dbf.dbid = gpconf.dbid;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
@@ -1,5 +1,5 @@
 # arenadata_toolkit extension
 comment = 'extension is used for manipulation of objects created by adb-bundle'
-default_version = '1.7'
+default_version = '1.8'
 module_pathname = '$libdir/arenadata_toolkit'
 relocatable = false

--- a/gpcontrib/arenadata_toolkit/expected/upgrade_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/upgrade_test.out
@@ -180,7 +180,12 @@ ORDER BY 1;
  1.6: column tablespace_location check
  1.6: create the latest check
  1.6: only alter check
-(39 rows)
+ 1.7: alter and create_tables check
+ 1.7: alter, create_tables and collect_table_stats check
+ 1.7: column tablespace_location check
+ 1.7: create the latest check
+ 1.7: only alter check
+(44 rows)
 
 -- Cleanup
 DROP FUNCTION do_upgrade_test_for_arenadata_toolkit(TEXT);


### PR DESCRIPTION
Avoid using gp_tablespace_segment_location in a correlated subplan

The gp_tablespace_segment_location function is marked as being executed on all
segments. When used in a correlated subplan, when its argument depends on the
outer plan, it may produce incorrect results. We plan to disable such plans.
Rewrite arenadata_toolkit to avoid using the correlated function on segments in
the subplan.

Ticket: ADBDEV-8931