### PR TITLE
Resolve conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302511211
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202004022
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+#define CATALOG_VERSION_NO	302512151
 
 #endif


### PR DESCRIPTION
Resolve conflicts in src/include/catalog/catversion.h

Commit 2991ac5 updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.