### PR TITLE
Fix 'gp_dqa' regression test

### DIFF
--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2243,11 +2243,11 @@ explain (verbose, costs off) select count(distinct (b)::text) as b, count(distin
                                                 QUERY PLAN
 -----------------------------------------------------------------------------------------------------------
  Finalize Aggregate
-   Output: count(DISTINCT ((b)::text)), count(DISTINCT (a)::character varying)
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT a)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (a)::character varying))
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT a))
          ->  Partial Aggregate
-               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (a)::character varying)
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT a)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Output: b, a, ((b)::text), (AggExprId)
                      Hash Key: ((b)::text), a, (AggExprId)

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2384,11 +2384,11 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
                                                  QUERY PLAN
 -------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
-   Output: count(DISTINCT ((b)::text)), count(DISTINCT (a)::character varying)
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT a)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (a)::character varying))
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT a))
          ->  Partial Aggregate
-               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (a)::character varying)
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT a)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Output: b, a, ((b)::text), (AggExprId)
                      Hash Key: ((b)::text), a, (AggExprId)


### PR DESCRIPTION
Fix 'gp_dqa' regression test

Commit a477bfc1dfb8 changed handling of RelabelType nodes. Now in
'applyRelabelType()' this node can be removed completely for some cases, and,
therefore, explain output can have less info about type cast. It has broken 
'gp_dqa' test. As that is current Postgres behavior, this patch updates the
expected output of the test.
