### PR TITLE
Fix behavior of src/backend/storage/lmgr/lock.c

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -938,7 +938,8 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	 * extension lock.  We do allow to acquire the same relation extension
 	 * lock more than once but that case won't reach here.
 	 */
-	Assert(!IsRelationExtensionLockHeld);
+	/* GPDB_13_MERGE_FIXME: Rework this for AO-tables */
+	Assert(!IsRelationExtensionLockHeld || IS_QUERY_EXECUTOR_BACKEND());
 
 	/*
 	 * We don't acquire any other heavyweight lock while holding the page lock


### PR DESCRIPTION
Fix behavior of src/backend/storage/lmgr/lock.c

Commit 15ef6ff added a new assertion to the LockAcquireExtended function in
src/backend/storage/lmgr/lock.c. This assertion is invalid on the executor when
inserting into an AO table. For example, the choose_segno_internal function
explicitly acquires an ExclusiveLock lock from LockRelationForExtension and
then calls the GetAppendOnlyEntryAuxOids function, which opens the table_open
table with an AccessShareLock lock. This leads to the same LockAcquireExtended
function, but with IsRelationExtensionLockHeld already set, which is precisely
what the new assertion prevents.