### PR TITLE
Fix conflicts in src/backend/utils/cache/relcache.c

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -361,15 +361,9 @@ ScanPgRelation(Oid targetRelId, bool indexOK, bool force_non_historic)
 	 * need to register the snapshot.
 	 */
 	if (force_non_historic)
-<<<<<<< HEAD
 		snapshot = GetNonHistoricCatalogSnapshot(
 			RelationRelationId,
 			DistributedTransactionContext);
-	else
-		snapshot = GetCatalogSnapshot(RelationRelationId);
-=======
-		snapshot = GetNonHistoricCatalogSnapshot(RelationRelationId);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	pg_class_scan = systable_beginscan(pg_class_desc, ClassOidIndexId,
 									   indexOK && criticalRelcachesBuilt,


### PR DESCRIPTION
Fix conflicts in src/backend/utils/cache/relcache.c

Commit 42750b0 in src/backend/utils/cache/relcache.c in the ScanPgRelation
function removed the call to the GetCatalogSnapshot function and added a
comment before it. However, the earlier commit fdf5a57 had already added a new
DistributedTransactionContext argument to the call to the
GetNonHistoricCatalogSnapshot function above.