### PR TITLE
Fix compilation of src/include/utils/plancache.h

### DIFF
--- a/src/include/utils/plancache.h
+++ b/src/include/utils/plancache.h
@@ -21,11 +21,12 @@
 #include "nodes/primnodes.h"
 #include "tcop/cmdtag.h"
 #include "utils/queryenvironment.h"
-#include "utils/resowner.h"
 
 
 /* Forward declaration, to avoid including parsenodes.h here */
 struct RawStmt;
+/* Forward declaration, to avoid including resowner.h here */
+typedef struct ResourceOwnerData *ResourceOwner;
 
 /* possible values for plan_cache_mode */
 typedef enum


### PR DESCRIPTION
Fix compilation of src/include/utils/plancache.h

Commit 8f59f6b in src/include/utils/plancache.h added a new include,
utils/resowner.h, and two new functions, CachedPlanAllowsSimpleValidityCheck
and CachedPlanIsSimplyValid, that use the ResourceOwner type from this include.
Fix the compilation by removing this include and adding a forward type
declaration instead.