### PR TITLE
Fix conflicts in src/backend/access/transam/xlogarchive.c

### DIFF
--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -156,68 +156,6 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	else
 		XLogFileName(lastRestartPointFname, 0, 0L, wal_segment_size);
 
-<<<<<<< HEAD
-	/*
-	 * construct the command to be executed
-	 */
-	dp = xlogRestoreCmd;
-	endp = xlogRestoreCmd + MAXPGPATH - 1;
-	*endp = '\0';
-
-	for (sp = recoveryRestoreCommand; *sp; sp++)
-	{
-		if (*sp == '%')
-		{
-			switch (sp[1])
-			{
-				case 'p':
-					/* %p: relative path of target file */
-					sp++;
-					StrNCpy(dp, xlogpath, endp - dp);
-					make_native_path(dp);
-					dp += strlen(dp);
-					break;
-				case 'f':
-					/* %f: filename of desired file */
-					sp++;
-					StrNCpy(dp, xlogfname, endp - dp);
-					dp += strlen(dp);
-					break;
-				case 'r':
-					/* %r: filename of last restartpoint */
-					sp++;
-					StrNCpy(dp, lastRestartPointFname, endp - dp);
-					dp += strlen(dp);
-					break;
-				case 'c':
-					/* GPDB: %c: contentId of segment */
-					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
-					sp++;
-					pg_ltoa(GpIdentity.segindex, contentid);
-					StrNCpy(dp, contentid, endp - dp);
-					dp += strlen(dp);
-					break;
-				case '%':
-					/* convert %% to a single % */
-					sp++;
-					if (dp < endp)
-						*dp++ = *sp;
-					break;
-				default:
-					/* otherwise treat the % as not special */
-					if (dp < endp)
-						*dp++ = *sp;
-					break;
-			}
-		}
-		else
-		{
-			if (dp < endp)
-				*dp++ = *sp;
-		}
-	}
-	*dp = '\0';
-=======
 	/* Build the restore command to execute */
 	xlogRestoreCmd = BuildRestoreCommand(recoveryRestoreCommand,
 										 xlogpath, xlogfname,
@@ -225,7 +163,6 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	if (xlogRestoreCmd == NULL)
 		elog(ERROR, "could not build restore command \"%s\"",
 			 recoveryRestoreCommand);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	ereport(DEBUG3,
 			(errmsg_internal("executing restore command \"%s\"",

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -69,8 +69,6 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	XLogRecPtr	restartRedoPtr;
 	TimeLineID	restartTli;
 
-	char        contentid[12];  /* sign, 10 digits and '\0' */
-
 	/*
 	 * Ignore restore_command when not in archive recovery (meaning
 	 * we are in crash recovery).

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -105,12 +105,14 @@ BuildRestoreCommand(const char *restoreCommand,
 					appendStringInfoString(&result,
 										   lastRestartPointFname);
 					break;
+#ifndef FRONTEND
 				case 'c':
 					/* GPDB: %c: contentId of segment */
 					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
 					appendStringInfo(&result, "%i", GpIdentity.segindex);
 					break;
+#endif
 				case '%':
 					/* convert %% to a single % */
 					sp++;

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -23,6 +23,11 @@
 #include "lib/stringinfo.h"
 
 /*
+ * GPDB specific imports:
+ */
+#include "cdb/cdbvars.h"
+
+/*
  * BuildRestoreCommand
  *
  * Builds a restore command to retrieve a file from WAL archives, replacing
@@ -99,6 +104,12 @@ BuildRestoreCommand(const char *restoreCommand,
 					sp++;
 					appendStringInfoString(&result,
 										   lastRestartPointFname);
+					break;
+				case 'c':
+					/* GPDB: %c: contentId of segment */
+					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					appendStringInfo(&result, "%i", GpIdentity.segindex);
 					break;
 				case '%':
 					/* convert %% to a single % */


### PR DESCRIPTION
Fix conflicts in src/backend/access/transam/xlogarchive.c

Commit e09ad07 in src/backend/access/transam/xlogarchive.c in the
RestoreArchivedFile function replaced a large chunk of code with a call to the
new BuildRestoreCommand function. However, the earlier commit 96b9844 had
already added GPDB-specific code for the 'c' case to this location.

Add ifndef FRONTEND because archive.c may link to frontend code where
GpIdentity is not defined.