### PR TITLE
Fix conflicts in src/include/utils/selfuncs.h

### DIFF
--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -158,7 +158,7 @@ extern double histogram_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
 									Datum constval, bool varonleft,
 									int min_hist_size, int n_skip,
 									int *hist_size);
-extern double generic_restriction_selectivity(PlannerInfo *root, Oid operator,
+extern double generic_restriction_selectivity(PlannerInfo *root, Oid operOid,
 											  List *args, int varRelid,
 											  double default_selectivity);
 extern double ineq_histogram_selectivity(PlannerInfo *root,

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -48,9 +48,6 @@
 /* default selectivity estimate for other matching operators */
 #define DEFAULT_MATCHING_SEL	0.010
 
-/* default number of distinct values in a table */
-#define DEFAULT_NUM_DISTINCT  200
-
 /* default selectivity estimate for boolean and null test nodes */
 #define DEFAULT_UNK_SEL			DEFAULT_EQ_SEL                      /*CDB*/
 #define DEFAULT_NOT_UNK_SEL		(1.0 - DEFAULT_UNK_SEL)

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -43,17 +43,13 @@
 #define DEFAULT_RANGE_INEQ_SEL	(10 * DEFAULT_EQ_SEL)               /*CDB*/
 
 /* default selectivity estimate for pattern-match operators such as LIKE */
-<<<<<<< HEAD
 #define DEFAULT_MATCH_SEL	    (50 * DEFAULT_EQ_SEL)               /*CDB*/
-=======
-#define DEFAULT_MATCH_SEL	0.005
 
 /* default selectivity estimate for other matching operators */
 #define DEFAULT_MATCHING_SEL	0.010
 
 /* default number of distinct values in a table */
 #define DEFAULT_NUM_DISTINCT  200
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 /* default selectivity estimate for boolean and null test nodes */
 #define DEFAULT_UNK_SEL			DEFAULT_EQ_SEL                      /*CDB*/

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -155,6 +155,7 @@ extern double histogram_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
 									Datum constval, bool varonleft,
 									int min_hist_size, int n_skip,
 									int *hist_size);
+/* GPDB: avoid C++ keyword "operator" for header include in gpopt C++ code */
 extern double generic_restriction_selectivity(PlannerInfo *root, Oid operOid,
 											  List *args, int varRelid,
 											  double default_selectivity);


### PR DESCRIPTION
Fix conflicts in src/include/utils/selfuncs.h

1) Commit a808186 added a new DEFAULT_MATCHING_SEL definition to
src/include/utils/selfuncs.h, while an earlier commit, 6b0e52b, had already
changed the DEFAULT_MATCH_SEL definition just before that point.

2) Commit a808186 in src/include/utils/selfuncs.h added a definition of a new
function, generic_restriction_selectivity, with the keyword operator as an
argument. This include is included in src/include/gpopt/utils/gpdbdefs.h, which
compiles by C++, where operator is a reserved keyword. Rename in the include.