### PR TITLE
Fix conflicts in src/test/modules/Makefile

### DIFF
--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -25,16 +25,14 @@ SUBDIRS = \
 		  unsafe_tests \
 		  worker_spi
 
-<<<<<<< HEAD
 # GPDB subdirs
 SUBDIRS += test_planner
-=======
+
 ifeq ($(with_openssl),yes)
 SUBDIRS += ssl_passphrase_callback
 else
 ALWAYS_SUBDIRS += ssl_passphrase_callback
 endif
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 
 $(recurse)
 $(recurse_always)


### PR DESCRIPTION
Fix conflicts in src/test/modules/Makefile

Commit 896fcdb in src/test/modules/Makefile added ssl_passphrase_callback to
the SUBDIRS variable, and commit 13c98bd added it to the ALWAYS_SUBDIRS
variable. However, the earlier commit 8ae22d1 had already added test_planner to
the SUBDIRS variable in the same location.