### PR TITLE
Fix conflicts in src/backend/catalog/system_views.sql

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -908,7 +908,6 @@ CREATE VIEW pg_stat_replication AS
         JOIN pg_stat_get_wal_senders() AS W ON (S.pid = W.pid)
         LEFT JOIN pg_authid AS U ON (S.usesysid = U.oid);
 
-<<<<<<< HEAD
 CREATE FUNCTION gp_stat_get_master_replication() RETURNS SETOF RECORD AS
 $$
     SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
@@ -968,7 +967,7 @@ CREATE VIEW gp_stat_replication AS
          spill_txns int8, spill_count int8, spill_bytes int8)
          ON G.gp_segment_id = R.gp_segment_id
     );
-=======
+
 CREATE VIEW pg_stat_slru AS
     SELECT
             s.name,
@@ -981,7 +980,6 @@ CREATE VIEW pg_stat_slru AS
             s.truncates,
             s.stats_reset
     FROM pg_stat_get_slru() s;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 CREATE VIEW pg_stat_wal_receiver AS
     SELECT

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -637,6 +637,7 @@ FROM
          case when d.policytype = 'r' then (sum(n_live_tup)/d.numsegments)::bigint else sum(n_live_tup) end n_live_tup,
          case when d.policytype = 'r' then (sum(n_dead_tup)/d.numsegments)::bigint else sum(n_dead_tup) end n_dead_tup,
          case when d.policytype = 'r' then (sum(n_mod_since_analyze)/d.numsegments)::bigint else sum(n_mod_since_analyze) end n_mod_since_analyze,
+         case when d.policytype = 'r' then (sum(n_ins_since_vacuum)/d.numsegments)::bigint else sum(n_ins_since_vacuum) end n_ins_since_vacuum,
          max(last_vacuum) as last_vacuum,
          max(last_autovacuum) as last_autovacuum,
          max(last_analyze) as last_analyze,

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -613,6 +613,7 @@ SELECT
     m.n_live_tup,
     m.n_dead_tup,
     m.n_mod_since_analyze,
+    m.n_ins_since_vacuum,
     s.last_vacuum,
     s.last_autovacuum,
     s.last_analyze,


### PR DESCRIPTION
Fix conflicts in src/backend/catalog/system_views.sql

1) Commit 28cac71 added a new view, pg_stat_slru, to
src/backend/catalog/system_views.sql. Earlier GPDB-specific commits had already
added the GPDB-specific functions gp_stat_get_master_replication,
gp_stat_get_segment_replication, gp_stat_get_segment_replication_error, and the
view gp_stat_replication to the same location.

2) Commit b07642d in src/backend/catalog/system_views.sql added a new column,
n_ins_since_vacuum, to the pg_stat_all_tables view. During the merge, this
change was applied automatically only to pg_stat_all_tables_internal, which is
part of the GPDB-specific implementation of pg_stat_all_table. Add the column
to the outer pg_stat_all_tables view.