### PR TITLE
Fix 'opr_sanity' regression test

### DIFF
--- a/src/test/regress/expected/opr_sanity.out
+++ b/src/test/regress/expected/opr_sanity.out
@@ -2192,7 +2192,7 @@ ORDER BY 1, 2, 3;
                     | record_ops       | record_ops       | record
                     | tsquery_ops      | tsquery_ops      | tsquery
                     | tsvector_ops     | tsvector_ops     | tsvector
-(14 rows)
+(15 rows)
 
 -- **************** pg_index ****************
 -- Look for illegal values in pg_index fields.


### PR DESCRIPTION
Fix 'opr_sanity' regression test

Commit 2c60fb078236 updated expected output file for the test 'opr_sanity' by
adding a new result line, but it didn't update the result row count. It caused
test failure. This patch updates the expected output row count to fix the test.