### PR TITLE
Fix conflicts in src/backend/access/index/indexam.c

### DIFF
--- a/src/backend/access/index/indexam.c
+++ b/src/backend/access/index/indexam.c
@@ -61,14 +61,11 @@
 #include "storage/bufmgr.h"
 #include "storage/lmgr.h"
 #include "storage/predicate.h"
+#include "utils/fmgroids.h"
 #include "utils/ruleutils.h"
 #include "utils/snapmgr.h"
-<<<<<<< HEAD
-#include "utils/fmgroids.h"
-=======
 #include "utils/syscache.h"
 
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 /* ----------------------------------------------------------------
  *					macros used in index_ routines


### PR DESCRIPTION
Fix conflicts in src/backend/access/index/indexam.c

Commit 911e702 added utils/syscache.h as the last include in
src/backend/access/index/indexam.c, while the earlier commit 8b2deb1 already
added utils/fmgroids.h as the last include.