### PR TITLE
Fix test output for regression test replica_identity

### DIFF
--- a/src/test/regress/expected/replica_identity.out
+++ b/src/test/regress/expected/replica_identity.out
@@ -204,11 +204,13 @@ Indexes:
     "test_replica_identity2_id_key" UNIQUE CONSTRAINT, btree (id) REPLICA IDENTITY
 
 ALTER TABLE test_replica_identity2 ALTER COLUMN id TYPE bigint;
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
 \d test_replica_identity2
-      Table "public.test_replica_identity2"
- Column |  Type  | Collation | Nullable | Default 
---------+--------+-----------+----------+---------
- id     | bigint |           | not null | 
+       Table "public.test_replica_identity2"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ id     | integer |           | not null | 
 Indexes:
     "test_replica_identity2_id_key" UNIQUE CONSTRAINT, btree (id) REPLICA IDENTITY
 


### PR DESCRIPTION
Fix test output for regression test replica_identity

Commit 1cc9c2412cc9a2fbe6a381170097d315fd40ccca adds preserving replica identity
index across ALTER TABLE rewrite. But altering column with primary key or unique
constraint is not supported at GPDB. Actualize test's output with this
limitation.