### PR TITLE
ADBDEV-8948: Fix the arenadata_toolkit upgrade_test test

### DIFF
--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.3--1.4.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.3--1.4.sql
@@ -45,9 +45,9 @@ BEGIN
 			CASE
 				WHEN 'pg_default' = t.spcname THEN gpconf.datadir || '/base'
 				WHEN 'pg_global' = t.spcname THEN gpconf.datadir || '/global'
-				ELSE (SELECT tblspc_loc
-					  FROM gp_tablespace_segment_location(t.oid)
-					  WHERE gp_segment_id = dbf.segindex)
+				ELSE (SELECT pg_tablespace_location(oid)
+					  FROM gp_dist_random('pg_catalog.pg_tablespace')
+					  WHERE oid = t.oid and gp_segment_id = dbf.segindex)
 				END AS tablespace_location
 		FROM arenadata_toolkit.__db_segment_files dbf
 		LEFT JOIN pg_class c ON c.oid = dbf.reloid


### PR DESCRIPTION
Fix the arenadata_toolkit upgrade_test test

Commit 73b889e replaced the use of the gp_tablespace_segment_location function
in the correlated subplan in the new version of the arenadata_toolkit extension
with the pg_tablespace_location and gp_dist_random functions. However, this
function remained in previous versions of the extension, causing the
upgrade_test test to fail. Replace it in previous versions as well.

Ticket: ADBDEV-8948