### PR TITLE
Fix tests in contrib/hstore/expected/hstore.out

### DIFF
--- a/contrib/hstore/expected/hstore.out
+++ b/contrib/hstore/expected/hstore.out
@@ -1354,9 +1354,10 @@ drop index hidx;
 create index hidx on testhstore using gist(h gist_hstore_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
 DETAIL:  Valid values are between "1" and "8168".
-create index hidx on testhstore using gist(h gist_hstore_ops(siglen=2025));
-create index hidx on testhstore using gist(h gist_hstore_ops(siglen=2024));
-ERROR:  relation "hidx" already exists
+create index hidx on testhstore using gist(h gist_hstore_ops(siglen=8169));
+ERROR:  value 8169 out of bounds for option "siglen"
+DETAIL:  Valid values are between "1" and "8168".
+create index hidx on testhstore using gist(h gist_hstore_ops(siglen=8168));
 set enable_seqscan=off;
 select count(*) from testhstore where h @> 'wait=>NULL';
  count 

--- a/contrib/hstore/expected/hstore.out
+++ b/contrib/hstore/expected/hstore.out
@@ -1353,11 +1353,10 @@ select count(*) from testhstore where h ?& ARRAY['public','disabled'];
 drop index hidx;
 create index hidx on testhstore using gist(h gist_hstore_ops(siglen=0));
 ERROR:  value 0 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
+DETAIL:  Valid values are between "1" and "8168".
 create index hidx on testhstore using gist(h gist_hstore_ops(siglen=2025));
-ERROR:  value 2025 out of bounds for option "siglen"
-DETAIL:  Valid values are between "1" and "2024".
 create index hidx on testhstore using gist(h gist_hstore_ops(siglen=2024));
+ERROR:  relation "hidx" already exists
 set enable_seqscan=off;
 select count(*) from testhstore where h @> 'wait=>NULL';
  count 

--- a/contrib/hstore/sql/hstore.sql
+++ b/contrib/hstore/sql/hstore.sql
@@ -306,8 +306,8 @@ select count(*) from testhstore where h ?& ARRAY['public','disabled'];
 
 drop index hidx;
 create index hidx on testhstore using gist(h gist_hstore_ops(siglen=0));
-create index hidx on testhstore using gist(h gist_hstore_ops(siglen=2025));
-create index hidx on testhstore using gist(h gist_hstore_ops(siglen=2024));
+create index hidx on testhstore using gist(h gist_hstore_ops(siglen=8169));
+create index hidx on testhstore using gist(h gist_hstore_ops(siglen=8168));
 set enable_seqscan=off;
 
 select count(*) from testhstore where h @> 'wait=>NULL';


### PR DESCRIPTION
Fix tests in contrib/hstore/expected/hstore.out

Commit 911e702 changed the maximum value of the length option. Change this in
tests.