### PR TITLE
Fix PyGreSQL version

### DIFF
--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -28,7 +28,7 @@ RUN set -eux; \
     apt install -y protobuf-compiler libpq-dev libossp-uuid-dev; \
 # Install allure-behave for behave tests
     pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave==2.4.0 protobuf==3.20.0; \
-    pip3 install pygresql==6.2.0; \
+    pip3 install pygresql==6.1.0; \
     pip3 cache purge
 
 WORKDIR /home/gpadmin

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -28,7 +28,7 @@ RUN set -eux; \
     apt install -y protobuf-compiler libpq-dev libossp-uuid-dev; \
 # Install allure-behave for behave tests
     pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave==2.4.0 protobuf==3.20.0; \
-    pip3 install pygresql==6.1.0; \
+    pip3 install PyGreSQL==6.1.0; \
     pip3 cache purge
 
 WORKDIR /home/gpadmin

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -28,7 +28,7 @@ RUN set -eux; \
     apt install -y protobuf-compiler libpq-dev libossp-uuid-dev; \
 # Install allure-behave for behave tests
     pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave==2.4.0 protobuf==3.20.0; \
-    pip3 install PyGreSQL; \
+    pip3 install pygresql==6.2.0; \
     pip3 cache purge
 
 WORKDIR /home/gpadmin


### PR DESCRIPTION
Fix PyGreSQL version

After commit PyGreSQL/PyGreSQL@0f8e075, the latest version of PyGreSQL won't
install. Fix the working version.

```bash
pip3 install PyGreSQL
Collecting PyGreSQL
  Using cached pygresql-6.2.0.tar.gz (272 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
          return self._get_build_requires(
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 143, in _get_build_requires
          self.run_setup()
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 78, in <module>
          patch_pyproject_toml()  # needed for Python < 3.9
        File "setup.py", line 62, in patch_pyproject_toml
          from setuptools.config import pyprojecttoml
      ImportError: cannot import name 'pyprojecttoml' from 'setuptools.config' (/usr/lib/python3/dist-packages/setuptools/config.py)
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```