### PR TITLE
Fix conflicts in src/include/access/xlog.h

### DIFF
--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -325,12 +325,7 @@ extern XLogRecPtr GetFlushRecPtr(void);
 extern XLogRecPtr GetLastImportantRecPtr(void);
 extern void RemovePromoteSignalFiles(void);
 
-<<<<<<< HEAD
-extern void HandleStartupProcInterrupts(void);
-extern void StartupProcessMain(void);
-=======
 extern bool PromoteIsTriggered(void);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 extern bool CheckPromoteSignal(void);
 extern void WakeupRecovery(void);
 extern void SetWalWriterSleeping(bool sleeping);


### PR DESCRIPTION
Fix conflicts in src/include/access/xlog.h

Commit 496ee64 added a declaration of a new function, PromoteIsTriggered, to
src/include/access/xlog.h, while an earlier commit, 6b0e52b, had already added
declarations of the functions HandleStartupProcInterrupts and
StartupProcessMain in the same location. In the upstream, these functions have
been moved to src/include/postmaster/startup.h.