### PR TITLE
Fix 'equivclass' regression test

### DIFF
--- a/src/test/regress/expected/equivclass.out
+++ b/src/test/regress/expected/equivclass.out
@@ -514,9 +514,11 @@ create temp view overview as
   select f1::information_schema.sql_identifier as sqli, f2 from undername;
 explain (costs off)  -- this should not require a sort
   select * from overview where sqli = 'foo' order by sqli;
-          QUERY PLAN          
-------------------------------
- Seq Scan on undername
-   Filter: (f1 = 'foo'::name)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on undername
+         Filter: (f1 = 'foo'::name)
+ Optimizer: Postgres query optimizer
+(4 rows)
 

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -496,6 +496,20 @@ explain (costs off)
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on tenk1
          Filter: ((unique1 = unique1) OR (unique2 = unique2))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+-- check that we recognize equivalence with dummy domains in the way
+create temp table undername (f1 name, f2 int);
+create temp view overview as
+  select f1::information_schema.sql_identifier as sqli, f2 from undername;
+explain (costs off)  -- this should not require a sort
+  select * from overview where sqli = 'foo' order by sqli;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on undername
+         Filter: (f1 = 'foo'::name)
  Optimizer: Postgres query optimizer
 (4 rows)
 


### PR DESCRIPTION
Fix 'equivclass' regression test

Commit a477bfc1dfb8 added a new case with explain to the 'equivclass' test. This
patch updates the explain output due to MPP plan differences. Also the expected
output is added for Orca.
