### PR TITLE
Fix conflicts in src/bin/pg_rewind/pg_rewind.c

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -156,11 +156,7 @@ main(int argc, char **argv)
 		}
 	}
 
-<<<<<<< HEAD
-	while ((c = getopt_long(argc, argv, "D:nNPRS:", long_options, &option_index)) != -1)
-=======
-	while ((c = getopt_long(argc, argv, "cD:nNPR", long_options, &option_index)) != -1)
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+	while ((c = getopt_long(argc, argv, "cD:nNPRS:", long_options, &option_index)) != -1)
 	{
 		switch (c)
 		{
@@ -420,12 +416,7 @@ main(int argc, char **argv)
 	if (showprogress)
 		pg_log_info("reading WAL in target");
 	extractPageMap(datadir_target, chkptrec, lastcommontliIndex,
-<<<<<<< HEAD
-				   ControlFile_target.checkPoint);
-=======
 				   ControlFile_target.checkPoint, restore_command);
-	filemap_finalize();
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 	/*
 	 * We have collected all information we need from both systems. Decide


### PR DESCRIPTION
Fix conflicts in src/bin/pg_rewind/pg_rewind.c

1) Commit a7e8ece added handling of the 'c' option to the main function in
src/bin/pg_rewind/pg_rewind.c. An earlier commit by eacc688 had already added
handling of the 'S' option in the same location, and commit 19cd1cf had
refactored it.

2) Commit a7e8ece added a new restore_command argument to the extractPageMap
function call in src/bin/pg_rewind/pg_rewind.c. An earlier commit 1a770cf had
already removed the call to filemap_finalize below.