### PR TITLE
ADBDEV-9042-1: Make alter_db_set_tablespace test stable

### DIFF
--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -126,9 +126,21 @@ for dbid, datadir in db_instances.items():
 return rows
 $fn$;
 
-CREATE OR REPLACE FUNCTION wait_for_primaries_to_restart() RETURNS BOOLEAN AS $$
-	SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
-$$ LANGUAGE sql;
+CREATE OR REPLACE FUNCTION connectSeg(n int, port int, hostname text) RETURNS bool AS $$
+import os
+import subprocess
+import time
+for i in range(n):
+    try:
+        subprocess.run(["psql", "-h", str(hostname), "-p", str(port), "postgres", "-Xc", "select 1;"],
+                       env={"PGOPTIONS": "-c gp_role=utility", "PATH": os.getenv("PATH")},
+                       check=True)
+        return True
+    except Exception as e:
+        time.sleep(1)
+raise Exception("wait connection timeout")
+$$
+LANGUAGE plpython3u;
 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -660,7 +672,7 @@ SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configura
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 
 -- Wait for primary on segment 0 to recover after panics
-SELECT wait_for_primaries_to_restart();
+SELECT connectSeg(600, port, hostname) FROM gp_segment_configuration WHERE content = 0 and preferred_role = 'p';
 
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
@@ -732,7 +744,7 @@ SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 
 -- Wait for primary on segment 0 to recover after panics
-SELECT wait_for_primaries_to_restart();
+SELECT connectSeg(600, port, hostname) FROM gp_segment_configuration WHERE content = 0 and preferred_role = 'p';
 
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');

--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -126,6 +126,10 @@ for dbid, datadir in db_instances.items():
 return rows
 $fn$;
 
+CREATE OR REPLACE FUNCTION wait_for_primaries_to_restart() RETURNS BOOLEAN AS $$
+	SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
+$$ LANGUAGE sql;
+
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 -- Tests for ALTER DATABASE SET TABLESPACE adhere to the following format. A
@@ -655,8 +659,8 @@ SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configura
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 
--- Wait for primaries to recover after panics
-SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
+-- Wait for primary on segment 0 to recover after panics
+SELECT wait_for_primaries_to_restart();
 
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
@@ -726,6 +730,9 @@ SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp
 
 -- When we execute an ALTER DATABASE SET TABLESPACE command on alter_db and the panic is triggered
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
+
+-- Wait for primary on segment 0 to recover after panics
+SELECT wait_for_primaries_to_restart();
 
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -114,6 +114,9 @@ for dbid, datadir in db_instances.items():
 
 return rows
 $fn$;
+CREATE OR REPLACE FUNCTION wait_for_primaries_to_restart() RETURNS BOOLEAN AS $$
+	SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
+$$ LANGUAGE sql;
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Tests for ALTER DATABASE SET TABLESPACE adhere to the following format. A
 -- scenario is provided for each test with a table that compactly specifies
@@ -1068,10 +1071,10 @@ SELECT gp_inject_fault('start_prepare', 'panic', dbid) FROM gp_segment_configura
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 1802)
 ERROR:  fault triggered, fault name:'start_prepare' fault type:'panic'  (seg0 127.0.0.1:25432 pid=61308)
--- Wait for primaries to recover after panics
-SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
- ?column? 
-----------
+-- Wait for primary on segment 0 to recover after panics
+SELECT wait_for_primaries_to_restart();
+ wait_for_primaries_to_restart 
+-------------------------------
  t
 (1 row)
 
@@ -1211,6 +1214,13 @@ SELECT gp_inject_fault('after_xlog_xact_prepare_flushed', 'panic', dbid) FROM gp
 ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 3078)
 ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'  (seg0 127.0.0.1:25432 pid=78007)
+-- Wait for primary on segment 0 to recover after panics
+SELECT wait_for_primaries_to_restart();
+ wait_for_primaries_to_restart 
+-------------------------------
+ t
+(1 row)
+
 -- Then the tablespace for the database remains to be the source tablespace in all segments and the master.
 SELECT * FROM list_db_tablespace('alter_db', 'adst_source_tablespace');
  gp_segment_id | db_name  |    tablespace_name     
@@ -1276,12 +1286,13 @@ SELECT force_mirrors_to_catch_up();
 
 -- Final cleanup
 DROP SCHEMA adst CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function get_tablespace_version_directory_name()
 drop cascades to function setup_tablespace_location_dir_for_test(text)
 drop cascades to function setup()
 drop cascades to function list_db_tablespace(text,text)
 drop cascades to function stat_db_objects(text,text)
+drop cascades to function wait_for_primaries_to_restart()
 SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
  gp_inject_fault 
 -----------------

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -114,9 +114,21 @@ for dbid, datadir in db_instances.items():
 
 return rows
 $fn$;
-CREATE OR REPLACE FUNCTION wait_for_primaries_to_restart() RETURNS BOOLEAN AS $$
-	SELECT count(gp_segment_id) > 0 FROM gp_dist_random('pg_tablespace');
-$$ LANGUAGE sql;
+CREATE OR REPLACE FUNCTION connectSeg(n int, port int, hostname text) RETURNS bool AS $$
+import os
+import subprocess
+import time
+for i in range(n):
+    try:
+        subprocess.run(["psql", "-h", str(hostname), "-p", str(port), "postgres", "-Xc", "select 1;"],
+                       env={"PGOPTIONS": "-c gp_role=utility", "PATH": os.getenv("PATH")},
+                       check=True)
+        return True
+    except Exception as e:
+        time.sleep(1)
+raise Exception("wait connection timeout")
+$$
+LANGUAGE plpython3u;
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- Tests for ALTER DATABASE SET TABLESPACE adhere to the following format. A
 -- scenario is provided for each test with a table that compactly specifies
@@ -1072,9 +1084,9 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 1802)
 ERROR:  fault triggered, fault name:'start_prepare' fault type:'panic'  (seg0 127.0.0.1:25432 pid=61308)
 -- Wait for primary on segment 0 to recover after panics
-SELECT wait_for_primaries_to_restart();
- wait_for_primaries_to_restart 
--------------------------------
+SELECT connectSeg(600, port, hostname) FROM gp_segment_configuration WHERE content = 0 and preferred_role = 'p';
+ connectseg 
+------------
  t
 (1 row)
 
@@ -1215,9 +1227,9 @@ ALTER DATABASE alter_db SET TABLESPACE adst_destination_tablespace;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 3078)
 ERROR:  fault triggered, fault name:'after_xlog_xact_prepare_flushed' fault type:'panic'  (seg0 127.0.0.1:25432 pid=78007)
 -- Wait for primary on segment 0 to recover after panics
-SELECT wait_for_primaries_to_restart();
- wait_for_primaries_to_restart 
--------------------------------
+SELECT connectSeg(600, port, hostname) FROM gp_segment_configuration WHERE content = 0 and preferred_role = 'p';
+ connectseg 
+------------
  t
 (1 row)
 
@@ -1292,7 +1304,7 @@ drop cascades to function setup_tablespace_location_dir_for_test(text)
 drop cascades to function setup()
 drop cascades to function list_db_tablespace(text,text)
 drop cascades to function stat_db_objects(text,text)
-drop cascades to function wait_for_primaries_to_restart()
+drop cascades to function connectseg(integer,integer,text)
 SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
  gp_inject_fault 
 -----------------


### PR DESCRIPTION
Make alter_db_set_tablespace test stable

Commit 591df49 incorrectly stabilized the alter_db_set_tablespace test, which
crashed on CI due to the panicked segment sometimes taking a long time to
recover. This patch adds a more correct wait for the segment to recover after a
panic.