### PR TITLE
Fix conflicts in src/test/modules/test_pg_dump/t/001_base.pl

### DIFF
--- a/src/test/modules/test_pg_dump/t/001_base.pl
+++ b/src/test/modules/test_pg_dump/t/001_base.pl
@@ -570,10 +570,7 @@ my %tests = (
 		like   => {%pgdump_runs},
 		unlike => {
 			data_only          => 1,
-<<<<<<< HEAD
 			extension_schema   => 1,
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 			pg_dumpall_globals => 1,
 			section_data       => 1,
 			section_pre_data   => 1,
@@ -587,10 +584,7 @@ my %tests = (
 		like   => {%pgdump_runs},
 		unlike => {
 			data_only          => 1,
-<<<<<<< HEAD
 			extension_schema   => 1,
-=======
->>>>>>> 4dbcb3f844eca4a401ce06aa2781bd9a9be433e9
 			pg_dumpall_globals => 1,
 			section_data       => 1,
 			section_pre_data   => 1,


### PR DESCRIPTION
We already have Postgres commits 542013e and, on top of it 5cb0e8b. Now we try 
to sync with the first one (542013e) again which conflicting with the second
one (5cb0e8b). Resolve conflicts in favor of the second commit.
