### PR TITLE
Fix tests in src/bin/pg_basebackup/t/010_pg_basebackup.pl

### DIFF
--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -358,7 +358,7 @@ SKIP:
 	$node->safe_psql('postgres',
 		"CREATE TABLESPACE tblspc3 LOCATION '$tempdir/$superlongname';");
 	$node->command_ok(
-		[ 'pg_basebackup', '-D', "$tempdir/tarbackup_l3", '--target-gp-dbid', '123', '-Ft' ],
+		[ 'pg_basebackup', '-D', "$tempdir/tarbackup_l3", '--no-estimate-size', '--target-gp-dbid', '123', '-Ft' ],
 		'pg_basebackup tar with long symlink target');
 	$node->safe_psql('postgres', "DROP TABLESPACE tblspc3;");
 	rmtree("$tempdir/tarbackup_l3");


### PR DESCRIPTION
Fix tests in src/bin/pg_basebackup/t/010_pg_basebackup.pl

Commit fab13dc enabled the backup size estimate calculation by default.
However, the earlier commit 8ae22d1 in src/backend/replication/basebackup.c in
the sendDir function had already replaced the symbolic link name length check
from sizeof(linkpath) to define MAX_TARABLE_SYMLINK_PATH_LENGTH equal to 100.
If the length is greater during the calculation, an error is thrown. Disable
the backup size estimate calculation in the
src/bin/pg_basebackup/t/010_pg_basebackup.pl test for tests with very long
symbolic link names.