### PR TITLE
Fix conflicts in src/backend/commands/copy.c

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2055,18 +2055,13 @@ BeginCopy(ParseState *pstate,
 		}
 
 		/* plan the query */
-<<<<<<< HEAD
 		int			cursorOptions = CURSOR_OPT_PARALLEL_OK;
 
 		/* GPDB: Pass the IGNORE EXTERNAL PARTITION option to the planner. */
 		if (cstate->skip_foreign_partitions)
 			cursorOptions |= CURSOR_OPT_SKIP_FOREIGN_PARTITIONS;
 
-		plan = pg_plan_query(query, cursorOptions, NULL);
-=======
-		plan = pg_plan_query(query, pstate->p_sourcetext,
-							 CURSOR_OPT_PARALLEL_OK, NULL);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+		plan = pg_plan_query(query, pstate->p_sourcetext, cursorOptions, NULL);
 
 		/*
 		 * With row level security and a user using "COPY relation TO", we


### PR DESCRIPTION
Fix conflicts in src/backend/commands/copy.c

Commit 6aba63e in src/backend/commands/copy.c in the BeginCopy function when
calling the pg_plan_query function adds a new pstate->p_sourcetext argument.
However, earlier commits 19cd1cf and 051cc04 had already added GPDB-specific
code before this point.