### PR TITLE
Fix conflicts in src/backend/optimizer/util/pathnode.c

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2245,11 +2245,7 @@ create_unique_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 					 NIL,
 					 subpath->startup_cost,
 					 subpath->total_cost,
-<<<<<<< HEAD
 					 (rel->rows / numsegments),
-=======
-					 rel->rows,
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 					 subpath->pathtarget->width);
 	}
 
@@ -2523,8 +2519,7 @@ create_unique_rowid_path(PlannerInfo *root,
 					 subpath->startup_cost,
 					 subpath->total_cost,
 					 (rel->rows / numsegments),
-					 false /* streaming */
-				);
+					 subpath->pathtarget->width);
 	}
 
 	if (all_btree && all_hash)


### PR DESCRIPTION
Fix conflicts in src/backend/optimizer/util/pathnode.c

Commit 1f39bce in src/backend/optimizer/util/pathnode.c added a new argument,
subpath->pathtarget->width, to the cost_agg function in the create_unique_path
function. However, an earlier commit c5f6dbb had already divided the previous
rel->rows argument by numsegments. Fix an incorrect last argument in the
create_unique_rowid_path function when calling the cost_agg function.