### PR TITLE
Fix tests in src/test/regress/expected/tsearch.out

### DIFF
--- a/src/test/regress/expected/tsearch.out
+++ b/src/test/regress/expected/tsearch.out
@@ -273,11 +273,13 @@ ERROR:  unrecognized parameter "foo"
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
 DETAIL:  Valid values are between "1" and "8168".
-CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=2048));
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=8169));
+ERROR:  value 8169 out of bounds for option "siglen"
+DETAIL:  Valid values are between "1" and "8168".
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100,foo='bar'));
-ERROR:  relation "wowidx1" already exists
+ERROR:  unrecognized parameter "foo"
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100, siglen = 200));
-ERROR:  relation "wowidx1" already exists
+ERROR:  parameter "siglen" specified more than once
 CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
 \d test_tsvector
             Table "public.test_tsvector"
@@ -287,7 +289,6 @@ CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
  a      | tsvector |           |          | 
 Indexes:
     "wowidx" gist (a)
-    "wowidx1" gist (a tsvector_ops (siglen='2048'))
     "wowidx2" gist (a tsvector_ops (siglen='1'))
 Distributed by: (t)
 
@@ -375,7 +376,6 @@ CREATE INDEX wowidx ON test_tsvector USING gist (a tsvector_ops(siglen=484));
  a      | tsvector |           |          | 
 Indexes:
     "wowidx" gist (a tsvector_ops (siglen='484'))
-    "wowidx1" gist (a tsvector_ops (siglen='2048'))
 Distributed by: (t)
 
 EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
@@ -541,7 +541,7 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
          ->  Partial Aggregate
                ->  Bitmap Heap Scan on test_tsvector
                      Recheck Cond: (a @@ '!''qh'''::tsquery)
-                     ->  Bitmap Index Scan on wowidx1
+                     ->  Bitmap Index Scan on wowidx
                            Index Cond: (a @@ '!''qh'''::tsquery)
  Optimizer: Postgres query optimizer
 (8 rows)

--- a/src/test/regress/expected/tsearch.out
+++ b/src/test/regress/expected/tsearch.out
@@ -272,14 +272,12 @@ CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(foo=1));
 ERROR:  unrecognized parameter "foo"
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
+DETAIL:  Valid values are between "1" and "8168".
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=2048));
-ERROR:  value 2048 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100,foo='bar'));
-ERROR:  unrecognized parameter "foo"
+ERROR:  relation "wowidx1" already exists
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100, siglen = 200));
-ERROR:  parameter "siglen" specified more than once
+ERROR:  relation "wowidx1" already exists
 CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
 \d test_tsvector
             Table "public.test_tsvector"
@@ -289,18 +287,23 @@ CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
  a      | tsvector |           |          | 
 Indexes:
     "wowidx" gist (a)
+    "wowidx1" gist (a tsvector_ops (siglen='2048'))
     "wowidx2" gist (a tsvector_ops (siglen='1'))
+Distributed by: (t)
 
 DROP INDEX wowidx;
 EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
-                         QUERY PLAN                          
--------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on test_tsvector
-         Recheck Cond: (a @@ '''wr'' | ''qh'''::tsquery)
-         ->  Bitmap Index Scan on wowidx2
-               Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
-(5 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_tsvector
+                     Recheck Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+                     ->  Bitmap Index Scan on wowidx2
+                           Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
  count 
@@ -372,16 +375,21 @@ CREATE INDEX wowidx ON test_tsvector USING gist (a tsvector_ops(siglen=484));
  a      | tsvector |           |          | 
 Indexes:
     "wowidx" gist (a tsvector_ops (siglen='484'))
+    "wowidx1" gist (a tsvector_ops (siglen='2048'))
+Distributed by: (t)
 
 EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
-                         QUERY PLAN                          
--------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on test_tsvector
-         Recheck Cond: (a @@ '''wr'' | ''qh'''::tsquery)
-         ->  Bitmap Index Scan on wowidx
-               Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
-(5 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on test_tsvector
+                     Recheck Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+                     ->  Bitmap Index Scan on wowidx
+                           Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
  count 
@@ -533,7 +541,7 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
          ->  Partial Aggregate
                ->  Bitmap Heap Scan on test_tsvector
                      Recheck Cond: (a @@ '!''qh'''::tsquery)
-                     ->  Bitmap Index Scan on wowidx
+                     ->  Bitmap Index Scan on wowidx1
                            Index Cond: (a @@ '!''qh'''::tsquery)
  Optimizer: Postgres query optimizer
 (8 rows)

--- a/src/test/regress/expected/tsearch_optimizer.out
+++ b/src/test/regress/expected/tsearch_optimizer.out
@@ -204,7 +204,189 @@ explain (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
                ->  Index Scan using wowidx on test_tsvector
                      Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
+ count 
+-------
+   158
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'wr&qh';
+ count 
+-------
+    17
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'eq&yt';
+ count 
+-------
+     6
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'eq|yt';
+ count 
+-------
+    98
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '(eq&yt)|(wr&qh)';
+ count 
+-------
+    23
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '(eq|yt)&(wr|qh)';
+ count 
+-------
+    39
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'w:*|q:*';
+ count 
+-------
+   494
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ any ('{wr,qh}');
+ count 
+-------
+   158
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'no_such_lexeme';
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
+ count 
+-------
+   508
+(1 row)
+
+-- Test siglen parameter of GiST tsvector_ops
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(foo=1));
+ERROR:  unrecognized parameter "foo"
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=0));
+ERROR:  value 0 out of bounds for option "siglen"
+DETAIL:  Valid values are between "1" and "8168".
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=2048));
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100,foo='bar'));
+ERROR:  relation "wowidx1" already exists
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100, siglen = 200));
+ERROR:  relation "wowidx1" already exists
+CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
+\d test_tsvector
+            Table "public.test_tsvector"
+ Column |   Type   | Collation | Nullable | Default 
+--------+----------+-----------+----------+---------
+ t      | text     |           |          | 
+ a      | tsvector |           |          | 
+Indexes:
+    "wowidx" gist (a)
+    "wowidx1" gist (a tsvector_ops (siglen='2048'))
+    "wowidx2" gist (a tsvector_ops (siglen='1'))
+Distributed by: (t)
+
+DROP INDEX wowidx;
+EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Index Scan using wowidx1 on test_tsvector
+                     Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+                     Filter: (a @@ '''wr'' | ''qh'''::tsquery)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
+ count 
+-------
+   158
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'wr&qh';
+ count 
+-------
+    17
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'eq&yt';
+ count 
+-------
+     6
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'eq|yt';
+ count 
+-------
+    98
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '(eq&yt)|(wr&qh)';
+ count 
+-------
+    23
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '(eq|yt)&(wr|qh)';
+ count 
+-------
+    39
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'w:*|q:*';
+ count 
+-------
+   494
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ any ('{wr,qh}');
+ count 
+-------
+   158
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ 'no_such_lexeme';
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
+ count 
+-------
+   508
+(1 row)
+
+DROP INDEX wowidx2;
+CREATE INDEX wowidx ON test_tsvector USING gist (a tsvector_ops(siglen=484));
+\d test_tsvector
+            Table "public.test_tsvector"
+ Column |   Type   | Collation | Nullable | Default 
+--------+----------+-----------+----------+---------
+ t      | text     |           |          | 
+ a      | tsvector |           |          | 
+Indexes:
+    "wowidx" gist (a tsvector_ops (siglen='484'))
+    "wowidx1" gist (a tsvector_ops (siglen='2048'))
+Distributed by: (t)
+
+EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Index Scan using wowidx1 on test_tsvector
+                     Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+                     Filter: (a @@ '''wr'' | ''qh'''::tsquery)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
@@ -275,12 +457,13 @@ CREATE INDEX wowidx ON test_tsvector USING gin (a);
 SET enable_seqscan=OFF;
 -- GIN only supports bitmapscan, so no need to test plain indexscan
 explain (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
-                          QUERY PLAN                           
----------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Seq Scan on test_tsvector
+               ->  Index Scan using wowidx1 on test_tsvector
+                     Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (6 rows)
@@ -348,12 +531,13 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
 -- Test optimization of non-empty GIN_SEARCH_MODE_ALL queries
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
-                      QUERY PLAN                       
--------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Seq Scan on test_tsvector
+               ->  Index Scan using wowidx1 on test_tsvector
+                     Index Cond: (a @@ '!''qh'''::tsquery)
                      Filter: (a @@ '!''qh'''::tsquery)
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -366,12 +550,13 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr' AND a @@ '!qh';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Seq Scan on test_tsvector
+               ->  Index Scan using wowidx1 on test_tsvector
+                     Index Cond: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
                      Filter: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)

--- a/src/test/regress/expected/tsearch_optimizer.out
+++ b/src/test/regress/expected/tsearch_optimizer.out
@@ -273,11 +273,13 @@ ERROR:  unrecognized parameter "foo"
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
 DETAIL:  Valid values are between "1" and "8168".
-CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=2048));
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=8169));
+ERROR:  value 8169 out of bounds for option "siglen"
+DETAIL:  Valid values are between "1" and "8168".
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100,foo='bar'));
-ERROR:  relation "wowidx1" already exists
+ERROR:  unrecognized parameter "foo"
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100, siglen = 200));
-ERROR:  relation "wowidx1" already exists
+ERROR:  parameter "siglen" specified more than once
 CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
 \d test_tsvector
             Table "public.test_tsvector"
@@ -287,7 +289,6 @@ CREATE INDEX wowidx2 ON test_tsvector USING gist (a tsvector_ops(siglen=1));
  a      | tsvector |           |          | 
 Indexes:
     "wowidx" gist (a)
-    "wowidx1" gist (a tsvector_ops (siglen='2048'))
     "wowidx2" gist (a tsvector_ops (siglen='1'))
 Distributed by: (t)
 
@@ -298,7 +299,7 @@ EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using wowidx1 on test_tsvector
+               ->  Index Scan using wowidx2 on test_tsvector
                      Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -374,7 +375,6 @@ CREATE INDEX wowidx ON test_tsvector USING gist (a tsvector_ops(siglen=484));
  a      | tsvector |           |          | 
 Indexes:
     "wowidx" gist (a tsvector_ops (siglen='484'))
-    "wowidx1" gist (a tsvector_ops (siglen='2048'))
 Distributed by: (t)
 
 EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
@@ -383,7 +383,7 @@ EXPLAIN (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using wowidx1 on test_tsvector
+               ->  Index Scan using wowidx on test_tsvector
                      Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -457,13 +457,12 @@ CREATE INDEX wowidx ON test_tsvector USING gin (a);
 SET enable_seqscan=OFF;
 -- GIN only supports bitmapscan, so no need to test plain indexscan
 explain (costs off) SELECT count(*) FROM test_tsvector WHERE a @@ 'wr|qh';
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using wowidx1 on test_tsvector
-                     Index Cond: (a @@ '''wr'' | ''qh'''::tsquery)
+               ->  Seq Scan on test_tsvector
                      Filter: (a @@ '''wr'' | ''qh'''::tsquery)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
 (6 rows)
@@ -531,13 +530,12 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
 -- Test optimization of non-empty GIN_SEARCH_MODE_ALL queries
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
-                         QUERY PLAN                          
--------------------------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using wowidx1 on test_tsvector
-                     Index Cond: (a @@ '!''qh'''::tsquery)
+               ->  Seq Scan on test_tsvector
                      Filter: (a @@ '!''qh'''::tsquery)
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -550,13 +548,12 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!qh';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM test_tsvector WHERE a @@ 'wr' AND a @@ '!qh';
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
-               ->  Index Scan using wowidx1 on test_tsvector
-                     Index Cond: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
+               ->  Seq Scan on test_tsvector
                      Filter: ((a @@ '''wr'''::tsquery) AND (a @@ '!''qh'''::tsquery))
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)

--- a/src/test/regress/sql/tsearch.sql
+++ b/src/test/regress/sql/tsearch.sql
@@ -91,7 +91,7 @@ SELECT count(*) FROM test_tsvector WHERE a @@ '!no_such_lexeme';
 -- Test siglen parameter of GiST tsvector_ops
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(foo=1));
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=0));
-CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=2048));
+CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=8169));
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100,foo='bar'));
 CREATE INDEX wowidx1 ON test_tsvector USING gist (a tsvector_ops(siglen=100, siglen = 200));
 


### PR DESCRIPTION
Fix tests in src/test/regress/expected/tsearch.out

Commit 911e702 added new tests to src/test/regress/sql/tsearch.sql. Adapt their
output for the GPDB and add the new tests to the ORCA.