### PR TITLE
Fix compilation of src/backend/access/common/reloptions_gp.c

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -113,7 +113,7 @@ static relopt_string stringRelOpts_gp[] =
 			RELOPT_KIND_APPENDOPTIMIZED,
 			AccessExclusiveLock
 		},
-		0, true, NULL, ""
+		0, true, NULL, NULL, ""
 	},
 	/* list terminator */
 	{{NULL}}


### PR DESCRIPTION
Fix compilation of src/backend/access/common/reloptions_gp.c

Commit 911e702 added a new field, fill_cb, to the relopt_string structure in
src/include/access/reloptions.h. Add its initialization to the GPDB-specific
file src/backend/access/common/reloptions_gp.c.