### PR TITLE
Fix conflicts in src/backend/optimizer/plan/planner.c

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16699,7 +16699,7 @@ build_ctas_with_dist(Relation rel, DistributedBy *dist_clause,
 		rawstmt->stmt_len = 0;
 
 		q_list = pg_analyze_and_rewrite(rawstmt, synthetic_sql, NULL, 0, NULL);
-		p_list = pg_plan_queries(q_list, 0, NULL);
+		p_list = pg_plan_queries(q_list, NULL, 0, NULL);
 		pstmt = linitial_node(PlannedStmt, p_list);
 		ctas = castNode(CreateTableAsStmt, pstmt->utilityStmt);
 
@@ -16731,7 +16731,7 @@ build_ctas_with_dist(Relation rel, DistributedBy *dist_clause,
 	Assert(q->commandType == CMD_SELECT || q->commandType == CMD_INSERT);
 
 	/* plan the query */
-	stmt = planner(q, 0, NULL);
+	stmt = planner(q, NULL, 0, NULL);
 	stmt->intoClause = into;
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -311,12 +311,11 @@ planner(Query *parse, const char *query_string, int cursorOptions,
 	instr_time	starttime, endtime;
 
 	if (planner_hook)
-<<<<<<< HEAD
 	{
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
-		result = (*planner_hook) (parse, cursorOptions, boundParams);
+		result = (*planner_hook) (parse, query_string, cursorOptions, boundParams);
 
 		if (gp_log_optimization_time)
 		{
@@ -326,13 +325,8 @@ planner(Query *parse, const char *query_string, int cursorOptions,
 		}
 	}
 	else
-		result = standard_planner(parse, cursorOptions, boundParams);
-
-=======
-		result = (*planner_hook) (parse, query_string, cursorOptions, boundParams);
-	else
 		result = standard_planner(parse, query_string, cursorOptions, boundParams);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+
 	return result;
 }
 
@@ -5501,17 +5495,13 @@ create_distinct_paths(PlannerInfo *root,
 	else if (parse->hasDistinctOn || !enable_hashagg)
 		allow_hash = false;		/* policy-based decision not to hash */
 	else
-<<<<<<< HEAD
-		allow_hash = true;		/* default */
-=======
 	{
 		Size		hashentrysize = hash_agg_entry_size(
 			0, cheapest_input_path->pathtarget->width, 0);
 
 		allow_hash = enable_hashagg_disk ||
-			(hashentrysize * numDistinctRows <= work_mem * 1024L);
+			(hashentrysize * numDistinctRowsTotal <= work_mem * 1024L);
 	}
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	if (allow_hash && grouping_is_hashable(parse->distinctClause))
 	{
@@ -7501,10 +7491,6 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 
 			if (enable_hashagg_disk ||
 				hashaggtablesize < work_mem * 1024L)
-<<<<<<< HEAD
-			{
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 				add_path(grouped_rel, (Path *)
 						 create_agg_path(root,
 										 grouped_rel,
@@ -7517,7 +7503,6 @@ add_paths_to_grouping_rel(PlannerInfo *root, RelOptInfo *input_rel,
 										 havingQual,
 										 agg_final_costs,
 										 dNumGroups));
-			}
 		}
 	}
 

--- a/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
+++ b/src/test/modules/test_planner/integration_tests/planner_integration_tests.c
@@ -15,7 +15,7 @@ test_stable_function_in_subquery_is_evaluated_to_const()
 	const char *query_string = "select * from (select now()) a;";
 
 	Query *query = make_query(query_string);
-	PlannedStmt *plannedstmt = planner(query, 0, NULL);
+	PlannedStmt *plannedstmt = planner(query, query_string, 0, NULL);
 
 	TargetEntry *tle = get_target_entry_from_root_plan_node(plannedstmt);
 
@@ -28,7 +28,7 @@ test_stable_function_in_simple_query_is_not_evaluated_in_planner()
 	const char *query_string = "select now();";
 
 	Query *query = make_query(query_string);
-	PlannedStmt *plannedstmt = planner(query, 0, NULL);
+	PlannedStmt *plannedstmt = planner(query, query_string, 0, NULL);
 
 	TargetEntry *tle = get_target_entry_from_root_plan_node(plannedstmt);
 

--- a/src/test/regress/hooktest/hook_test.c
+++ b/src/test/regress/hooktest/hook_test.c
@@ -33,9 +33,9 @@ test_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	elog(LOG, "In test_planner_hook");
 
 	if (prev_planner_hook)
-		stmt = (*prev_planner_hook) (parse, cursorOptions, boundParams);
+		stmt = (*prev_planner_hook) (parse, NULL, cursorOptions, boundParams);
 	else
-		stmt = standard_planner(parse, cursorOptions, boundParams);
+		stmt = standard_planner(parse, NULL, cursorOptions, boundParams);
 
 	return stmt;
 }

--- a/src/test/regress/hooktest/hook_test.c
+++ b/src/test/regress/hooktest/hook_test.c
@@ -7,7 +7,7 @@ PG_MODULE_MAGIC;
 
 static planner_hook_type prev_planner_hook = NULL;
 
-static PlannedStmt *test_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams);
+static PlannedStmt *test_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams);
 
 void		_PG_init(void);
 void		_PG_fini(void);
@@ -26,16 +26,16 @@ _PG_fini(void)
 }
 
 static PlannedStmt *
-test_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
+test_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt *stmt;
 
 	elog(LOG, "In test_planner_hook");
 
 	if (prev_planner_hook)
-		stmt = (*prev_planner_hook) (parse, NULL, cursorOptions, boundParams);
+		stmt = (*prev_planner_hook) (parse, query_string, cursorOptions, boundParams);
 	else
-		stmt = standard_planner(parse, NULL, cursorOptions, boundParams);
+		stmt = standard_planner(parse, query_string, cursorOptions, boundParams);
 
 	return stmt;
 }


### PR DESCRIPTION
Fix conflicts in src/backend/optimizer/plan/planner.c

1) Commit 6aba63e added a new query_string argument to the planner,
standard_planner, pg_plan_query, and pg_plan_queries functions. Add it when
calling these functions in GPDB-specific places.

2) Commit 6aba63e added a new query_string argument to the planner function in
src/backend/optimizer/plan/planner.c when calling standard_planner. However,
earlier GPDB-specific commits had already added GPDB-specific code before this
location.

3) Commit 7d4395d added new tupleWidth and transitionSpace arguments to the
hash_agg_entry_size function call in src/backend/optimizer/plan/planner.c in
the create_distinct_paths function. Commit dd8e191 changed the allow_hash
calculation below. Earlier commit 1818894 had already added the allow_hash
assignment in the same place. Earlier commit c5f6dbb renamed the local variable
numDistinctRows to numDistinctRowsTotal.

4) Commit 1f39bce added the enable_hashagg_disk condition to the
add_paths_to_grouping_rel function in src/backend/optimizer/plan/planner.c.
Earlier commit 19cd1cf had already added the curly braces.

5) Commit 6aba63e added a new query_string argument to the planner_hook_type in
src/include/optimizer/planner.h. Add it in GPDB-specific locations.