### PR TITLE
Fix conflicts in src/backend/catalog/index.c

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2428,11 +2428,8 @@ BuildIndexInfo(Relation index)
 								 &ii->ii_ExclusionStrats);
 	}
 
-<<<<<<< HEAD
 	ii->ii_Am = index->rd_rel->relam;
-=======
 	ii->ii_OpclassOptions = RelationGetIndexRawAttOptions(index);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	return ii;
 }


### PR DESCRIPTION
Fix conflicts in src/backend/catalog/index.c

Commit 911e702 in src/backend/catalog/index.c added an assignment of the result
of the RelationGetIndexRawAttOptions function call to the ii_OpclassOptions
field at the end of the BuildIndexInfo function. However, an earlier commit,
9d40d47, had already added an assignment to the ii_Am field in the same
location.