### PR TITLE
Fix conflicts in src/test/regress/expected/sysviews.out

### DIFF
--- a/src/test/regress/expected/sysviews.out
+++ b/src/test/regress/expected/sysviews.out
@@ -74,10 +74,7 @@ select name, setting from pg_settings where name like 'enable%';
 --------------------------------+---------
  enable_bitmapscan              | on
  enable_gathermerge             | on
-<<<<<<< HEAD
  enable_groupagg                | on
-=======
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
  enable_groupingsets_hash_disk  | off
  enable_hashagg                 | on
  enable_hashagg_disk            | on
@@ -95,11 +92,7 @@ select name, setting from pg_settings where name like 'enable%';
  enable_seqscan                 | on
  enable_sort                    | on
  enable_tidscan                 | on
-<<<<<<< HEAD
 (20 rows)
-=======
-(19 rows)
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 -- Test that the pg_timezone_names and pg_timezone_abbrevs views are
 -- more-or-less working.  We can't test their contents in any great detail


### PR DESCRIPTION
Fix conflicts in src/test/regress/expected/sysviews.out

Commit 1f39bce added two new lines of output to
src/test/regress/expected/sysviews.out, while earlier GPDB-specific commits had
already added several more lines of output in the same location.