### PR TITLE
Fix test uao_compaction/stats.out

### DIFF
--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -1444,6 +1444,7 @@ restart:
 		if (minoff > maxoff)
 			delete_now = (blkno == orig_blkno);
 		else if (callback == NULL)
+			/* GPDB_13_MERGE_FIXME: Commit 02c9386 has alternative fix */
 			stats->num_index_tuples += maxoff - minoff + 1;
 		else
 			stats->num_index_tuples += nhtidslive;

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -1443,7 +1443,7 @@ restart:
 		 */
 		if (minoff > maxoff)
 			delete_now = (blkno == orig_blkno);
-		else if callback == NULL
+		else if (callback == NULL)
 			stats->num_index_tuples += maxoff - minoff + 1;
 		else
 			stats->num_index_tuples += nhtidslive;

--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -1443,6 +1443,8 @@ restart:
 		 */
 		if (minoff > maxoff)
 			delete_now = (blkno == orig_blkno);
+		else if callback == NULL
+			stats->num_index_tuples += maxoff - minoff + 1;
 		else
 			stats->num_index_tuples += nhtidslive;
 


### PR DESCRIPTION
Commit 0d861bb in particular changed  the logic for vacuuming a page. 
Specifically, the  calculation of the remaining number of elements for 
statistics now depends on the callback in btvacuumpage(). This can produce 
a more precise result, but it works only for the bulk delete case. The regular 
vacuum case has become unhandled.

The update of statistics in btvacuumcleanup(), which is called from 
index_vacuum_cleanup() when executing vacuum_appendonly_indexes() with no dead 
segments, is affected. This is a rare situation, occuring only in a few test 
cases, on one of the segments, and it leads to incorrect statistics.

This patch restores the old logic for determining the number of 
tuples in btvacuumpage() when the callback is not set.
