### PR TITLE
Fix conflicts in src/backend/postmaster/pgstat.c

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -5018,6 +5018,7 @@ PgstatCollectorMain(int argc, char *argv[])
 
 				case PGSTAT_MTYPE_QUEUESTAT:  /* GPDB */
 					pgstat_recv_queuestat((PgStat_MsgQueuestat *) &msg, len);
+					break;
 
 				case PGSTAT_MTYPE_SLRU:
 					pgstat_recv_slru(&msg.msg_slru, len);

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4544,7 +4544,6 @@ pgstat_send_bgwriter(void)
 	MemSet(&BgWriterStats, 0, sizeof(BgWriterStats));
 }
 
-<<<<<<< HEAD
 /*
  * pgstat_send_qd_tabstats() -
  *
@@ -4783,7 +4782,7 @@ pgstat_combine_from_qe(CdbDispatchResults *results, int writerSliceIndex)
 		}
 	}
 }
-=======
+
 /* ----------
  * pgstat_send_slru() -
  *
@@ -4824,7 +4823,6 @@ pgstat_send_slru(void)
 	}
 }
 
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 /* ----------
  * PgstatCollectorMain() -
@@ -5018,13 +5016,11 @@ PgstatCollectorMain(int argc, char *argv[])
 					pgstat_recv_bgwriter(&msg.msg_bgwriter, len);
 					break;
 
-<<<<<<< HEAD
 				case PGSTAT_MTYPE_QUEUESTAT:  /* GPDB */
 					pgstat_recv_queuestat((PgStat_MsgQueuestat *) &msg, len);
-=======
+
 				case PGSTAT_MTYPE_SLRU:
 					pgstat_recv_slru(&msg.msg_slru, len);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 					break;
 
 				case PGSTAT_MTYPE_FUNCSTAT:
@@ -5549,13 +5545,10 @@ pgstat_read_statsfiles(Oid onlydb, bool permanent, bool deep)
 	int32		format_id;
 	bool		found;
 	const char *statfile = permanent ? PGSTAT_STAT_PERMANENT_FILENAME : pgstat_stat_filename;
-<<<<<<< HEAD
 	PgStat_StatQueueEntry queuebuf;	/* GPDB */
 	PgStat_StatQueueEntry *queueentry; /* GPDB */
 	HTAB	   *queuehash = NULL;  /* GPDB */
-=======
 	int			i;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	/*
 	 * The tables will live in pgStatLocalContext.


### PR DESCRIPTION
Fix conflicts in src/backend/postmaster/pgstat.c

1) Commit 28cac71 added a new function pgstat_send_slru to
src/backend/postmaster/pgstat.c, while earlier GPDB-specific commits had
already added the GPDB-specific functions pgstat_send_qd_tabstats,
pgstat_combine_one_qe_result, and pgstat_combine_from_qe to the same location.

2) Commit 28cac71 in src/backend/postmaster/pgstat.c added a call to the new
pgstat_recv_slru function in the PgstatCollectorMain function for the new
PGSTAT_MTYPE_SLRU case, while the earlier commit 6b0e52b had already added a
call to the pgstat_recv_queuestat function for the GPDB-specific
PGSTAT_MTYPE_QUEUESTAT case.

3) Commit 28cac71 in src/backend/postmaster/pgstat.c added a new local variable
i in the pgstat_read_statsfiles function, while the earlier commit c7649f1 had
already added the new GPDB-specific local variables queuebuf, queueentry, and
queuehash in the same location.