### PR TITLE
Fix conflicts in src/include/optimizer/cost.h

### DIFF
--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -72,10 +72,7 @@ extern PGDLLIMPORT bool enable_bitmapscan;
 extern PGDLLIMPORT bool enable_tidscan;
 extern PGDLLIMPORT bool enable_sort;
 extern PGDLLIMPORT bool enable_hashagg;
-<<<<<<< HEAD
 extern PGDLLIMPORT bool enable_groupagg;
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 extern PGDLLIMPORT bool enable_hashagg_disk;
 extern PGDLLIMPORT bool enable_groupingsets_hash_disk;
 extern PGDLLIMPORT bool enable_nestloop;


### PR DESCRIPTION
Fix conflicts in src/include/optimizer/cost.h

Commit 1f39bce added declarations of new variables enable_hashagg_disk and
enable_hashagg_disk to src/include/optimizer/cost.h, although the earlier
commit 19cd1cf had already done so, and also added a declaration of a new
variable, enable_groupagg, before this point.