### PR TITLE
Fix conflicts in src/backend/parser/gram.y

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -18351,12 +18351,9 @@ unreserved_keyword:
 			| NFKC
 			| NFKD
 			| NO
-<<<<<<< HEAD
 			| NOCREATEEXTTABLE
 			| NOOVERCOMMIT
-=======
 			| NORMALIZED
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 			| NOTHING
 			| NOTIFY
 			| NOWAIT


### PR DESCRIPTION
Fix conflicts in src/backend/parser/gram.y

Commit 2991ac5 added a new unreserved keyword, NORMALIZED, to
src/backend/parser/gram.y, while an earlier commit, 6b0e52b, had already added
NOCREATEEXTTABLE and NOOVERCOMMIT to the same location.