### PR TITLE
ADBDEV-9043: Make join_gp test stable

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -818,6 +818,7 @@ set enable_nestloop = 1;
 set enable_material = 0;
 set enable_seqscan = 0;
 set enable_bitmapscan = 0;
+analyze tenk2;
 explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
@@ -828,7 +829,7 @@ explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
                      ->  Index Only Scan using tenk1_unique2 on tenk1  (cost=0.16..1650.16 rows=3334 width=4)
                      ->  Materialize  (cost=0.16..18479.11 rows=10000 width=0)
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.16..18329.11 rows=10000 width=0)
-                                 ->  Index Only Scan using tenk2_unique2 on tenk2  (cost=0.16..17929.11 rows=3334 width=0)
+                                 ->  Index Only Scan using tenk2_hundred on tenk2  (cost=0.16..223.47 rows=3333 width=0)
  Optimizer: Postgres query optimizer
 (9 rows)
 

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -817,6 +817,7 @@ set enable_nestloop = 1;
 set enable_material = 0;
 set enable_seqscan = 0;
 set enable_bitmapscan = 0;
+analyze tenk2;
 explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -428,6 +428,7 @@ set enable_nestloop = 1;
 set enable_material = 0;
 set enable_seqscan = 0;
 set enable_bitmapscan = 0;
+analyze tenk2;
 explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
 select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
 reset enable_nestloop;


### PR DESCRIPTION
Make join_gp test stable

The join_gp test were unstable because in next query

```sql
explain select tenk1.unique2 >= 0 from tenk1 left join tenk2 on true limit 1;
```

index used to access tenk2 relation could vary between test runs.
This was due to the fact that if we got to that test before auto-analyze
process does its thing, we would use "outdated" costs of indexes so we
preferred `tenk2_unique2` over `tenk2_hundred` index.
But if we got to that test after auto-analyze, we would have up to date costs
of indexes and we would prefer `tenk2_hundred` index **over** `tenk2_unique2`.

This was not the problem in previous versions of gpdb, as cost of
`tenk2_unique2` was actually lower than `tenk2_hundred` before and after
`analyze`. But in **8.x** commit about deduplication of nbtree index
(0d861bbb702f8aa05c2a4e3f1650e7e8df8c8c27) was included, so the number
of pages, which index occupy went smaller and so the cost of this index
`tenk2_hundred` became lower than `tenk2_unique2`.

So to fix flakiness, explicit `analyze` was put before main query.