### PR TITLE
Fix behavior of src/backend/nodes/readfuncs.c

### DIFF
--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -800,6 +800,7 @@ _readIndexElem(void)
 	READ_STRING_FIELD(indexcolname);
 	READ_NODE_FIELD(collation);
 	READ_NODE_FIELD(opclass);
+	READ_NODE_FIELD(opclassopts);
 	READ_ENUM_FIELD(ordering, SortByDir);
 	READ_ENUM_FIELD(nulls_ordering, SortByNulls);
 


### PR DESCRIPTION
Fix behavior of src/backend/nodes/readfuncs.c

Commit 911e702 in src/backend/nodes/outfuncs.c added serialization of the new
opclassopts field of the IndexElem struct in the _outIndexElem function. Add
deserialization of this field in src/backend/nodes/readfuncs.c in the
_readIndexElem function.