### PR TITLE
Fix output for regression test drop_column

### DIFF
--- a/src/test/regress/expected/uao_compaction/drop_column.out
+++ b/src/test/regress/expected/uao_compaction/drop_column.out
@@ -38,7 +38,7 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uao_drop_col';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uao_drop_col_index';
       relname       | reltuples 
 --------------------+-----------
- uao_drop_col_index |         7
+ uao_drop_col_index |         3
 (1 row)
 
 ALTER TABLE uao_drop_col DROP COLUMN c;

--- a/src/test/regress/expected/uaocs_compaction/drop_column.out
+++ b/src/test/regress/expected/uaocs_compaction/drop_column.out
@@ -38,7 +38,7 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_drop';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_drop_index';
      relname      | reltuples 
 ------------------+-----------
- uaocs_drop_index |         7
+ uaocs_drop_index |         3
 (1 row)
 
 ALTER TABLE uaocs_drop DROP COLUMN c;


### PR DESCRIPTION
Fix output for regression test drop_column

Commit 0d861bbb702f8aa05c2a4e3f1650e7e8df8c8c27 adds deduplication for indexes.
It has decreased size of index, which lead to decrease count of relation tuple of
index. Update test's output.