### PR TITLE
Fix conflicts in src/bin/pg_basebackup/pg_basebackup.c

### DIFF
--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -2484,6 +2484,7 @@ main(int argc, char **argv)
 				}
 
 				excludefroms[num_exclude_from++] = pg_strdup(optarg);
+				break;
 			case 4:
 				estimatesize = false;
 				break;

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -2283,14 +2283,11 @@ main(int argc, char **argv)
 		{"waldir", required_argument, NULL, 1},
 		{"no-slot", no_argument, NULL, 2},
 		{"no-verify-checksums", no_argument, NULL, 3},
-<<<<<<< HEAD
 		{"exclude", required_argument, NULL, 'E'},
 		{"force-overwrite", no_argument, NULL, 128},
 		{"target-gp-dbid", required_argument, NULL, 129},
 		{"exclude-from", required_argument, NULL, 130},
-=======
 		{"no-estimate-size", no_argument, NULL, 4},
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 		{NULL, 0, NULL, 0}
 	};
 	int			c;
@@ -2461,7 +2458,6 @@ main(int argc, char **argv)
 			case 3:
 				verify_checksums = false;
 				break;
-<<<<<<< HEAD
 			case 'E':
 				if (num_exclude >= MAX_EXCLUDE)
 				{
@@ -2488,10 +2484,8 @@ main(int argc, char **argv)
 				}
 
 				excludefroms[num_exclude_from++] = pg_strdup(optarg);
-=======
 			case 4:
 				estimatesize = false;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 				break;
 			default:
 


### PR DESCRIPTION
Fix conflicts in src/bin/pg_basebackup/pg_basebackup.c

The fab13dc commit in src/bin/pg_basebackup/pg_basebackup.c in the main
function added a new element "no-estimate-size" to the long_options array and
its processing for case 4 below. Earlier GPDB-specific commits had already
added new elements "exclude", "force-overwrite", "target-gp-dbid" and
"exclude-from" to this array and their processing for cases 'E', 128, 129, and
130 below.