### PR TITLE
Refactor locks in AO tables

### DIFF
--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -663,13 +663,13 @@ AppendOptimizedDropDeadSegments(Relation aorel, Bitmapset *segnos)
 	/*
 	 * drop segments in batch with concurrent-safety
 	 */
-	LockRelationForExtension(aorel, ExclusiveLock);
+	LockRelation(aorel, ExclusiveLock);
 
 	segno = -1;
 	while ((segno = bms_next_member(segnos, segno)) >= 0)
 		AppendOptimizedDropDeadSegment(aorel, segno);
 	
-	UnlockRelationForExtension(aorel, ExclusiveLock);
+	UnlockRelation(aorel, ExclusiveLock);
 }
 
 /*
@@ -696,7 +696,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockRelationForExtension(aorel, ExclusiveLock);
+	LockRelation(aorel, ExclusiveLock);
 
 	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
 							  &segrelid, NULL, NULL, NULL, NULL);
@@ -756,7 +756,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 		}
 	}
 	systable_endscan(aoscan);
-	UnlockRelationForExtension(aorel, ExclusiveLock);
+	UnlockRelation(aorel, ExclusiveLock);
 	table_close(pg_aoseg_rel, AccessShareLock);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -663,13 +663,13 @@ AppendOptimizedDropDeadSegments(Relation aorel, Bitmapset *segnos)
 	/*
 	 * drop segments in batch with concurrent-safety
 	 */
-	LockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
+	LockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(aorel), 0, ExclusiveLock);
 
 	segno = -1;
 	while ((segno = bms_next_member(segnos, segno)) >= 0)
 		AppendOptimizedDropDeadSegment(aorel, segno);
 	
-	UnlockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
+	UnlockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(aorel), 0, ExclusiveLock);
 }
 
 /*
@@ -696,7 +696,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
+	LockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(aorel), 0, ExclusiveLock);
 
 	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
 							  &segrelid, NULL, NULL, NULL, NULL);
@@ -756,7 +756,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 		}
 	}
 	systable_endscan(aoscan);
-	UnlockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
+	UnlockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(aorel), 0, ExclusiveLock);
 	table_close(pg_aoseg_rel, AccessShareLock);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -663,13 +663,13 @@ AppendOptimizedDropDeadSegments(Relation aorel, Bitmapset *segnos)
 	/*
 	 * drop segments in batch with concurrent-safety
 	 */
-	LockRelation(aorel, ExclusiveLock);
+	LockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
 
 	segno = -1;
 	while ((segno = bms_next_member(segnos, segno)) >= 0)
 		AppendOptimizedDropDeadSegment(aorel, segno);
 	
-	UnlockRelation(aorel, ExclusiveLock);
+	UnlockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
 }
 
 /*
@@ -696,7 +696,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockRelation(aorel, ExclusiveLock);
+	LockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
 
 	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
 							  &segrelid, NULL, NULL, NULL, NULL);
@@ -756,7 +756,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 		}
 	}
 	systable_endscan(aoscan);
-	UnlockRelation(aorel, ExclusiveLock);
+	UnlockDatabaseObject(RelationGetRelid(aorel), 0, 0, ExclusiveLock);
 	table_close(pg_aoseg_rel, AccessShareLock);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -160,7 +160,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
+	LockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(rel), 0, ExclusiveLock);
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	GetAppendOnlyEntryAuxOids(rel->rd_id, appendOnlyMetaDataSnapshot,
@@ -265,7 +265,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	/* OK, we have the aoseg tuple locked for us. */
 	systable_endscan(aoscan);
 
-	UnlockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
+	UnlockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(rel), 0, ExclusiveLock);
 
 	table_close(pg_aoseg_rel, AccessShareLock);
 
@@ -423,7 +423,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
+	LockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(rel), 0, ExclusiveLock);
 
 	/*
 	 * Obtain the snapshot that is taken at the beginning of the transaction.
@@ -602,7 +602,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 		chosen_segno = choose_new_segfile(rel, used, avoid_segnos);
 	}
 
-	UnlockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
+	UnlockDatabaseObject(AppendOnlyRelationId, RelationGetRelid(rel), 0, ExclusiveLock);
 
 	if (Debug_appendonly_print_segfile_choice && chosen_segno != -1)
 		ereport(LOG,

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -160,7 +160,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockRelationForExtension(rel, ExclusiveLock);
+	LockRelation(rel, ExclusiveLock);
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	GetAppendOnlyEntryAuxOids(rel->rd_id, appendOnlyMetaDataSnapshot,
@@ -265,7 +265,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	/* OK, we have the aoseg tuple locked for us. */
 	systable_endscan(aoscan);
 
-	UnlockRelationForExtension(rel, ExclusiveLock);
+	UnlockRelation(rel, ExclusiveLock);
 
 	table_close(pg_aoseg_rel, AccessShareLock);
 
@@ -423,7 +423,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockRelationForExtension(rel, ExclusiveLock);
+	LockRelation(rel, ExclusiveLock);
 
 	/*
 	 * Obtain the snapshot that is taken at the beginning of the transaction.
@@ -602,7 +602,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 		chosen_segno = choose_new_segfile(rel, used, avoid_segnos);
 	}
 
-	UnlockRelationForExtension(rel, ExclusiveLock);
+	UnlockRelation(rel, ExclusiveLock);
 
 	if (Debug_appendonly_print_segfile_choice && chosen_segno != -1)
 		ereport(LOG,

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -160,7 +160,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockRelation(rel, ExclusiveLock);
+	LockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	GetAppendOnlyEntryAuxOids(rel->rd_id, appendOnlyMetaDataSnapshot,
@@ -265,7 +265,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	/* OK, we have the aoseg tuple locked for us. */
 	systable_endscan(aoscan);
 
-	UnlockRelation(rel, ExclusiveLock);
+	UnlockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
 
 	table_close(pg_aoseg_rel, AccessShareLock);
 
@@ -423,7 +423,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
 	 * Grab a lock to serialize.
 	 */
-	LockRelation(rel, ExclusiveLock);
+	LockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
 
 	/*
 	 * Obtain the snapshot that is taken at the beginning of the transaction.
@@ -602,7 +602,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 		chosen_segno = choose_new_segfile(rel, used, avoid_segnos);
 	}
 
-	UnlockRelation(rel, ExclusiveLock);
+	UnlockDatabaseObject(RelationGetRelid(rel), 0, 0, ExclusiveLock);
 
 	if (Debug_appendonly_print_segfile_choice && chosen_segno != -1)
 		ereport(LOG,


### PR DESCRIPTION
Refactor locks in AO tables

Commit 15ef6ff added a new assertion, !IsRelationExtensionLockHeld, to the
LockAcquireExtended function in src/backend/storage/lmgr/lock.c.

For AO tables, the earlier commit 5778f31 had already added the
LockRelationForExtension lock and the UnlockRelationForExtension unlock to the
AppendOnlyRecycleDeadSegments, AppendOnlyTruncateToEOF, LockSegnoForWrite, and
choose_segno_internal functions in
src/backend/access/appendonly/appendonly/compaction.c and
src/backend/access/appendonly/appendonlywriter.c.

The earlier commit dedd407 moved the LockRelationForExtension lock and the
UnlockRelationForExtension unlock from the function
AppendOptimizedRecycleDeadSegments to the AppendOptimizedDropDeadSegments
function.

This lock type is invalid for use in AO tables, as confirmed by the new
assertion. For example, the choose_segno_internal function explicitly acquires
an ExclusiveLock lock from LockRelationForExtension and then calls the
GetAppendOnlyEntryAuxOids function, which opens the table_open table with an
AccessShareLock lock. This leads to the same LockAcquireExtended function, but
with IsRelationExtensionLockHeld already set, which is precisely what the new
assertion prevents.

Change the lock type in AO tables from LockRelationForExtension to
LockDatabaseObject, and the unlock type from UnlockRelationForExtension to
UnlockDatabaseObject.