### PR TITLE
Fix conflicts in src/backend/utils/error/elog.c

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -547,10 +547,7 @@ errfinish(const char *filename, int lineno, const char *funcname)
 
 	recursion_depth++;
 	CHECK_STACK_DEPTH();
-<<<<<<< HEAD
 	saved_errno = edata->saved_errno;   /*CDB*/
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	/* Save the last few bits of error state into the stack entry */
 	if (filename)
@@ -1609,7 +1606,6 @@ getinternalerrposition(void)
 }
 
 /*
-<<<<<<< HEAD
  * CDB: errFatalReturn -- set flag indicating errfinish() should return
  * to the caller instead of calling proc_exit() after reporting a FATAL
  * error.  Allows termination by re-raising a signal in order to obtain
@@ -1628,10 +1624,7 @@ errFatalReturn(bool fatalReturn)
 	return 0;					/* return value does not matter */
 }
 
-
 /*
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
  * Functions to allow construction of error message strings separately from
  * the ereport() call itself.
  *


### PR DESCRIPTION
Fix conflicts in src/backend/utils/error/elog.c

1) Commit 17a28b0 in src/backend/utils/error/elog.c added code to save the new
filename, lineno, and funcname arguments in the errfinish function. Earlier
commit 060c265 had already done this, and earlier commit 6b0e52b had already
added saving and restoring of the error code above.

2) Commit 17a28b0 in src/backend/utils/error/elog.c removed the elog_finish
function. Earlier commit 060c265 had already done this, and earlier commit
6b0e52b had already added the new errFatalReturn function.