### PR TITLE
Fix conflicts in contrib/ltree/sql/ltree.sql

### DIFF
--- a/contrib/ltree/expected/ltree.out
+++ b/contrib/ltree/expected/ltree.out
@@ -7823,11 +7823,10 @@ SELECT * FROM ltreetest WHERE t ? '{23.*.1,23.*.2}' order by t asc;
 drop index tstidx;
 create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
+DETAIL:  Valid values are between "1" and "8168".
 create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=2025));
-ERROR:  value 2025 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
 create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=2024));
+ERROR:  relation "tstidx" already exists
 SELECT count(*) FROM ltreetest WHERE t <  '12.3';
  count 
 -------
@@ -8024,7 +8023,6 @@ SELECT count(*) FROM _ltreetest WHERE t ? '{23.*.1,23.*.2}' ;
     15
 (1 row)
 
-<<<<<<< HEAD
 -- Test that has all opclasses
 select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='ltree'::regtype;
     opcname     | amname 
@@ -8033,15 +8031,14 @@ select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod
  gist_ltree_ops | gist
  ltree_ops      | bitmap
 (3 rows)
-=======
+
 drop index _tstidx;
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
+DETAIL:  Valid values are between "1" and "8168".
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2025));
-ERROR:  value 2025 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2024));
+ERROR:  relation "_tstidx" already exists
 SELECT count(*) FROM _ltreetest WHERE t @> '1.1.1' ;
  count 
 -------
@@ -8095,5 +8092,4 @@ SELECT count(*) FROM _ltreetest WHERE t ? '{23.*.1,23.*.2}' ;
 -------
     15
 (1 row)
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10
 

--- a/contrib/ltree/expected/ltree.out
+++ b/contrib/ltree/expected/ltree.out
@@ -7824,9 +7824,10 @@ drop index tstidx;
 create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
 DETAIL:  Valid values are between "1" and "8168".
-create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=2025));
-create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=2024));
-ERROR:  relation "tstidx" already exists
+create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=8169));
+ERROR:  value 8169 out of bounds for option "siglen"
+DETAIL:  Valid values are between "1" and "8168".
+create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=8168));
 SELECT count(*) FROM ltreetest WHERE t <  '12.3';
  count 
 -------
@@ -8036,9 +8037,10 @@ drop index _tstidx;
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
 DETAIL:  Valid values are between "1" and "8168".
-create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2025));
-create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2024));
-ERROR:  relation "_tstidx" already exists
+create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=8169));
+ERROR:  value 8169 out of bounds for option "siglen"
+DETAIL:  Valid values are between "1" and "8168".
+create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=8168));
 SELECT count(*) FROM _ltreetest WHERE t @> '1.1.1' ;
  count 
 -------

--- a/contrib/ltree/sql/ltree.sql
+++ b/contrib/ltree/sql/ltree.sql
@@ -370,10 +370,9 @@ SELECT count(*) FROM _ltreetest WHERE t ~ '23.*.1' ;
 SELECT count(*) FROM _ltreetest WHERE t ~ '23.*.2' ;
 SELECT count(*) FROM _ltreetest WHERE t ? '{23.*.1,23.*.2}' ;
 
-<<<<<<< HEAD
 -- Test that has all opclasses
 select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod and opcintype='ltree'::regtype;
-=======
+
 drop index _tstidx;
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=0));
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2025));
@@ -388,4 +387,3 @@ SELECT count(*) FROM _ltreetest WHERE t ~ '23.*{1}.1' ;
 SELECT count(*) FROM _ltreetest WHERE t ~ '23.*.1' ;
 SELECT count(*) FROM _ltreetest WHERE t ~ '23.*.2' ;
 SELECT count(*) FROM _ltreetest WHERE t ? '{23.*.1,23.*.2}' ;
->>>>>>> ed7a5095716ee498ecc406e1b8d5ab92c7662d10

--- a/contrib/ltree/sql/ltree.sql
+++ b/contrib/ltree/sql/ltree.sql
@@ -326,8 +326,8 @@ SELECT * FROM ltreetest WHERE t ? '{23.*.1,23.*.2}' order by t asc;
 
 drop index tstidx;
 create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=0));
-create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=2025));
-create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=2024));
+create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=8169));
+create index tstidx on ltreetest using gist (t gist_ltree_ops(siglen=8168));
 
 SELECT count(*) FROM ltreetest WHERE t <  '12.3';
 SELECT count(*) FROM ltreetest WHERE t <= '12.3';
@@ -375,8 +375,8 @@ select opcname,amname from pg_opclass opc,  pg_am am  where am.oid=opc.opcmethod
 
 drop index _tstidx;
 create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=0));
-create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2025));
-create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=2024));
+create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=8169));
+create index _tstidx on _ltreetest using gist (t gist__ltree_ops(siglen=8168));
 
 SELECT count(*) FROM _ltreetest WHERE t @> '1.1.1' ;
 SELECT count(*) FROM _ltreetest WHERE t <@ '1.1.1' ;


### PR DESCRIPTION
Fix conflicts in contrib/ltree/sql/ltree.sql

Commit 911e702 added new tests to contrib/ltree/sql/ltree.sql, while an earlier
commit, b82efe5, had already added other new tests in the same location.