### PR TITLE
Fix tests in src/test/regress/expected/qp_olap_windowerr.out

### DIFF
--- a/src/test/regress/expected/qp_olap_windowerr.out
+++ b/src/test/regress/expected/qp_olap_windowerr.out
@@ -5058,9 +5058,9 @@ ERROR:  window functions are not allowed in index predicates
 LINE 1: ...indow_seq on wintest_for_window_seq (i) where i < count(*) o...
                                                              ^
 CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq (sum(i) over (order by i));
-ERROR:  syntax error at or near "("
-LINE 1: ...window_seq on wintest_for_window_seq (sum(i) over (order by ...
-                                                             ^
+ERROR:  syntax error at or near "by"
+LINE 1: ...ow_seq on wintest_for_window_seq (sum(i) over (order by i));
+                                                                ^
 CREATE INDEX wintest_idx_for_window_seq on wintest_for_window_seq ((sum(i) over (order by i)));
 ERROR:  window functions are not allowed in index expressions
 LINE 1: ...st_idx_for_window_seq on wintest_for_window_seq ((sum(i) ove...


### PR DESCRIPTION
Fix tests in src/test/regress/expected/qp_olap_windowerr.out

Commit 7f380c5 optimized syntax error messages. Change in GPDB-specific tests.
