### PR TITLE
Fix conflicts in src/backend/catalog/pg_proc.c

### DIFF
--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -38,11 +38,7 @@
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
-<<<<<<< HEAD
-#include "parser/parse_expr.h"
-=======
 #include "parser/parse_coerce.h"
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 #include "parser/parse_type.h"
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"


### PR DESCRIPTION
Fix conflicts in src/backend/catalog/pg_proc.c

Commit e6c178b added a new include, parser/parse_coerce.h, to
src/backend/catalog/pg_proc.c, while earlier commit 5b2af3c had already added a
new include, parser/parse_expr.h, in the same location. Remove the
parser/parse_expr.h include because none of its four symbols:
operator_precedence_warning, Transform_null_equals, transformExpr, and
ParseExprKindName are used in src/backend/catalog/pg_proc.c anymore.