### PR TITLE
Fix output for regression test join_gp

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -828,7 +828,7 @@ explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
                      ->  Index Only Scan using tenk1_unique2 on tenk1  (cost=0.16..1650.16 rows=3334 width=4)
                      ->  Materialize  (cost=0.16..18479.11 rows=10000 width=0)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.16..18329.11 rows=10000 width=0)
-                                 ->  Index Only Scan using tenk2_unique2 on tenk2  (cost=0.16..17929.11 rows=3334 width=0)
+                                 ->  Index Only Scan using tenk2_hundred on tenk2  (cost=0.16..17929.11 rows=3334 width=0)
  Optimizer: Postgres query optimizer
 (9 rows)
 


### PR DESCRIPTION
Fix output for regression test join_gp

Commit 0d861bbb702f8aa05c2a4e3f1650e7e8df8c8c27 adds deduplication for indexes.
It also change costs of using indexes, which may lead to use another index. It
happens for regression test join_gp. Update test's output.
