### PR TITLE
Fix tests in src/test/regress/expected/inherit.out

### DIFF
--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -2663,35 +2663,31 @@ CREATE TABLE errtst_parent (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) PARTITION BY RANGE (partid) DISTRIBUTED BY (dist);
+) PARTITION BY RANGE (partid) DISTRIBUTED BY (partid);
 -- fast defaults lead to attribute mapping being used in one
 -- direction, but not the other
 CREATE TABLE errtst_child_fastdef (
     partid int not null,
     shdata int not null,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 -- no remapping in either direction necessary
 CREATE TABLE errtst_child_plaindef (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
-    dist int default 0,
     CHECK(data < 10)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 -- remapping in both direction
 CREATE TABLE errtst_child_reorder (
     data int NOT NULL DEFAULT 0,
     shdata int not null,
     partid int not null,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
     CHECK(data < 10)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 ALTER TABLE errtst_child_fastdef ADD COLUMN data int NOT NULL DEFAULT 0;
 ALTER TABLE errtst_child_fastdef ADD CONSTRAINT errtest_child_fastdef_data_check CHECK (data < 10);
 ALTER TABLE errtst_parent ATTACH PARTITION errtst_child_fastdef FOR VALUES FROM (0) TO (10);
@@ -2704,33 +2700,33 @@ INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '5');
 -- insert with child check constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', '10');
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 10, 0).
+DETAIL:  Failing row contains (0, 1, 10).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', '10');
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 10, 0).
+DETAIL:  Failing row contains (10, 1, 10).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '10');
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 10, 0).
+DETAIL:  Failing row contains (20, 1, 10).
 -- insert with child not null constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_fastdef" violates not-null constraint
-DETAIL:  Failing row contains (0, 1, null, 0).
+DETAIL:  Failing row contains (0, 1, null).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_plaindef" violates not-null constraint
-DETAIL:  Failing row contains (10, 1, null, 0).
+DETAIL:  Failing row contains (10, 1, null).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_reorder" violates not-null constraint
-DETAIL:  Failing row contains (20, 1, null, 0).
+DETAIL:  Failing row contains (20, 1, null).
 -- insert with shared check constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '5', '5');
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (0, 5, 5, 0).
+DETAIL:  Failing row contains (0, 5, 5).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '5', '5');
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (10, 5, 5, 0).
+DETAIL:  Failing row contains (10, 5, 5).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '5', '5');
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (20, 5, 5, 0).
+DETAIL:  Failing row contains (20, 5, 5).
 -- within partition update without child check constraint violation
 BEGIN;
 UPDATE errtst_parent SET data = data + 1 WHERE partid = 0;
@@ -2740,13 +2736,13 @@ ROLLBACK;
 -- within partition update with child check constraint violation
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 0, 15).
+DETAIL:  Failing row contains (0, 1, 15).
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 15, 0).
+DETAIL:  Failing row contains (10, 1, 15).
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (15, 1, 20, 0).
+DETAIL:  Failing row contains (15, 1, 20).
 -- direct leaf partition update, without partition id violation
 BEGIN;
 UPDATE errtst_child_fastdef SET partid = 1 WHERE partid = 0;
@@ -2756,13 +2752,13 @@ ROLLBACK;
 -- direct leaf partition update, with partition id violation
 UPDATE errtst_child_fastdef SET partid = partid + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_fastdef" violates partition constraint
-DETAIL:  Failing row contains (10, 1, 0, 5).
+DETAIL:  Failing row contains (10, 1, 5).
 UPDATE errtst_child_plaindef SET partid = partid + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_plaindef" violates partition constraint
-DETAIL:  Failing row contains (20, 1, 5, 0).
+DETAIL:  Failing row contains (20, 1, 5).
 UPDATE errtst_child_reorder SET partid = partid + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_reorder" violates partition constraint
-DETAIL:  Failing row contains (5, 1, 30, 0).
+DETAIL:  Failing row contains (5, 1, 30).
 -- partition move, without child check constraint violation
 BEGIN;
 UPDATE errtst_parent SET partid = 10, data = data + 1 WHERE partid = 0;
@@ -2772,13 +2768,13 @@ ROLLBACK;
 -- partition move, with child check constraint violation
 UPDATE errtst_parent SET partid = 10, data = data + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 15, 0).
+DETAIL:  Failing row contains (10, 1, 15).
 UPDATE errtst_parent SET partid = 20, data = data + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 15, 0).
+DETAIL:  Failing row contains (20, 1, 15).
 UPDATE errtst_parent SET partid = 0, data = data + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 15, 0).
+DETAIL:  Failing row contains (0, 1, 15).
 -- partition move, without target partition
 UPDATE errtst_parent SET partid = 30, data = data + 10 WHERE partid = 20;
 ERROR:  no partition of relation "errtst_parent" found for row

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -2663,31 +2663,35 @@ CREATE TABLE errtst_parent (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
+    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) PARTITION BY RANGE (partid);
+) PARTITION BY RANGE (partid) DISTRIBUTED BY (dist);
 -- fast defaults lead to attribute mapping being used in one
 -- direction, but not the other
 CREATE TABLE errtst_child_fastdef (
     partid int not null,
     shdata int not null,
+    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-);
+) DISTRIBUTED BY (dist);
 -- no remapping in either direction necessary
 CREATE TABLE errtst_child_plaindef (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
+    dist int default 0,
     CHECK(data < 10)
-);
+) DISTRIBUTED BY (dist);
 -- remapping in both direction
 CREATE TABLE errtst_child_reorder (
     data int NOT NULL DEFAULT 0,
     shdata int not null,
     partid int not null,
+    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
     CHECK(data < 10)
-);
+) DISTRIBUTED BY (dist);
 ALTER TABLE errtst_child_fastdef ADD COLUMN data int NOT NULL DEFAULT 0;
 ALTER TABLE errtst_child_fastdef ADD CONSTRAINT errtest_child_fastdef_data_check CHECK (data < 10);
 ALTER TABLE errtst_parent ATTACH PARTITION errtst_child_fastdef FOR VALUES FROM (0) TO (10);
@@ -2700,33 +2704,33 @@ INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '5');
 -- insert with child check constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', '10');
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 10).
+DETAIL:  Failing row contains (0, 1, 10, 0).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', '10');
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 10).
+DETAIL:  Failing row contains (10, 1, 10, 0).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '10');
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 10).
+DETAIL:  Failing row contains (20, 1, 10, 0).
 -- insert with child not null constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_fastdef" violates not-null constraint
-DETAIL:  Failing row contains (0, 1, null).
+DETAIL:  Failing row contains (0, 1, null, 0).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_plaindef" violates not-null constraint
-DETAIL:  Failing row contains (10, 1, null).
+DETAIL:  Failing row contains (10, 1, null, 0).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_reorder" violates not-null constraint
-DETAIL:  Failing row contains (20, 1, null).
+DETAIL:  Failing row contains (20, 1, null, 0).
 -- insert with shared check constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '5', '5');
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (0, 5, 5).
+DETAIL:  Failing row contains (0, 5, 5, 0).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '5', '5');
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (10, 5, 5).
+DETAIL:  Failing row contains (10, 5, 5, 0).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '5', '5');
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (20, 5, 5).
+DETAIL:  Failing row contains (20, 5, 5, 0).
 -- within partition update without child check constraint violation
 BEGIN;
 UPDATE errtst_parent SET data = data + 1 WHERE partid = 0;
@@ -2736,13 +2740,13 @@ ROLLBACK;
 -- within partition update with child check constraint violation
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 15).
+DETAIL:  Failing row contains (0, 1, 0, 15).
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 15).
+DETAIL:  Failing row contains (10, 1, 15, 0).
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (15, 1, 20).
+DETAIL:  Failing row contains (15, 1, 20, 0).
 -- direct leaf partition update, without partition id violation
 BEGIN;
 UPDATE errtst_child_fastdef SET partid = 1 WHERE partid = 0;
@@ -2752,13 +2756,13 @@ ROLLBACK;
 -- direct leaf partition update, with partition id violation
 UPDATE errtst_child_fastdef SET partid = partid + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_fastdef" violates partition constraint
-DETAIL:  Failing row contains (10, 1, 5).
+DETAIL:  Failing row contains (10, 1, 0, 5).
 UPDATE errtst_child_plaindef SET partid = partid + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_plaindef" violates partition constraint
-DETAIL:  Failing row contains (20, 1, 5).
+DETAIL:  Failing row contains (20, 1, 5, 0).
 UPDATE errtst_child_reorder SET partid = partid + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_reorder" violates partition constraint
-DETAIL:  Failing row contains (5, 1, 30).
+DETAIL:  Failing row contains (5, 1, 30, 0).
 -- partition move, without child check constraint violation
 BEGIN;
 UPDATE errtst_parent SET partid = 10, data = data + 1 WHERE partid = 0;
@@ -2768,13 +2772,13 @@ ROLLBACK;
 -- partition move, with child check constraint violation
 UPDATE errtst_parent SET partid = 10, data = data + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 15).
+DETAIL:  Failing row contains (10, 1, 15, 0).
 UPDATE errtst_parent SET partid = 20, data = data + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 15).
+DETAIL:  Failing row contains (20, 1, 15, 0).
 UPDATE errtst_parent SET partid = 0, data = data + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 15).
+DETAIL:  Failing row contains (0, 1, 15, 0).
 -- partition move, without target partition
 UPDATE errtst_parent SET partid = 30, data = data + 10 WHERE partid = 20;
 ERROR:  no partition of relation "errtst_parent" found for row

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -2635,3 +2635,130 @@ reset session authorization;
 revoke all on permtest_parent from regress_no_child_access;
 drop role regress_no_child_access;
 drop table permtest_parent;
+-- Verify that constraint errors across partition root / child are
+-- handled correctly (Bug #16293)
+CREATE TABLE errtst_parent (
+    partid int not null,
+    shdata int not null,
+    data int NOT NULL DEFAULT 0,
+    dist int default 0,
+    CONSTRAINT shdata_small CHECK(shdata < 3)
+) PARTITION BY RANGE (partid) DISTRIBUTED BY (dist);
+-- fast defaults lead to attribute mapping being used in one
+-- direction, but not the other
+CREATE TABLE errtst_child_fastdef (
+    partid int not null,
+    shdata int not null,
+    dist int default 0,
+    CONSTRAINT shdata_small CHECK(shdata < 3)
+) DISTRIBUTED BY (dist);
+-- no remapping in either direction necessary
+CREATE TABLE errtst_child_plaindef (
+    partid int not null,
+    shdata int not null,
+    data int NOT NULL DEFAULT 0,
+    CONSTRAINT shdata_small CHECK(shdata < 3),
+    dist int default 0,
+    CHECK(data < 10)
+) DISTRIBUTED BY (dist);
+-- remapping in both direction
+CREATE TABLE errtst_child_reorder (
+    data int NOT NULL DEFAULT 0,
+    shdata int not null,
+    partid int not null,
+    dist int default 0,
+    CONSTRAINT shdata_small CHECK(shdata < 3),
+    CHECK(data < 10)
+) DISTRIBUTED BY (dist);
+ALTER TABLE errtst_child_fastdef ADD COLUMN data int NOT NULL DEFAULT 0;
+ALTER TABLE errtst_child_fastdef ADD CONSTRAINT errtest_child_fastdef_data_check CHECK (data < 10);
+ALTER TABLE errtst_parent ATTACH PARTITION errtst_child_fastdef FOR VALUES FROM (0) TO (10);
+ALTER TABLE errtst_parent ATTACH PARTITION errtst_child_plaindef FOR VALUES FROM (10) TO (20);
+ALTER TABLE errtst_parent ATTACH PARTITION errtst_child_reorder FOR VALUES FROM (20) TO (30);
+-- insert without child check constraint error
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', '5');
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', '5');
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '5');
+-- insert with child check constraint error
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', '10');
+ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
+DETAIL:  Failing row contains (0, 1, 10, 0).
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', '10');
+ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
+DETAIL:  Failing row contains (10, 1, 10, 0).
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '10');
+ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
+DETAIL:  Failing row contains (20, 1, 10, 0).
+-- insert with child not null constraint error
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', NULL);
+ERROR:  null value in column "data" of relation "errtst_child_fastdef" violates not-null constraint
+DETAIL:  Failing row contains (0, 1, null, 0).
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', NULL);
+ERROR:  null value in column "data" of relation "errtst_child_plaindef" violates not-null constraint
+DETAIL:  Failing row contains (10, 1, null, 0).
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', NULL);
+ERROR:  null value in column "data" of relation "errtst_child_reorder" violates not-null constraint
+DETAIL:  Failing row contains (20, 1, null, 0).
+-- insert with shared check constraint error
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '5', '5');
+ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "shdata_small"
+DETAIL:  Failing row contains (0, 5, 5, 0).
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '5', '5');
+ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "shdata_small"
+DETAIL:  Failing row contains (10, 5, 5, 0).
+INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '5', '5');
+ERROR:  new row for relation "errtst_child_reorder" violates check constraint "shdata_small"
+DETAIL:  Failing row contains (20, 5, 5, 0).
+-- within partition update without child check constraint violation
+BEGIN;
+UPDATE errtst_parent SET data = data + 1 WHERE partid = 0;
+UPDATE errtst_parent SET data = data + 1 WHERE partid = 10;
+UPDATE errtst_parent SET data = data + 1 WHERE partid = 20;
+ROLLBACK;
+-- within partition update with child check constraint violation
+UPDATE errtst_parent SET data = data + 10 WHERE partid = 0;
+ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
+DETAIL:  Failing row contains (0, 1, 15, 0).
+UPDATE errtst_parent SET data = data + 10 WHERE partid = 10;
+ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
+DETAIL:  Failing row contains (10, 1, 15, 0).
+UPDATE errtst_parent SET data = data + 10 WHERE partid = 20;
+ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
+DETAIL:  Failing row contains (20, 1, 15, 0).
+-- direct leaf partition update, without partition id violation
+BEGIN;
+UPDATE errtst_child_fastdef SET partid = 1 WHERE partid = 0;
+UPDATE errtst_child_plaindef SET partid = 11 WHERE partid = 10;
+UPDATE errtst_child_reorder SET partid = 21 WHERE partid = 20;
+ROLLBACK;
+-- direct leaf partition update, with partition id violation
+UPDATE errtst_child_fastdef SET partid = partid + 10 WHERE partid = 0;
+ERROR:  new row for relation "errtst_child_fastdef" violates partition constraint
+DETAIL:  Failing row contains (10, 1, 0, 5).
+UPDATE errtst_child_plaindef SET partid = partid + 10 WHERE partid = 10;
+ERROR:  new row for relation "errtst_child_plaindef" violates partition constraint
+DETAIL:  Failing row contains (20, 1, 5, 0).
+UPDATE errtst_child_reorder SET partid = partid + 10 WHERE partid = 20;
+ERROR:  new row for relation "errtst_child_reorder" violates partition constraint
+DETAIL:  Failing row contains (5, 1, 30, 0).
+-- partition move, without child check constraint violation
+BEGIN;
+UPDATE errtst_parent SET partid = 10, data = data + 1 WHERE partid = 0;
+UPDATE errtst_parent SET partid = 20, data = data + 1 WHERE partid = 10;
+UPDATE errtst_parent SET partid = 0, data = data + 1 WHERE partid = 20;
+ROLLBACK;
+-- partition move, with child check constraint violation
+UPDATE errtst_parent SET partid = 10, data = data + 10 WHERE partid = 0;
+ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
+DETAIL:  Failing row contains (10, 1, 15, 0).
+UPDATE errtst_parent SET partid = 20, data = data + 10 WHERE partid = 10;
+ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
+DETAIL:  Failing row contains (20, 1, 15, 0).
+UPDATE errtst_parent SET partid = 0, data = data + 10 WHERE partid = 20;
+ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
+DETAIL:  Failing row contains (0, 1, 15, 0).
+-- partition move, without target partition
+UPDATE errtst_parent SET partid = 30, data = data + 10 WHERE partid = 20;
+ERROR:  no partition of relation "errtst_parent" found for row
+DETAIL:  Partition key of the failing row contains (partid) = (30).
+DROP TABLE errtst_parent;

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -2641,35 +2641,31 @@ CREATE TABLE errtst_parent (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) PARTITION BY RANGE (partid) DISTRIBUTED BY (dist);
+) PARTITION BY RANGE (partid) DISTRIBUTED BY (partid);
 -- fast defaults lead to attribute mapping being used in one
 -- direction, but not the other
 CREATE TABLE errtst_child_fastdef (
     partid int not null,
     shdata int not null,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 -- no remapping in either direction necessary
 CREATE TABLE errtst_child_plaindef (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
-    dist int default 0,
     CHECK(data < 10)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 -- remapping in both direction
 CREATE TABLE errtst_child_reorder (
     data int NOT NULL DEFAULT 0,
     shdata int not null,
     partid int not null,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
     CHECK(data < 10)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 ALTER TABLE errtst_child_fastdef ADD COLUMN data int NOT NULL DEFAULT 0;
 ALTER TABLE errtst_child_fastdef ADD CONSTRAINT errtest_child_fastdef_data_check CHECK (data < 10);
 ALTER TABLE errtst_parent ATTACH PARTITION errtst_child_fastdef FOR VALUES FROM (0) TO (10);
@@ -2682,33 +2678,33 @@ INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '5');
 -- insert with child check constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', '10');
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 10, 0).
+DETAIL:  Failing row contains (0, 1, 10).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', '10');
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 10, 0).
+DETAIL:  Failing row contains (10, 1, 10).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', '10');
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 10, 0).
+DETAIL:  Failing row contains (20, 1, 10).
 -- insert with child not null constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_fastdef" violates not-null constraint
-DETAIL:  Failing row contains (0, 1, null, 0).
+DETAIL:  Failing row contains (0, 1, null).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_plaindef" violates not-null constraint
-DETAIL:  Failing row contains (10, 1, null, 0).
+DETAIL:  Failing row contains (10, 1, null).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '1', NULL);
 ERROR:  null value in column "data" of relation "errtst_child_reorder" violates not-null constraint
-DETAIL:  Failing row contains (20, 1, null, 0).
+DETAIL:  Failing row contains (20, 1, null).
 -- insert with shared check constraint error
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ( '0', '5', '5');
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (0, 5, 5, 0).
+DETAIL:  Failing row contains (0, 5, 5).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('10', '5', '5');
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (10, 5, 5, 0).
+DETAIL:  Failing row contains (10, 5, 5).
 INSERT INTO errtst_parent(partid, shdata, data) VALUES ('20', '5', '5');
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "shdata_small"
-DETAIL:  Failing row contains (20, 5, 5, 0).
+DETAIL:  Failing row contains (20, 5, 5).
 -- within partition update without child check constraint violation
 BEGIN;
 UPDATE errtst_parent SET data = data + 1 WHERE partid = 0;
@@ -2718,13 +2714,13 @@ ROLLBACK;
 -- within partition update with child check constraint violation
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 15, 0).
+DETAIL:  Failing row contains (0, 1, 15).
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 15, 0).
+DETAIL:  Failing row contains (10, 1, 15).
 UPDATE errtst_parent SET data = data + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 15, 0).
+DETAIL:  Failing row contains (20, 1, 15).
 -- direct leaf partition update, without partition id violation
 BEGIN;
 UPDATE errtst_child_fastdef SET partid = 1 WHERE partid = 0;
@@ -2734,13 +2730,13 @@ ROLLBACK;
 -- direct leaf partition update, with partition id violation
 UPDATE errtst_child_fastdef SET partid = partid + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_fastdef" violates partition constraint
-DETAIL:  Failing row contains (10, 1, 0, 5).
+DETAIL:  Failing row contains (10, 1, 5).
 UPDATE errtst_child_plaindef SET partid = partid + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_plaindef" violates partition constraint
-DETAIL:  Failing row contains (20, 1, 5, 0).
+DETAIL:  Failing row contains (20, 1, 5).
 UPDATE errtst_child_reorder SET partid = partid + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_reorder" violates partition constraint
-DETAIL:  Failing row contains (5, 1, 30, 0).
+DETAIL:  Failing row contains (5, 1, 30).
 -- partition move, without child check constraint violation
 BEGIN;
 UPDATE errtst_parent SET partid = 10, data = data + 1 WHERE partid = 0;
@@ -2750,13 +2746,13 @@ ROLLBACK;
 -- partition move, with child check constraint violation
 UPDATE errtst_parent SET partid = 10, data = data + 10 WHERE partid = 0;
 ERROR:  new row for relation "errtst_child_plaindef" violates check constraint "errtst_child_plaindef_data_check"
-DETAIL:  Failing row contains (10, 1, 15, 0).
+DETAIL:  Failing row contains (10, 1, 15).
 UPDATE errtst_parent SET partid = 20, data = data + 10 WHERE partid = 10;
 ERROR:  new row for relation "errtst_child_reorder" violates check constraint "errtst_child_reorder_data_check"
-DETAIL:  Failing row contains (20, 1, 15, 0).
+DETAIL:  Failing row contains (20, 1, 15).
 UPDATE errtst_parent SET partid = 0, data = data + 10 WHERE partid = 20;
 ERROR:  new row for relation "errtst_child_fastdef" violates check constraint "errtest_child_fastdef_data_check"
-DETAIL:  Failing row contains (0, 1, 15, 0).
+DETAIL:  Failing row contains (0, 1, 15).
 -- partition move, without target partition
 UPDATE errtst_parent SET partid = 30, data = data + 10 WHERE partid = 20;
 ERROR:  no partition of relation "errtst_parent" found for row

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -926,16 +926,18 @@ CREATE TABLE errtst_parent (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
+    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) PARTITION BY RANGE (partid);
+) PARTITION BY RANGE (partid) DISTRIBUTED BY (dist);
 
 -- fast defaults lead to attribute mapping being used in one
 -- direction, but not the other
 CREATE TABLE errtst_child_fastdef (
     partid int not null,
     shdata int not null,
+    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-);
+) DISTRIBUTED BY (dist);
 
 -- no remapping in either direction necessary
 CREATE TABLE errtst_child_plaindef (
@@ -943,17 +945,19 @@ CREATE TABLE errtst_child_plaindef (
     shdata int not null,
     data int NOT NULL DEFAULT 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
+    dist int default 0,
     CHECK(data < 10)
-);
+) DISTRIBUTED BY (dist);
 
 -- remapping in both direction
 CREATE TABLE errtst_child_reorder (
     data int NOT NULL DEFAULT 0,
     shdata int not null,
     partid int not null,
+    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
     CHECK(data < 10)
-);
+) DISTRIBUTED BY (dist);
 
 ALTER TABLE errtst_child_fastdef ADD COLUMN data int NOT NULL DEFAULT 0;
 ALTER TABLE errtst_child_fastdef ADD CONSTRAINT errtest_child_fastdef_data_check CHECK (data < 10);

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -926,18 +926,16 @@ CREATE TABLE errtst_parent (
     partid int not null,
     shdata int not null,
     data int NOT NULL DEFAULT 0,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) PARTITION BY RANGE (partid) DISTRIBUTED BY (dist);
+) PARTITION BY RANGE (partid) DISTRIBUTED BY (partid);
 
 -- fast defaults lead to attribute mapping being used in one
 -- direction, but not the other
 CREATE TABLE errtst_child_fastdef (
     partid int not null,
     shdata int not null,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 
 -- no remapping in either direction necessary
 CREATE TABLE errtst_child_plaindef (
@@ -945,19 +943,17 @@ CREATE TABLE errtst_child_plaindef (
     shdata int not null,
     data int NOT NULL DEFAULT 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
-    dist int default 0,
     CHECK(data < 10)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 
 -- remapping in both direction
 CREATE TABLE errtst_child_reorder (
     data int NOT NULL DEFAULT 0,
     shdata int not null,
     partid int not null,
-    dist int default 0,
     CONSTRAINT shdata_small CHECK(shdata < 3),
     CHECK(data < 10)
-) DISTRIBUTED BY (dist);
+) DISTRIBUTED BY (partid);
 
 ALTER TABLE errtst_child_fastdef ADD COLUMN data int NOT NULL DEFAULT 0;
 ALTER TABLE errtst_child_fastdef ADD CONSTRAINT errtest_child_fastdef_data_check CHECK (data < 10);


### PR DESCRIPTION
Fix tests in src/test/regress/expected/inherit.out

Commit f801ceb added new tests to src/test/regress/sql/inherit.sql, but not all
operations on the distribution column are supported in the GPDB. Add an
explicit distribution by partition column to avoid changing the tests. Add new
tests to ORCA.