### PR TITLE
Fix conflicts in src/test/regress/sql/aggregates.sql

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -2900,209 +2900,6 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 set enable_hashagg = false;
 set jit_above_cost = 0;
 explain (costs off)
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-                   QUERY PLAN                   
-------------------------------------------------
- GroupAggregate
-   Group Key: ((g % 100000))
-   ->  Sort
-         Sort Key: ((g % 100000))
-         ->  Function Scan on generate_series g
-(5 rows)
-
-create table agg_group_1 as
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-/*
- * create table agg_group_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
-set jit_above_cost to default;
-create table agg_group_3 as
-select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
-  from generate_series(0, 1999) g
-  group by g/2;
-create table agg_group_4 as
-select (g/2)::numeric as c1, array_agg(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 1999) g
-  group by g/2;
--- Produce results with hash aggregation
-set enable_hashagg = true;
-set enable_sort = false;
-set jit_above_cost = 0;
-explain (costs off)
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-                QUERY PLAN                
-------------------------------------------
- HashAggregate
-   Group Key: (g % 100000)
-   ->  Function Scan on generate_series g
-(3 rows)
-
-create table agg_hash_1 as
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-/*
- * create table agg_hash_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
-set jit_above_cost to default;
-create table agg_hash_3 as
-select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
-  from generate_series(0, 1999) g
-  group by g/2;
-create table agg_hash_4 as
-select (g/2)::numeric as c1, array_agg(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 1999) g
-  group by g/2;
-set enable_sort = true;
-set work_mem to default;
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
--- Compare group aggregation results to hash aggregation results
-(select * from agg_hash_1 except select * from agg_group_1)
-  union all
-(select * from agg_group_1 except select * from agg_hash_1);
- c1 | c2 | c3 
-----+----+----
-(0 rows)
-
-/*
- * (select * from agg_hash_2 except select * from agg_group_2)
- *   union all
- * (select * from agg_group_2 except select * from agg_hash_2);
- */
-(select * from agg_hash_3 except select * from agg_group_3)
-  union all
-(select * from agg_group_3 except select * from agg_hash_3);
- c1 | c2 | c3 
-----+----+----
-(0 rows)
-
-(select * from agg_hash_4 except select * from agg_group_4)
-  union all
-(select * from agg_group_4 except select * from agg_hash_4);
- c1 | c2 | c3 
-----+----+----
-(0 rows)
-
-drop table agg_group_1;
---  drop table agg_group_2;
-drop table agg_group_3;
-drop table agg_group_4;
-drop table agg_hash_1;
---  drop table agg_hash_2;
-drop table agg_hash_3;
-drop table agg_hash_4;
--- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
-explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=10000000025.03..10000000025.05 rows=1 width=8) (actual time=0.214..0.214 rows=1 loops=1)
-   ->  Nested Loop  (cost=10000000000.02..10000000023.48 rows=622 width=0) (actual time=0.013..0.179 rows=848 loops=1)
-         ->  Aggregate  (cost=0.02..0.03 rows=1 width=1) (actual time=0.003..0.003 rows=1 loops=1)
-               ->  Result  (cost=0.00..0.01 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=1)
-         ->  Seq Scan on pg_class  (cost=0.00..17.22 rows=622 width=0) (actual time=0.010..0.116 rows=848 loops=1)
- Planning Time: 0.534 ms
-   (slice0)    Executor memory: 50K bytes.
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution Time: 0.302 ms
-(10 rows)
-
---
--- Hash Aggregation Spill tests
---
-set enable_sort=false;
-set work_mem='64kB';
-select unique1, count(*), sum(twothousand) from tenk1
-group by unique1
-having sum(fivethous) > 4975
-order by sum(twothousand);
- unique1 | count | sum  
----------+-------+------
-    4976 |     1 |  976
-    4977 |     1 |  977
-    4978 |     1 |  978
-    4979 |     1 |  979
-    4980 |     1 |  980
-    4981 |     1 |  981
-    4982 |     1 |  982
-    4983 |     1 |  983
-    4984 |     1 |  984
-    4985 |     1 |  985
-    4986 |     1 |  986
-    4987 |     1 |  987
-    4988 |     1 |  988
-    4989 |     1 |  989
-    4990 |     1 |  990
-    4991 |     1 |  991
-    4992 |     1 |  992
-    4993 |     1 |  993
-    4994 |     1 |  994
-    4995 |     1 |  995
-    4996 |     1 |  996
-    4997 |     1 |  997
-    4998 |     1 |  998
-    4999 |     1 |  999
-    9976 |     1 | 1976
-    9977 |     1 | 1977
-    9978 |     1 | 1978
-    9979 |     1 | 1979
-    9980 |     1 | 1980
-    9981 |     1 | 1981
-    9982 |     1 | 1982
-    9983 |     1 | 1983
-    9984 |     1 | 1984
-    9985 |     1 | 1985
-    9986 |     1 | 1986
-    9987 |     1 | 1987
-    9988 |     1 | 1988
-    9989 |     1 | 1989
-    9990 |     1 | 1990
-    9991 |     1 | 1991
-    9992 |     1 | 1992
-    9993 |     1 | 1993
-    9994 |     1 | 1994
-    9995 |     1 | 1995
-    9996 |     1 | 1996
-    9997 |     1 | 1997
-    9998 |     1 | 1998
-    9999 |     1 | 1999
-(48 rows)
-
-set work_mem to default;
-set enable_sort to default;
---
--- Compare results between plans using sorting and plans using hash
--- aggregation. Force spilling in both cases by setting work_mem low.
---
-set work_mem='64kB';
--- Produce results with sorting.
-set enable_hashagg = false;
-set jit_above_cost = 0;
-explain (costs off)
 select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
@@ -3119,6 +2916,7 @@ create table agg_group_1 as
 select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
+/* GPDB_13_MERGE_FIXME: enable this test
 create table agg_group_2 as
 select * from
   (values (100), (300), (500)) as r(a),
@@ -3129,6 +2927,7 @@ select * from
     from generate_series(0, 1999) g
     where g < r.a
     group by g/2) as s;
+*/
 set jit_above_cost to default;
 create table agg_group_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
@@ -3157,6 +2956,7 @@ create table agg_hash_1 as
 select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
+/* GPDB_13_MERGE_FIXME: enable this test
 create table agg_hash_2 as
 select * from
   (values (100), (300), (500)) as r(a),
@@ -3167,6 +2967,7 @@ select * from
     from generate_series(0, 1999) g
     where g < r.a
     group by g/2) as s;
+*/
 set jit_above_cost to default;
 create table agg_hash_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
@@ -3178,6 +2979,7 @@ select (g/2)::numeric as c1, array_agg(g::numeric) as c2, count(*) as c3
   group by g/2;
 set enable_sort = true;
 set work_mem to default;
+WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Compare group aggregation results to hash aggregation results
 (select * from agg_hash_1 except select * from agg_group_1)
   union all
@@ -3186,13 +2988,11 @@ set work_mem to default;
 ----+----+----
 (0 rows)
 
+/* GPDB_13_MERGE_FIXME: enable this test
 (select * from agg_hash_2 except select * from agg_group_2)
   union all
 (select * from agg_group_2 except select * from agg_hash_2);
- a | c1 | c2 | c3 
----+----+----+----
-(0 rows)
-
+*/
 (select * from agg_hash_3 except select * from agg_group_3)
   union all
 (select * from agg_group_3 except select * from agg_hash_3);
@@ -3208,10 +3008,26 @@ set work_mem to default;
 (0 rows)
 
 drop table agg_group_1;
-drop table agg_group_2;
+--  drop table agg_group_2;
 drop table agg_group_3;
 drop table agg_group_4;
 drop table agg_hash_1;
-drop table agg_hash_2;
+--  drop table agg_hash_2;
 drop table agg_hash_3;
 drop table agg_hash_4;
+-- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=10000000017.65..10000000017.66 rows=1 width=8) (actual time=3.113..3.115 rows=1 loops=1)
+   ->  Nested Loop  (cost=10000000000.02..10000000016.36 rows=516 width=0) (actual time=0.026..2.361 rows=670 loops=1)
+         ->  Aggregate  (cost=0.02..0.03 rows=1 width=1) (actual time=0.009..0.011 rows=1 loops=1)
+               ->  Result  (cost=0.00..0.01 rows=1 width=8) (actual time=0.003..0.005 rows=1 loops=1)
+         ->  Seq Scan on pg_class  (cost=0.00..11.16 rows=516 width=0) (actual time=0.012..0.811 rows=670 loops=1)
+ Optimizer: Postgres query optimizer
+ Planning Time: 0.804 ms
+   (slice0)    Executor memory: 125K bytes.
+ Memory used:  128000kB
+ Execution Time: 3.243 ms
+(10 rows)
+

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -2489,6 +2489,26 @@ DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
  -4567890123456789
 (1 row)
 
+select cleast_agg(q1,q2) from int8_tbl;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+ERROR:  cannot display a value of type anycompatible
+select cleast_agg(4.5,f1) from int4_tbl;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+ERROR:  cannot display a value of type anycompatible
+select cleast_agg(variadic array[4.5,f1]) from int4_tbl;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+ERROR:  cannot display a value of type anycompatible
+select pg_typeof(cleast_agg(variadic array[4.5,f1])) from int4_tbl;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+   pg_typeof   
+---------------
+ anycompatible
+(1 row)
+
 -- test aggregates with common transition functions share the same states
 begin work;
 create type avg_state as (total bigint, count bigint);
@@ -3064,34 +3084,34 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 set enable_hashagg = false;
 set jit_above_cost = 0;
 explain (costs off)
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-               QUERY PLAN                
------------------------------------------
+select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
+  from generate_series(0, 19999) g
+  group by g%10000;
+               QUERY PLAN               
+----------------------------------------
  HashAggregate
-   Group Key: (generate_series % 100000)
+   Group Key: (generate_series % 10000)
    ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 create table agg_group_1 as
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
+select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
+  from generate_series(0, 19999) g
+  group by g%10000;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-/*
- * create table agg_group_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+/* GPDB_13_MERGE_FIXME: enable this test
+create table agg_group_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+           array_agg(g::numeric) as c2,
+	   count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
+*/
 set jit_above_cost to default;
 create table agg_group_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
@@ -3108,34 +3128,34 @@ set enable_hashagg = true;
 set enable_sort = false;
 set jit_above_cost = 0;
 explain (costs off)
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-               QUERY PLAN                
------------------------------------------
+select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
+  from generate_series(0, 19999) g
+  group by g%10000;
+               QUERY PLAN               
+----------------------------------------
  HashAggregate
-   Group Key: (generate_series % 100000)
+   Group Key: (generate_series % 10000)
    ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 create table agg_hash_1 as
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
+select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
+  from generate_series(0, 19999) g
+  group by g%10000;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-/*
- * create table agg_hash_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
+/* GPDB_13_MERGE_FIXME: enable this test
+create table agg_hash_2 as
+select * from
+  (values (100), (300), (500)) as r(a),
+  lateral (
+    select (g/2)::numeric as c1,
+           array_agg(g::numeric) as c2,
+	   count(*) as c3
+    from generate_series(0, 1999) g
+    where g < r.a
+    group by g/2) as s;
+*/
 set jit_above_cost to default;
 create table agg_hash_3 as
 select (g/2)::numeric as c1, sum(7::int4) as c2, count(*) as c3
@@ -3158,11 +3178,11 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 ----+----+----
 (0 rows)
 
-/*
- * (select * from agg_hash_2 except select * from agg_group_2)
- *   union all
- * (select * from agg_group_2 except select * from agg_hash_2);
- */
+/* GPDB_13_MERGE_FIXME: enable this test
+(select * from agg_hash_2 except select * from agg_group_2)
+  union all
+(select * from agg_group_2 except select * from agg_hash_2);
+*/
 (select * from agg_hash_3 except select * from agg_group_3)
   union all
 (select * from agg_group_3 except select * from agg_hash_3);

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -1250,29 +1250,6 @@ set enable_hashagg = false;
 set jit_above_cost = 0;
 
 explain (costs off)
-<<<<<<< HEAD
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-
-create table agg_group_1 as
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-
-/*
- * create table agg_group_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
-=======
 select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
@@ -1282,6 +1259,7 @@ select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
 
+/* GPDB_13_MERGE_FIXME: enable this test
 create table agg_group_2 as
 select * from
   (values (100), (300), (500)) as r(a),
@@ -1292,7 +1270,7 @@ select * from
     from generate_series(0, 1999) g
     where g < r.a
     group by g/2) as s;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+*/
 
 set jit_above_cost to default;
 
@@ -1314,29 +1292,6 @@ set enable_sort = false;
 set jit_above_cost = 0;
 
 explain (costs off)
-<<<<<<< HEAD
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-
-create table agg_hash_1 as
-select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
-  from generate_series(0, 199999) g
-  group by g%100000;
-
-/*
- * create table agg_hash_2 as
- * select * from
- *   (values (100), (300), (500)) as r(a),
- *   lateral (
- *     select (g/2)::numeric as c1,
- *            array_agg(g::numeric) as c2,
- *            count(*) as c3
- *     from generate_series(0, 1999) g
- *     where g < r.a
- *     group by g/2) as s;
- */
-=======
 select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
@@ -1346,6 +1301,7 @@ select g%10000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 19999) g
   group by g%10000;
 
+/* GPDB_13_MERGE_FIXME: enable this test
 create table agg_hash_2 as
 select * from
   (values (100), (300), (500)) as r(a),
@@ -1356,7 +1312,7 @@ select * from
     from generate_series(0, 1999) g
     where g < r.a
     group by g/2) as s;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+*/
 
 set jit_above_cost to default;
 
@@ -1379,17 +1335,11 @@ set work_mem to default;
   union all
 (select * from agg_group_1 except select * from agg_hash_1);
 
-<<<<<<< HEAD
-/*
- * (select * from agg_hash_2 except select * from agg_group_2)
- *   union all
- * (select * from agg_group_2 except select * from agg_hash_2);
- */
-=======
+/* GPDB_13_MERGE_FIXME: enable this test
 (select * from agg_hash_2 except select * from agg_group_2)
   union all
 (select * from agg_group_2 except select * from agg_hash_2);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
+*/
 
 (select * from agg_hash_3 except select * from agg_group_3)
   union all
@@ -1400,7 +1350,6 @@ set work_mem to default;
 (select * from agg_group_4 except select * from agg_hash_4);
 
 drop table agg_group_1;
-<<<<<<< HEAD
 --  drop table agg_group_2;
 drop table agg_group_3;
 drop table agg_group_4;
@@ -1411,12 +1360,3 @@ drop table agg_hash_4;
 
 -- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
 explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
-=======
-drop table agg_group_2;
-drop table agg_group_3;
-drop table agg_group_4;
-drop table agg_hash_1;
-drop table agg_hash_2;
-drop table agg_hash_3;
-drop table agg_hash_4;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10


### PR DESCRIPTION
Fix conflicts in src/test/regress/sql/aggregates.sql

1) Commit 1f39bce added new tests to src/test/regress/sql/aggregates.sql, and
commit 76df765 optimized them. However, the earlier commit 19cd1cf had already
added these same tests, commenting out some of them, and commit d435af7 had
already added another new test to the end of the file.

2) Commit 24e2885 added new tests to src/test/regress/sql/aggregates.sql. Add
them to the ORCA output.