### PR TITLE
Revert "Fix output for regression test drop_column (#2144)"

### DIFF
--- a/src/test/regress/expected/uao_compaction/drop_column.out
+++ b/src/test/regress/expected/uao_compaction/drop_column.out
@@ -38,7 +38,7 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uao_drop_col';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uao_drop_col_index';
       relname       | reltuples 
 --------------------+-----------
- uao_drop_col_index |         3
+ uao_drop_col_index |         7
 (1 row)
 
 ALTER TABLE uao_drop_col DROP COLUMN c;

--- a/src/test/regress/expected/uaocs_compaction/drop_column.out
+++ b/src/test/regress/expected/uaocs_compaction/drop_column.out
@@ -38,7 +38,7 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_drop';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_drop_index';
      relname      | reltuples 
 ------------------+-----------
- uaocs_drop_index |         3
+ uaocs_drop_index |         7
 (1 row)
 
 ALTER TABLE uaocs_drop DROP COLUMN c;


### PR DESCRIPTION
Commit 6366d4f fixed an incorrect output. Revert.

This reverts commit 6366d4f1ea1ef8deee0b2af8511c642c5e605e9b.