### PR TITLE
Fix conflicts in src/test/regress/sql/groupingsets.sql

### DIFF
--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -1849,25 +1849,15 @@ select v||'a', case when grouping(v||'a') = 1 then 1 else 0 end, count(*)
 --
 SET enable_groupingsets_hash_disk = true;
 SET work_mem='64kB';
-<<<<<<< HEAD
 WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 -- Produce results with sorting.
 set enable_hashagg = false;
 set jit_above_cost = 0;
 explain (costs off)
-<<<<<<< HEAD
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-=======
 select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,1999) g) s
 group by cube (g1000, g100,g10);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
                           QUERY PLAN                           
 ---------------------------------------------------------------
  GroupAggregate
@@ -1887,34 +1877,6 @@ group by cube (g1000, g100,g10);
 (14 rows)
 
 create table gs_group_1 as
-<<<<<<< HEAD
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-set jit_above_cost to default;
-create table gs_group_2 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by cube (g1000,g100,g10);
-create table gs_group_3 as
-select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
-  (select g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by grouping sets (g100,g10);
--- Produce results with hash aggregation.
-set enable_hashagg = true;
-set enable_sort = false;
-set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-set jit_above_cost = 0;
-explain (costs off)
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-=======
 select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,1999) g) s
@@ -1927,7 +1889,6 @@ select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,1999) g) s
 group by cube (g1000, g100,g10);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
                     QUERY PLAN                     
 ---------------------------------------------------
  MixedAggregate
@@ -1943,22 +1904,10 @@ group by cube (g1000, g100,g10);
 (10 rows)
 
 create table gs_hash_1 as
-<<<<<<< HEAD
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-set jit_above_cost to default;
-create table gs_hash_2 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by cube (g1000,g100,g10);
-create table gs_hash_3 as
-select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
-  (select g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by grouping sets (g100,g10);
+   from generate_series(0,1999) g) s
+group by cube (g1000, g100,g10);
 set enable_sort = true;
 set work_mem to default;
 WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
@@ -1966,46 +1915,17 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 -- relies on "IS NOT DISTINCT FROM" Hash Join, a variant that we likely have
 -- lost during the merge with upstream Postgres 12. Disable ORCA for this query
 SET optimizer TO off;
-=======
-select g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,1999) g) s
-group by cube (g1000, g100,g10);
-set enable_sort = true;
-set work_mem to default;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 -- Compare results
 (select * from gs_hash_1 except select * from gs_group_1)
   union all
 (select * from gs_group_1 except select * from gs_hash_1);
-<<<<<<< HEAD
- g1000 | g100 | g10 | sum | count | max 
--------+------+-----+-----+-------+-----
-(0 rows)
-
-(select * from gs_hash_2 except select * from gs_group_2)
-  union all
-(select * from gs_group_2 except select * from gs_hash_2);
- g1000 | g100 | g10 | sum | count | max 
--------+------+-----+-----+-------+-----
-(0 rows)
-
-(select g100,g10,unnest(a),c,m from gs_hash_3 except
-  select g100,g10,unnest(a),c,m from gs_group_3)
-    union all
-(select g100,g10,unnest(a),c,m from gs_group_3 except
-  select g100,g10,unnest(a),c,m from gs_hash_3);
- g100 | g10 | unnest | c | m 
-------+-----+--------+---+---
+ g100 | g10 | sum | count | max 
+------+-----+-----+-------+-----
 (0 rows)
 
 RESET optimizer;
 drop table gs_group_1;
-drop table gs_group_2;
-drop table gs_group_3;
 drop table gs_hash_1;
-drop table gs_hash_2;
-drop table gs_hash_3;
 SET enable_groupingsets_hash_disk TO DEFAULT;
 select a, rank(a+3) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
@@ -2052,14 +1972,5 @@ group by rollup (a,b) order by a;
    |   |    6
 (8 rows)
 
-=======
- g100 | g10 | sum | count | max 
-------+-----+-----+-------+-----
-(0 rows)
-
-drop table gs_group_1;
-drop table gs_hash_1;
-SET enable_groupingsets_hash_disk TO DEFAULT;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 -- end
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -2152,10 +2152,10 @@ WARNING:  "work_mem": setting is deprecated, and may be removed in a future rele
 set enable_hashagg = false;
 set jit_above_cost = 0;
 explain (costs off)
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
+   from generate_series(0,1999) g) s
+group by cube (g1000, g100,g10);
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Sequence
@@ -2189,37 +2189,19 @@ group by cube (g1000,g100,g10);
 (28 rows)
 
 create table gs_group_1 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-set jit_above_cost to default;
-create table gs_group_2 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by cube (g1000,g100,g10);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table gs_group_3 as
-select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
-  (select g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by grouping sets (g100,g10);
+   from generate_series(0,1999) g) s
+group by cube (g1000, g100,g10);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- Produce results with hash aggregation.
 set enable_hashagg = true;
 set enable_sort = false;
-set work_mem='64kB';
-WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
-set jit_above_cost = 0;
 explain (costs off)
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
+   from generate_series(0,1999) g) s
+group by cube (g1000, g100,g10);
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Sequence
@@ -2253,25 +2235,10 @@ group by cube (g1000,g100,g10);
 (28 rows)
 
 create table gs_hash_1 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
+select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-set jit_above_cost to default;
-create table gs_hash_2 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by cube (g1000,g100,g10);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table gs_hash_3 as
-select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
-  (select g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by grouping sets (g100,g10);
+   from generate_series(0,1999) g) s
+group by cube (g1000, g100,g10);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 set enable_sort = true;
 set work_mem to default;
@@ -2284,33 +2251,13 @@ SET optimizer TO off;
 (select * from gs_hash_1 except select * from gs_group_1)
   union all
 (select * from gs_group_1 except select * from gs_hash_1);
- g1000 | g100 | g10 | sum | count | max 
--------+------+-----+-----+-------+-----
-(0 rows)
-
-(select * from gs_hash_2 except select * from gs_group_2)
-  union all
-(select * from gs_group_2 except select * from gs_hash_2);
- g1000 | g100 | g10 | sum | count | max 
--------+------+-----+-----+-------+-----
-(0 rows)
-
-(select g100,g10,unnest(a),c,m from gs_hash_3 except
-  select g100,g10,unnest(a),c,m from gs_group_3)
-    union all
-(select g100,g10,unnest(a),c,m from gs_group_3 except
-  select g100,g10,unnest(a),c,m from gs_hash_3);
- g100 | g10 | unnest | c | m 
-------+-----+--------+---+---
+ g100 | g10 | sum | count | max 
+------+-----+-----+-------+-----
 (0 rows)
 
 RESET optimizer;
 drop table gs_group_1;
-drop table gs_group_2;
-drop table gs_group_3;
 drop table gs_hash_1;
-drop table gs_hash_2;
-drop table gs_hash_3;
 SET enable_groupingsets_hash_disk TO DEFAULT;
 select a, rank(a+3) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)

--- a/src/test/regress/sql/groupingsets.sql
+++ b/src/test/regress/sql/groupingsets.sql
@@ -558,36 +558,6 @@ SET work_mem='64kB';
 -- Produce results with sorting.
 
 set enable_hashagg = false;
-<<<<<<< HEAD
-
-set jit_above_cost = 0;
-
-explain (costs off)
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-
-create table gs_group_1 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-
-set jit_above_cost to default;
-
-create table gs_group_2 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by cube (g1000,g100,g10);
-
-create table gs_group_3 as
-select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
-  (select g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by grouping sets (g100,g10);
-=======
 set jit_above_cost = 0;
 
 explain (costs off)
@@ -601,43 +571,11 @@ select g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,1999) g) s
 group by cube (g1000, g100,g10);
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 -- Produce results with hash aggregation.
 
 set enable_hashagg = true;
 set enable_sort = false;
-<<<<<<< HEAD
-set work_mem='64kB';
-
-set jit_above_cost = 0;
-
-explain (costs off)
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-
-create table gs_hash_1 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,199999) g) s
-group by cube (g1000,g100,g10);
-
-set jit_above_cost to default;
-
-create table gs_hash_2 as
-select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by cube (g1000,g100,g10);
-
-create table gs_hash_3 as
-select g100, g10, array_agg(g) as a, count(*) as c, max(g::text) as m from
-  (select g/200 as g100, g/2000 as g10, g
-   from generate_series(0,19999) g) s
-group by grouping sets (g100,g10);
-=======
 
 explain (costs off)
 select g100, g10, sum(g::numeric), count(*), max(g::text) from
@@ -651,44 +589,25 @@ select g100, g10, sum(g::numeric), count(*), max(g::text) from
    from generate_series(0,1999) g) s
 group by cube (g1000, g100,g10);
 
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 set enable_sort = true;
 set work_mem to default;
 
-<<<<<<< HEAD
 -- GPDB_12_MERGE_FIXME: the following comparison query has an ORCA plan that
 -- relies on "IS NOT DISTINCT FROM" Hash Join, a variant that we likely have
 -- lost during the merge with upstream Postgres 12. Disable ORCA for this query
 SET optimizer TO off;
 
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 -- Compare results
 
 (select * from gs_hash_1 except select * from gs_group_1)
   union all
 (select * from gs_group_1 except select * from gs_hash_1);
 
-<<<<<<< HEAD
-(select * from gs_hash_2 except select * from gs_group_2)
-  union all
-(select * from gs_group_2 except select * from gs_hash_2);
-
-(select g100,g10,unnest(a),c,m from gs_hash_3 except
-  select g100,g10,unnest(a),c,m from gs_group_3)
-    union all
-(select g100,g10,unnest(a),c,m from gs_group_3 except
-  select g100,g10,unnest(a),c,m from gs_hash_3);
-
 RESET optimizer;
 
 drop table gs_group_1;
-drop table gs_group_2;
-drop table gs_group_3;
 drop table gs_hash_1;
-drop table gs_hash_2;
-drop table gs_hash_3;
 
 SET enable_groupingsets_hash_disk TO DEFAULT;
 
@@ -708,12 +627,5 @@ select a, b, rank(b) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
 group by rollup (a,b) order by a;
 
-=======
-drop table gs_group_1;
-drop table gs_hash_1;
-
-SET enable_groupingsets_hash_disk TO DEFAULT;
-
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 -- end
 reset optimizer_trace_fallback;


### PR DESCRIPTION
Fix conflicts in src/test/regress/sql/groupingsets.sql

Commit 1f39bce added new tests to src/test/regress/sql/groupingsets.sql, and
commit 76df765 optimized and partially removed them. However, the earlier
commit 19cd1cf had already added these same tests, and commit ad40cc6 had
already added new tests to the end of the file.