### PR TITLE
Implement cluster rebalance for ggrebalance utility

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -14,7 +14,7 @@ try:
     from gppylib.system.environment import GpCoordinatorEnvironment
     from gppylib.system import configurationInterface, configurationImplGpdb
     from gprebalance_modules.shrink import GGShrink, DBNAME
-    from gprebalance_modules.ggrebalanceSM import RebalanceSM, GGRebalanceSM
+    from gprebalance_modules.ggrebalance_main_sm import GGRebalanceMainSM
     from gprebalance_modules.planner import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -283,7 +283,7 @@ def main(options, args, parser):
             sys.exit(1)
 
         global gg_main_rebalance_SM
-        gg_main_rebalance_SM = GGRebalanceSM(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
+        gg_main_rebalance_SM = GGRebalanceMainSM(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
         gg_main_rebalance_SM.run()
 
         sys.exit(0)

--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -14,7 +14,7 @@ try:
     from gppylib.system.environment import GpCoordinatorEnvironment
     from gppylib.system import configurationInterface, configurationImplGpdb
     from gprebalance_modules.shrink import GGShrink, DBNAME
-    from gprebalance_modules.ggrebalanceSM import RebalanceSM
+    from gprebalance_modules.ggrebalanceSM import RebalanceSM, GGRebalanceSM
     from gprebalance_modules.planner import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -229,11 +229,11 @@ def remove_pid_file(coordinator_data_directory: str):
     except IOError:
         pass
 
-gg_shrink = None
+gg_main_rebalance_SM = None
 
 def sig_handler(sig, arg):
-    if gg_shrink is not None:
-        gg_shrink.shutdown()
+    if gg_main_rebalance_SM is not None:
+        gg_main_rebalance_SM.shutdown()
     else:
         sys.exit(1)
 
@@ -282,31 +282,9 @@ def main(options, args, parser):
             logger.error(f"{str(ex)}")
             sys.exit(1)
 
-        global gg_shrink
-        gg_shrink = GGShrink(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
-
-        # Note: the plan for a shrink later will be provided by the planner component.
-        # But for now we simply create a Plan object from the options directly.
-        # We'll keep this stub till planner is ready.
-        # If shrink_plan is None, we assume that we need to continue previous operation
-        # TODO: remove the comment above?
-        plan = None
-        if options.target_segment_count != None:
-            plan = Planner(logger, dburl, gparray, options).plan()
-        
-        if options.target_segment_count != None and options.show_plan:
-            logger.info(f"Final plan:\n{plan}")
-            #TODO: remove exit?
-            sys.exit(0)
-        
-        if plan is None or isinstance(plan, ShrinkPlan):
-            gg_shrink.run(plan)
-
-        if plan is not None and plan.getMoves() is not None:
-            # what if plan is None? for ex., if we recovered after interruption during shrink?...
-            gg_rebalance = RebalanceSM(logger, dburl, options)
-            gg_rebalance.run(plan)
-            logger.info('Rebalance is complete')
+        global gg_main_rebalance_SM
+        gg_main_rebalance_SM = GGRebalanceSM(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
+        gg_main_rebalance_SM.run()
 
         sys.exit(0)
     except Exception as e:

--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -230,12 +230,41 @@ def remove_pid_file(coordinator_data_directory: str):
         pass
 
 gg_main_rebalance_SM = None
+cmd_recoverseg = None
 
 def sig_handler(sig, arg):
     if gg_main_rebalance_SM is not None:
         gg_main_rebalance_SM.shutdown()
     else:
+        if cmd_recoverseg != None:
+            cmd_recoverseg.cancel()
         sys.exit(1)
+
+def check_down_segments(logger: Any, dburl: dbconn.DbURL):
+    # check if some of the segments are down - it can happen if we're recovering from an
+    # interrupted state, and such segments are left by the interrupted gprecoverseg
+    conn = dbconn.connect(dburl, encoding='UTF8', allowSystemTableMods=True)
+    dbconn.execSQL(conn, "SELECT gp_request_fts_probe_scan()")
+    cnt_primaries_down = int(dbconn.queryRow(conn, f"SELECT COUNT(1) FROM gp_segment_configuration WHERE role = 'p' AND status = 'd'")[0])
+    cnt_mirrors_down = int(dbconn.queryRow(conn, f"SELECT COUNT(1) FROM gp_segment_configuration WHERE role = 'm' AND status = 'd'")[0])
+    conn.close()
+
+    if cnt_primaries_down != 0:
+        raise Exception('Detected some primary segments are down, please recover manually')
+
+    if cnt_mirrors_down != 0:
+        logger.info("Some mirrors are down, trying to recover them, it may take some time...")
+        recoverseg_options = "-a -F"
+        global cmd_recoverseg
+        try:
+            cmd_recoverseg = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
+            cmd_recoverseg.run(validateAfter=True)
+        except Exception as e:
+            logger.error(str(e))
+            error_msg = f"Failed to execute 'gprecoverseg {recoverseg_options}'"
+            raise Exception(error_msg)
+        finally:
+            cmd_recoverseg = None
 
 def main(options, args, parser):
     try:
@@ -268,6 +297,8 @@ def main(options, args, parser):
         create_pid_file(options.coordinator_data_directory)
 
         gparray_dump_filename = options.coordinator_data_directory + '/gparraydump'
+
+        check_down_segments(logger, dburl)
 
         logger.info('Init gparray from catalog')
         try:

--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -14,6 +14,7 @@ try:
     from gppylib.system.environment import GpCoordinatorEnvironment
     from gppylib.system import configurationInterface, configurationImplGpdb
     from gprebalance_modules.shrink import GGShrink, DBNAME
+    from gprebalance_modules.ggrebalanceSM import RebalanceSM
     from gprebalance_modules.planner import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -288,16 +289,24 @@ def main(options, args, parser):
         # But for now we simply create a Plan object from the options directly.
         # We'll keep this stub till planner is ready.
         # If shrink_plan is None, we assume that we need to continue previous operation
+        # TODO: remove the comment above?
         plan = None
         if options.target_segment_count != None:
             plan = Planner(logger, dburl, gparray, options).plan()
         
         if options.target_segment_count != None and options.show_plan:
             logger.info(f"Final plan:\n{plan}")
+            #TODO: remove exit?
             sys.exit(0)
         
         if plan is None or isinstance(plan, ShrinkPlan):
             gg_shrink.run(plan)
+
+        if plan is not None and plan.getMoves() is not None:
+            # what if plan is None? for ex., if we recovered after interruption during shrink?...
+            gg_rebalance = RebalanceSM(logger, dburl, options)
+            gg_rebalance.run(plan)
+            logger.info('Rebalance is complete')
 
         sys.exit(0)
     except Exception as e:

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1688,6 +1688,20 @@ class GpRecoverSeg(Command):
        cmdStr = "$GPHOME/bin/gprecoverseg %s" % (options)
        Command.__init__(self,name,cmdStr,ctxt,remoteHost)
 
+class GpMoveMirrors(Command):
+   """
+   This command will execute the gpmovemirror utility
+   """
+
+   def __init__(self, name, options = "", ctxt = LOCAL, remoteHost = None):
+       self.name = name
+       self.options = options
+       self.ctxt = ctxt
+       self.remoteHost = remoteHost
+
+       cmdStr = "$GPHOME/bin/gpmovemirrors %s" % (options)
+       Command.__init__(self,name,cmdStr,ctxt,remoteHost)
+
 class IfAddrs:
     @staticmethod
     def list_addrs(hostname=None, include_loopback=False):

--- a/gpMgmt/bin/gppylib/fault_injection.py
+++ b/gpMgmt/bin/gppylib/fault_injection.py
@@ -1,12 +1,28 @@
 #!/usr/bin/env python3
 
 import os
+import threading
+import time
+import signal
 
 GPMGMT_FAULT_POINT = 'GPMGMT_FAULT_POINT'
+GPMGMT_FAULT_DELAY_MS = 'GPMGMT_FAULT_DELAY_MS'
 
 def inject_fault(fault_point):
     if GPMGMT_FAULT_POINT in os.environ and fault_point == os.environ[GPMGMT_FAULT_POINT]:
-        raise Exception('Fault Injection %s' % os.environ[GPMGMT_FAULT_POINT]) 
+        if GPMGMT_FAULT_DELAY_MS in os.environ and int(os.environ[GPMGMT_FAULT_DELAY_MS]) > 0:
+            delay_ms = int(os.environ[GPMGMT_FAULT_DELAY_MS])
+
+            def raise_exception(delay: int):
+                time.sleep(delay / 1000)
+                print('Fault Injection %s' % os.environ[GPMGMT_FAULT_POINT])
+                os.kill(os.getpid(), signal.SIGINT)
+
+            thread = threading.Thread(target=raise_exception, kwargs={"delay": delay_ms})
+            thread.daemon = True
+            thread.start()
+        else:
+            raise Exception('Fault Injection %s' % os.environ[GPMGMT_FAULT_POINT])
 
 # decorator for test purposes
 def wrap_state_func_with_faults(func):

--- a/gpMgmt/bin/gprebalance_modules/Makefile
+++ b/gpMgmt/bin/gprebalance_modules/Makefile
@@ -11,7 +11,7 @@ rebalance_status.py \
 shrink.py planner.py \
 rebalance_commons.py \
 rebalance_schema.py \
-solver.py
+solver.py ggrebalanceSM.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/gprebalance_modules'

--- a/gpMgmt/bin/gprebalance_modules/Makefile
+++ b/gpMgmt/bin/gprebalance_modules/Makefile
@@ -11,7 +11,8 @@ rebalance_status.py \
 shrink.py planner.py \
 rebalance_commons.py \
 rebalance_schema.py \
-solver.py ggrebalanceSM.py
+solver.py ggrebalance_sm.py \
+ggrebalance_main_sm.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/gprebalance_modules'

--- a/gpMgmt/bin/gprebalance_modules/ggrebalanceSM.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalanceSM.py
@@ -11,69 +11,401 @@ try:
     from gprebalance_modules.planner import *
     from gprebalance_modules.rebalance_schema import RebalanceSchema
     from gppylib.fault_injection import *
+    from gprebalance_modules.shrink import GGShrink, DBNAME
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
+
+class GGRebalanceSM:
+
+    states = [
+        'STATE_START',
+        'STATE_OPTIONS_VALIDATION',
+        'STATE_CLEANUP',
+        'STATE_ROLLBACK',
+        'STATE_PLANNING_STARTED',
+        'STATE_PLANNING_DONE',
+        'STATE_CHECK_PREVIOUS_RUN',
+        'STATE_SETUP_SCHEMA_STARTED',
+        'STATE_SETUP_SCHEMA_DONE',
+        'STATE_EXECUTOR_STARTED',
+        'STATE_EXECUTOR_DONE',
+        'STATE_SHRINK_STARTED',
+        'STATE_SHRINK_DONE',
+        'STATE_REBALANCE_STARTED',
+        'STATE_REBALANCE_DONE',
+        'STATE_END',
+        'STATE_ERROR'
+    ]
+
+    transitions = [
+        {
+            'trigger': 'start',
+            'source': 'STATE_START',
+            'dest': 'STATE_OPTIONS_VALIDATION'
+        },
+        {
+            'trigger': 'move_to_STATE_CLEANUP',
+            'source': 'STATE_OPTIONS_VALIDATION',
+            'dest': 'STATE_CLEANUP'
+        },
+        {
+            'trigger': 'move_to_STATE_ROLLBACK',
+            'source': 'STATE_OPTIONS_VALIDATION',
+            'dest': 'STATE_ROLLBACK'
+        },
+        {
+            'trigger': 'move_to_STATE_PLANNING_STARTED',
+            'source': 'STATE_OPTIONS_VALIDATION',
+            'dest': 'STATE_PLANNING_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_PLANNING_DONE',
+            'source': 'STATE_PLANNING_STARTED',
+            'dest': 'STATE_PLANNING_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_CHECK_PREVIOUS_RUN',
+            'source': 'STATE_PLANNING_DONE',
+            'dest': 'STATE_CHECK_PREVIOUS_RUN'
+        },
+        {
+            'trigger': 'move_to_STATE_SETUP_SCHEMA_STARTED',
+            'source': 'STATE_CHECK_PREVIOUS_RUN',
+            'dest': 'STATE_SETUP_SCHEMA_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_SETUP_SCHEMA_DONE',
+            'source': 'STATE_SETUP_SCHEMA_STARTED',
+            'dest': 'STATE_SETUP_SCHEMA_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_EXECUTOR_STARTED',
+            'source': ['STATE_SETUP_SCHEMA_DONE', 'STATE_CHECK_PREVIOUS_RUN'],
+            'dest': 'STATE_EXECUTOR_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_STARTED',
+            'source': 'STATE_EXECUTOR_STARTED',
+            'dest': 'STATE_SHRINK_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_SHRINK_DONE',
+            'source': 'STATE_SHRINK_STARTED',
+            'dest': 'STATE_SHRINK_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_STARTED',
+            'source': ['STATE_EXECUTOR_STARTED', 'STATE_SHRINK_DONE'],
+            'dest': 'STATE_REBALANCE_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_DONE',
+            'source': 'STATE_REBALANCE_STARTED',
+            'dest': 'STATE_REBALANCE_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_EXECUTOR_DONE',
+            'source': ['STATE_EXECUTOR_STARTED', 'STATE_SHRINK_DONE', 'STATE_REBALANCE_DONE'],
+            'dest': 'STATE_EXECUTOR_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_END',
+            'source': ['STATE_EXECUTOR_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_ROLLBACK'],
+            'dest': 'STATE_END'
+        },
+        {
+            'trigger': 'move_to_STATE_ERROR',
+            'source': '*',
+            'dest': 'STATE_ERROR'
+        }
+    ]
+
+    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any, gpEnv: GpCoordinatorEnvironment, gpArray: gparray.GpArray, gpArrayDumpFilename: str):
+        self.logger = logger
+        self.dburl = dburl
+        self.options = options
+        self.shutdown_requested = False
+        self.gparray = gpArray
+        self.conn = dbconn.connect(
+            self.dburl, encoding='UTF8', allowSystemTableMods=True)
+
+        self.rebalance_schema = RebalanceSchema(self.conn)
+
+        self.machine = Machine(model = self,
+                               queued=True,
+                               states = self.states,
+                               transitions = self.transitions,
+                               initial = 'STATE_START',
+                               before_state_change = 'on_every_state')
+
+        self.gg_shrink = GGShrink(self.logger, self.dburl, self.options, gpEnv, self.gparray, gpArrayDumpFilename)
+        self.gg_rebalance = RebalanceSM(self.logger, self.dburl, self.options)
+
+        # Note: the plan for a shrink later will be provided by the planner component.
+        # But for now we simply create a Plan object from the options directly.
+        # We'll keep this stub till planner is ready.
+        # If shrink_plan is None, we assume that we need to continue previous operation
+        # TODO: remove the comment above?
+        self.plan = None
+        self.main_state_from_prev_run = self.rebalance_schema.getMainStateFromPreviousRun()
+
+
+    def on_every_state(self) -> None:
+        self.logger.info('MAIN - on_every_state')
+
+        #if self.shutdown_requested:
+        #    self.logger.info('Rebalance was interrupted')
+        #    raise Exception('Rebalance was interrupted')
+
+        self.rebalance_schema.storeMainState(self.state)
+
+    def run(self) -> None:
+        self.trigger('start')
+
+    def shutdown(self) -> None:
+        self.logger.info('GGRebalanceSM -  SHUTDOWN')
+        need_exit = True
+        #self.shutdown_requested = True
+        if self.gg_shrink is not None:
+            print('[RELOG] - gg_shrink.shutdown()')
+            self.gg_shrink.shutdown()
+            need_exit = False
+
+        if self.gg_rebalance is not None:
+            print('[RELOG] - gg_rebalance.shutdown()')
+            self.gg_rebalance.shutdown()
+            need_exit = False
+
+        if need_exit:
+            print('[RELOG] - sig_handler exit()')
+            sys.exit(1)
+
+    # state callbacks start here
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_OPTIONS_VALIDATION(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        if self.options.clean_required:
+            self.trigger('move_to_STATE_CLEANUP')
+        elif self.options.rollback_required:
+            self.trigger('move_to_STATE_ROLLBACK')
+        else:
+            self.trigger('move_to_STATE_PLANNING_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_CLEANUP(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        if not self.rebalance_schema.schemaExists():
+            self.logger.info(f"Rebalance schema doesn't exist. Cleanup is not required.")
+        else:
+            self.logger.info(f">> self.main_state_from_prev_run  {self.main_state_from_prev_run}")
+            # TODO: rework this ugly check
+            self.gg_shrink.cleanup(self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE' or self.main_state_from_prev_run == 'STATE_ROLLBACK')
+            self.rebalance_schema.dropSchema()
+            self.logger.info('Cleanup is complete')
+        self.trigger('move_to_STATE_END')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_ROLLBACK(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        self.gg_shrink.rollback()
+        self.trigger('move_to_STATE_END')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_PLANNING_STARTED(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+
+        if self.options.target_segment_count != None:
+            self.plan = Planner(self.logger, self.dburl, self.gparray, self.options).plan()
+
+        if self.options.target_segment_count != None and self.options.show_plan:
+            self.logger.info(f"Final plan:\n{self.plan}")
+            #TODO: remove exit?
+            sys.exit(0)
+
+        self.trigger('move_to_STATE_PLANNING_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_PLANNING_DONE(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        self.trigger('move_to_STATE_CHECK_PREVIOUS_RUN')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_CHECK_PREVIOUS_RUN(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        if not self.rebalance_schema.schemaExists():
+            if self.plan == None:
+                self.logger.error("Rebalance schema doesn't exists and no shrink plan is supplied. Please specify shrink plan.")
+                self.trigger('move_to_STATE_ERROR')
+                return
+            if self.gparray.get_segment_count() < self.plan.target_segment_count:
+                logger.error('Target segment count (%s) > current segment count (%s).\n'
+                             'Currently only shrink is supported (target segment count < current segment count).'
+                              % (self.plan.target_segment_count, self.gparray.get_segment_count()))
+                self.trigger('move_to_STATE_ERROR')
+                return
+            self.trigger('move_to_STATE_SETUP_SCHEMA_STARTED')
+        else:
+            # Schema already exists from the previous run.
+            # In this case we already have a plan saved in the schema,
+            # and we'll continue (or rollback) according to it.
+            # Or, if everything is complete, just exit.
+            self.logger.info(f'main_state_from_prev_run {self.main_state_from_prev_run}')
+            if self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE':
+                self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
+                return
+
+            if self.plan != None:
+                self.logger.error("Can't start a new operation, because the previous one was interrupted. "
+                                  "Please try to launch again without a plan to continue from the interrupted state, "
+                                  "or use '--rollback' or '--cleanup' options.")
+                self.trigger('move_to_STATE_ERROR')
+                return
+
+            self.trigger('move_to_STATE_EXECUTOR_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SETUP_SCHEMA_STARTED(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+
+        # Create schema and status tables.
+        # It will also save plan in order to use it for recovering after interruption
+        self.rebalance_schema.createSchema(self.plan)
+
+        self.trigger('move_to_STATE_SETUP_SCHEMA_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SETUP_SCHEMA_DONE(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+
+        self.logger.info(f'Created "{self.rebalance_schema.getSchemaName()}" schema')
+
+        self.trigger('move_to_STATE_EXECUTOR_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_EXECUTOR_STARTED(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+
+        shrink_state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
+        if not self.gg_shrink.state_is_final(shrink_state_from_prev_run):
+            self.trigger('move_to_STATE_SHRINK_STARTED')
+        else:
+            self.trigger('move_to_STATE_REBALANCE_STARTED')
+            #if not self.options.skip_rebalance:
+            #    rebalance_state_from_prev_run = self.rebalance_schema.getRebalanceStateFromPreviousRun()
+            #    if not self.gg_rebalance.state_is_final(rebalance_state_from_prev_run):
+            #        self.trigger('move_to_STATE_REBALANCE_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_EXECUTOR_DONE(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        self.trigger('move_to_STATE_END')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_STARTED(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+
+        if self.plan is None or isinstance(self.plan, ShrinkPlan):
+            self.gg_shrink.run(self.plan)
+
+        self.trigger('move_to_STATE_SHRINK_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_SHRINK_DONE(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        self.trigger('move_to_STATE_REBALANCE_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_STARTED(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+
+        if self.plan is not None and self.plan.getMoves() is not None:
+            # what if plan is None? for ex., if we recovered after interruption during shrink?...
+            self.gg_rebalance.run(self.plan)
+            self.logger.info('Rebalance is complete')
+
+        self.trigger('move_to_STATE_REBALANCE_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_DONE(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        self.trigger('move_to_STATE_EXECUTOR_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_END(self) -> None:
+        self.logger.info(f'MAIN STATE: {self.state}')
+        #TODO: get rid of other connections?...
+        self.conn.close()
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_ERROR(self) -> None:
+        raise Exception('Main SM entered STATE_ERROR')
+
+    # state callbacks end here
+
+#################################
+#################################
 
 class RebalanceSM:
 
     states = [
         'STATE_REBALANCE_START',
-        'STATE_REBALANCE_MOVE_MIRRORS_START',
+        'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
         'STATE_REBALANCE_MOVE_MIRRORS_DONE',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
         'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-        'STATE_REBALANCE_MOVE_PRIMARIES_START',
+        'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
         'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
         'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
-        'STATE_REBALANCE_END'
+        'STATE_REBALANCE_DONE'
     ]
 
     transitions = [
         {
             'trigger': 'start',
             'source': 'STATE_REBALANCE_START',
-            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_START'
+            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED'
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE',
-            'source': 'STATE_REBALANCE_MOVE_MIRRORS_START',
+            'source': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
             'dest': 'STATE_REBALANCE_MOVE_MIRRORS_DONE'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START',
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
             'source': 'STATE_REBALANCE_MOVE_MIRRORS_DONE',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START'
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED'
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
             'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_START',
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
             'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_START'
+            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED'
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_START',
+            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
             'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START',
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
             'source': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START'
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED'
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
             'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_END',
+            'trigger': 'move_to_STATE_REBALANCE_DONE',
             'source': ['STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE', 'STATE_REBALANCE_MOVE_MIRRORS_DONE'],
-            'dest': 'STATE_REBALANCE_END'
+            'dest': 'STATE_REBALANCE_DONE'
         }
     ]
 
@@ -82,8 +414,11 @@ class RebalanceSM:
         self.logger = logger
         self.dburl = dburl
         self.options = options
+        self.shutdown_requested = False
         self.conn = dbconn.connect(
             self.dburl, encoding='UTF8', allowSystemTableMods=True)
+
+        self.rebalance_schema = RebalanceSchema(self.conn)
 
         self.machine = Machine(model = self,
                                queued=True,
@@ -94,12 +429,12 @@ class RebalanceSM:
 
     def on_every_state(self) -> None:
         self.logger.info('REBALANCE - on_every_state')
-        #if self.shutdown_requested:
-        #    self.logger.info('Shrink was interrupted')
-        #    raise Exception('Shrink was interrupted')
-        #assert self.state in self.states + self.states_main_shrink_flow + self.states_rollback_flow
-        #if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
-        #    self.rebalance_schema.storeState(self.state)
+
+        if self.shutdown_requested:
+            self.logger.info('Rebalance was interrupted')
+            raise Exception('Rebalance was interrupted')
+
+        self.rebalance_schema.storeRebalanceState(self.state)
 
     def run(self, plan: Plan) -> None:
         self.rebalance_plan = plan
@@ -116,7 +451,7 @@ class RebalanceSM:
             else:
                 self.moves_mirrors.append(move)
         
-        self.primary_segids_to_move = tuple([move.seg.getSegmentContentId() for move in self.moves_primaries])
+        self.primary_segids_to_move = [move.seg.getSegmentContentId() for move in self.moves_primaries]
 
         self.trigger('start')
 
@@ -132,27 +467,37 @@ class RebalanceSM:
                 batch_size = MAX_COORDINATOR_NUM_WORKERS
             gpmovemirrors_options += f' -B {batch_size}'
 
-        cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
-        cmd.run(validateAfter=True)
+        try:
+            cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
+            cmd.run(validateAfter=True)
+        except Exception as e:
+            error_msg = f"Error in gpmovemirrors process: {str(e)}"
+            self.logger.error(error_msg)
+
         # TODO: cleanup config files        
 
-    def execute_role_swaps(self, segids: tuple[SegmentId]):
+    def execute_role_swaps(self, segids: List[SegmentId]):
         """Execute multiple role swaps in single gprecoverseg -r call"""
         dbconn.execSQL(self.conn, "BEGIN")
+        seg_list = ', '.join(str(seg) for seg in segids)
         dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 't' WHERE "
-                       f"content IN {segids} AND preferred_role = 'm'")
+                       f"content IN ({seg_list}) AND preferred_role = 'm'")
         dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'm' WHERE "
-                       f"content IN {segids} AND preferred_role = 'p'")
+                       f"content IN ({seg_list}) AND preferred_role = 'p'")
         dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
-                       f"content IN {segids} AND preferred_role = 't'")
+                       f"content IN ({seg_list}) AND preferred_role = 't'")
         dbconn.execSQL(self.conn, "COMMIT")
 
         # TODO: refactor
         # TODO: specify log file location?...
         recoversegOptions = "-r -a"
-        cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
-        cmd.run(validateAfter=True)
-    
+        try:
+            cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
+            cmd.run(validateAfter=True)
+        except Exception as e:
+            error_msg = f"Error in gprecoverseg process: {str(e)}"
+            self.logger.error(error_msg)
+
     def create_config_file(self, moves: List[LogicalMove]) -> str:
         # TODO: do we really want to use /tmp location?
         filename = f'/tmp/ggrebalance_move_config_pid{os.getpid()}'
@@ -164,10 +509,17 @@ class RebalanceSM:
                 fp.write(cfg_line)
         return filename
 
+    def shutdown(self) -> None:
+        self.logger.info('Rebalance - shutdown_requested set to True')
+        self.shutdown_requested = True
+
+    def state_is_final(self, state: str) -> bool:
+        return state == self.states[-1]
+
     # state callbacks start here
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_START(self) -> None:
+    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED(self) -> None:
         self.logger.info('Rebalance - start moving mirrors')
         self.process_moves(self.moves_mirrors)
         self.logger.info('Rebalance - end moving mirrors')
@@ -176,21 +528,21 @@ class RebalanceSM:
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE(self) -> None:
         if self.primary_segids_to_move:
-            self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START')
+            self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED')
         else:
-            self.trigger('move_to_STATE_REBALANCE_END')
+            self.trigger('move_to_STATE_REBALANCE_DONE')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START(self) -> None:
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED(self) -> None:
         self.execute_role_swaps(self.primary_segids_to_move)
         self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_START')
+        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_START(self) -> None:
+    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED(self) -> None:
         self.logger.info('Rebalance - start moving primaries')
         self.process_moves(self.moves_primaries)
         self.logger.info('Rebalance - end moving primaries')
@@ -198,19 +550,19 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START')
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START(self) -> None:
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED(self) -> None:
         self.execute_role_swaps(self.primary_segids_to_move)
         self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_END')
+        self.trigger('move_to_STATE_REBALANCE_DONE')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_END(self) -> None:
+    def on_enter_STATE_REBALANCE_DONE(self) -> None:
         self.conn.close()
 
     # state callbacks end here

--- a/gpMgmt/bin/gprebalance_modules/ggrebalanceSM.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalanceSM.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+
+from transitions import Machine
+
+try:
+    from gppylib.commands.unix import *
+    from gppylib.commands.gp import *
+    from gppylib.gplog import *
+    from gppylib.commands.gp import GpMoveMirrors
+    from gppylib.system.environment import *
+    from gprebalance_modules.planner import *
+    from gprebalance_modules.rebalance_schema import RebalanceSchema
+    from gppylib.fault_injection import *
+except ImportError as e:
+    sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
+
+class RebalanceSM:
+
+    states = [
+        'STATE_REBALANCE_START',
+        'STATE_REBALANCE_MOVE_MIRRORS_START',
+        'STATE_REBALANCE_MOVE_MIRRORS_DONE',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
+        'STATE_REBALANCE_MOVE_PRIMARIES_START',
+        'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
+        'STATE_REBALANCE_END'
+    ]
+
+    transitions = [
+        {
+            'trigger': 'start',
+            'source': 'STATE_REBALANCE_START',
+            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_START'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE',
+            'source': 'STATE_REBALANCE_MOVE_MIRRORS_START',
+            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START',
+            'source': 'STATE_REBALANCE_MOVE_MIRRORS_DONE',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_START',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
+            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_START'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE',
+            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_START',
+            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START',
+            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_END',
+            'source': ['STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE', 'STATE_REBALANCE_MOVE_MIRRORS_DONE'],
+            'dest': 'STATE_REBALANCE_END'
+        }
+    ]
+
+
+    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any):
+        self.logger = logger
+        self.dburl = dburl
+        self.options = options
+        self.conn = dbconn.connect(
+            self.dburl, encoding='UTF8', allowSystemTableMods=True)
+
+        self.machine = Machine(model = self,
+                               queued=True,
+                               states = self.states,
+                               transitions = self.transitions,
+                               initial = 'STATE_REBALANCE_START',
+                               before_state_change = 'on_every_state')
+
+    def on_every_state(self) -> None:
+        self.logger.info('REBALANCE - on_every_state')
+        #if self.shutdown_requested:
+        #    self.logger.info('Shrink was interrupted')
+        #    raise Exception('Shrink was interrupted')
+        #assert self.state in self.states + self.states_main_shrink_flow + self.states_rollback_flow
+        #if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
+        #    self.rebalance_schema.storeState(self.state)
+
+    def run(self, plan: Plan) -> None:
+        self.rebalance_plan = plan
+        if not self.rebalance_plan.getMoves():
+            return
+
+        # TODO: we actually change the order of moves.
+        # what if it confuses the user?...
+        self.moves_primaries = []
+        self.moves_mirrors = []
+        for move in self.rebalance_plan.getMoves():
+            if move.seg.isSegmentPrimary() :
+                self.moves_primaries.append(move)
+            else:
+                self.moves_mirrors.append(move)
+        
+        self.primary_segids_to_move = tuple([move.seg.getSegmentContentId() for move in self.moves_primaries])
+
+        self.trigger('start')
+
+    def process_moves(self, moves: List[LogicalMove]):
+        filename = self.create_config_file(moves)
+        gpmovemirrors_options = f' -i {filename}'
+
+        if self.options.batch_size is not None:
+            batch_size = self.options.batch_size
+            # gpmovemirrors has its own limitation for batch size,
+            # need to consider it here.
+            if batch_size > MAX_COORDINATOR_NUM_WORKERS:
+                batch_size = MAX_COORDINATOR_NUM_WORKERS
+            gpmovemirrors_options += f' -B {batch_size}'
+
+        cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
+        cmd.run(validateAfter=True)
+        # TODO: cleanup config files        
+
+    def execute_role_swaps(self, segids: tuple[SegmentId]):
+        """Execute multiple role swaps in single gprecoverseg -r call"""
+        dbconn.execSQL(self.conn, "BEGIN")
+        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 't' WHERE "
+                       f"content IN {segids} AND preferred_role = 'm'")
+        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'm' WHERE "
+                       f"content IN {segids} AND preferred_role = 'p'")
+        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
+                       f"content IN {segids} AND preferred_role = 't'")
+        dbconn.execSQL(self.conn, "COMMIT")
+
+        # TODO: refactor
+        # TODO: specify log file location?...
+        recoversegOptions = "-r -a"
+        cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
+        cmd.run(validateAfter=True)
+    
+    def create_config_file(self, moves: List[LogicalMove]) -> str:
+        # TODO: do we really want to use /tmp location?
+        filename = f'/tmp/ggrebalance_move_config_pid{os.getpid()}'
+        with open(filename, 'w') as fp:
+            for move in moves:
+                segment_current_info = move.seg
+                cfg_line = f'{segment_current_info.getSegmentHostName()}|{segment_current_info.getSegmentPort()}|{segment_current_info.getSegmentDataDirectory()} '
+                cfg_line += f'{move.dstHost.hostname}|{move.target_port}|{move.target_datadir}\n'
+                fp.write(cfg_line)
+        return filename
+
+    # state callbacks start here
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_START(self) -> None:
+        self.logger.info('Rebalance - start moving mirrors')
+        self.process_moves(self.moves_mirrors)
+        self.logger.info('Rebalance - end moving mirrors')
+        self.trigger('move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE(self) -> None:
+        if self.primary_segids_to_move:
+            self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START')
+        else:
+            self.trigger('move_to_STATE_REBALANCE_END')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_START(self) -> None:
+        self.execute_role_swaps(self.primary_segids_to_move)
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_START')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_START(self) -> None:
+        self.logger.info('Rebalance - start moving primaries')
+        self.process_moves(self.moves_primaries)
+        self.logger.info('Rebalance - end moving primaries')
+        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_START(self) -> None:
+        self.execute_role_swaps(self.primary_segids_to_move)
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_END')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_END(self) -> None:
+        self.conn.close()
+
+    # state callbacks end here

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -202,8 +202,9 @@ class GGRebalanceMainSM:
         if not self.rebalance_schema.schemaExists():
             self.logger.info(f"Rebalance schema doesn't exist. Cleanup is not required.")
         else:
-            # TODO: rework this ugly check
-            self.gg_shrink.cleanup(self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE' or self.main_state_from_prev_run == 'STATE_ROLLBACK')
+            prev_run_was_complete = (self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE' or
+                                     self.main_state_from_prev_run == 'STATE_ROLLBACK')
+            self.gg_shrink.cleanup(prev_run_was_complete)
             self.rebalance_schema.dropSchema()
             self.logger.info('Cleanup is complete')
         self.trigger('move_to_STATE_END')

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -131,22 +131,6 @@ class GGRebalanceMainSM:
         self.conn = dbconn.connect(
             self.dburl, encoding='UTF8', allowSystemTableMods=True)
 
-        # check if some of the segments are down - it can happen if we're recovering from an
-        # interrupted state, and such segments are left by the interrupted gprecoverseg
-        self.cmd = None
-        dbconn.execSQL(self.conn, "SELECT gp_request_fts_probe_scan()")
-        if 0 != int(dbconn.queryRow(self.conn, f"SELECT COUNT(1) FROM gp_segment_configuration WHERE status='d'")[0]):
-            recoverseg_options = "-a"
-            try:
-                self.cmd = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
-                self.cmd.run(validateAfter=True)
-            except Exception as e:
-                error_msg = f"Error in gprecoverseg process: {str(e)}"
-                self.logger.error(error_msg)
-                raise Exception(error_msg)
-            finally:
-                self.cmd = None
-
         self.rebalance_schema = RebalanceSchema(self.conn)
 
         self.machine = Machine(model = self,
@@ -179,9 +163,6 @@ class GGRebalanceMainSM:
         if self.gg_rebalance is not None:
             self.gg_rebalance.shutdown()
             need_exit = False
-
-        if self.cmd != None:
-            self.cmd.cancel()
 
         if need_exit:
             sys.exit(1)

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -18,7 +18,7 @@ except ImportError as e:
 
 class GGRebalanceMainSM:
 
-    states = [
+    states_not_logged = [
         'STATE_START',
         'STATE_OPTIONS_VALIDATION',
         'STATE_CLEANUP',
@@ -26,6 +26,11 @@ class GGRebalanceMainSM:
         'STATE_PLANNING_STARTED',
         'STATE_PLANNING_DONE',
         'STATE_CHECK_PREVIOUS_RUN',
+        'STATE_END',
+        'STATE_ERROR'
+    ]
+
+    states_logged = [
         'STATE_SETUP_SCHEMA_STARTED',
         'STATE_SETUP_SCHEMA_DONE',
         'STATE_EXECUTOR_STARTED',
@@ -34,8 +39,6 @@ class GGRebalanceMainSM:
         'STATE_SHRINK_DONE',
         'STATE_REBALANCE_STARTED',
         'STATE_REBALANCE_DONE',
-        'STATE_END',
-        'STATE_ERROR'
     ]
 
     transitions = [
@@ -134,7 +137,7 @@ class GGRebalanceMainSM:
 
         self.machine = Machine(model = self,
                                queued=True,
-                               states = self.states,
+                               states = self.states_not_logged + self.states_logged,
                                transitions = self.transitions,
                                initial = 'STATE_START',
                                before_state_change = 'on_every_state')
@@ -152,13 +155,13 @@ class GGRebalanceMainSM:
 
 
     def on_every_state(self) -> None:
-        self.logger.info('MAIN - on_every_state')
+        self.logger.info(f'MAIN - on_every_state ({self.state})')
 
         #if self.shutdown_requested:
         #    self.logger.info('Rebalance was interrupted')
         #    raise Exception('Rebalance was interrupted')
-
-        self.rebalance_schema.storeMainState(self.state)
+        if self.state in self.states_logged:
+            self.rebalance_schema.storeMainState(self.state)
 
     def run(self) -> None:
         self.trigger('start')

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -142,8 +142,8 @@ class GGRebalanceMainSM:
                                initial = 'STATE_START',
                                before_state_change = 'on_every_state')
 
-        self.gg_shrink = GGShrink(self.logger, self.dburl, self.options, gpEnv, self.gparray, gpArrayDumpFilename)
-        self.gg_rebalance = RebalanceSM(self.logger, self.dburl, self.options, self.gparray)
+        self.gg_shrink = GGShrink(self.conn, self.rebalance_schema, self.logger, self.options, gpEnv, self.gparray, gpArrayDumpFilename)
+        self.gg_rebalance = RebalanceSM(self.conn, self.rebalance_schema, self.logger, self.options, self.gparray)
 
         # Note: the plan for a shrink later will be provided by the planner component.
         # But for now we simply create a Plan object from the options directly.

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -300,7 +300,6 @@ class GGRebalanceMainSM:
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_STARTED(self) -> None:
         if self.plan is not None and self.plan.getMoves() is not None:
-            # TODO: what if plan is None? for ex., if we recovered after interruption during shrink?...
             self.gg_rebalance.run(self.plan)
             self.logger.info('Rebalance is complete')
 

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -143,7 +143,7 @@ class GGRebalanceMainSM:
                                before_state_change = 'on_every_state')
 
         self.gg_shrink = GGShrink(self.logger, self.dburl, self.options, gpEnv, self.gparray, gpArrayDumpFilename)
-        self.gg_rebalance = RebalanceSM(self.logger, self.dburl, self.options)
+        self.gg_rebalance = RebalanceSM(self.logger, self.dburl, self.options, self.gparray)
 
         # Note: the plan for a shrink later will be provided by the planner component.
         # But for now we simply create a Plan object from the options directly.
@@ -212,7 +212,8 @@ class GGRebalanceMainSM:
     @wrap_state_func_with_faults
     def on_enter_STATE_ROLLBACK(self) -> None:
         self.logger.info(f'MAIN STATE: {self.state}')
-        self.gg_shrink.rollback()
+        self.plan = self.rebalance_schema.retrieveSavedPlan()
+        self.gg_shrink.rollback(self.plan)
         self.trigger('move_to_STATE_END')
 
     @wrap_state_func_with_faults
@@ -266,6 +267,8 @@ class GGRebalanceMainSM:
                 self.trigger('move_to_STATE_ERROR')
                 return
 
+            self.plan = self.rebalance_schema.retrieveSavedPlan()
+
             self.trigger('move_to_STATE_EXECUTOR_STARTED')
 
     @wrap_state_func_with_faults
@@ -290,15 +293,13 @@ class GGRebalanceMainSM:
     def on_enter_STATE_EXECUTOR_STARTED(self) -> None:
         self.logger.info(f'MAIN STATE: {self.state}')
 
-        shrink_state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
-        if not self.gg_shrink.state_is_final(shrink_state_from_prev_run):
-            self.trigger('move_to_STATE_SHRINK_STARTED')
-        else:
-            self.trigger('move_to_STATE_REBALANCE_STARTED')
-            #if not self.options.skip_rebalance:
-            #    rebalance_state_from_prev_run = self.rebalance_schema.getRebalanceStateFromPreviousRun()
-            #    if not self.gg_rebalance.state_is_final(rebalance_state_from_prev_run):
-            #        self.trigger('move_to_STATE_REBALANCE_STARTED')
+        if isinstance(self.plan, ShrinkPlan):
+            shrink_state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
+            if not self.gg_shrink.state_is_final(shrink_state_from_prev_run):
+                self.trigger('move_to_STATE_SHRINK_STARTED')
+                return
+
+        self.trigger('move_to_STATE_REBALANCE_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_EXECUTOR_DONE(self) -> None:
@@ -309,8 +310,7 @@ class GGRebalanceMainSM:
     def on_enter_STATE_SHRINK_STARTED(self) -> None:
         self.logger.info(f'MAIN STATE: {self.state}')
 
-        if self.plan is None or isinstance(self.plan, ShrinkPlan):
-            self.gg_shrink.run(self.plan)
+        self.gg_shrink.run(self.plan)
 
         self.trigger('move_to_STATE_SHRINK_DONE')
 

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -163,8 +163,6 @@ class GGRebalanceMainSM:
         self.main_state_from_prev_run = self.rebalance_schema.getMainStateFromPreviousRun()
 
     def on_every_state(self) -> None:
-        self.logger.info(f'MAIN - on_every_state ({self.state})')
-
         if self.state in self.states_logged:
             self.rebalance_schema.storeMainState(self.state)
 
@@ -192,7 +190,6 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_OPTIONS_VALIDATION(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         if self.options.clean_required:
             self.trigger('move_to_STATE_CLEANUP')
         elif self.options.rollback_required:
@@ -202,11 +199,9 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_CLEANUP(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         if not self.rebalance_schema.schemaExists():
             self.logger.info(f"Rebalance schema doesn't exist. Cleanup is not required.")
         else:
-            self.logger.info(f">> self.main_state_from_prev_run  {self.main_state_from_prev_run}")
             # TODO: rework this ugly check
             self.gg_shrink.cleanup(self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE' or self.main_state_from_prev_run == 'STATE_ROLLBACK')
             self.rebalance_schema.dropSchema()
@@ -215,15 +210,12 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_ROLLBACK(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         self.plan = self.rebalance_schema.retrieveSavedPlan()
         self.gg_shrink.rollback(self.plan)
         self.trigger('move_to_STATE_END')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_PLANNING_STARTED(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
-
         if self.options.target_segment_count != None:
             self.plan = Planner(self.logger, self.dburl, self.gparray, self.options).plan()
 
@@ -234,12 +226,10 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_PLANNING_DONE(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         self.trigger('move_to_STATE_CHECK_PREVIOUS_RUN')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_CHECK_PREVIOUS_RUN(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         if not self.rebalance_schema.schemaExists():
             if self.plan == None:
                 self.logger.error("Rebalance schema doesn't exists and no shrink plan is supplied. Please specify shrink plan.")
@@ -257,7 +247,6 @@ class GGRebalanceMainSM:
             # In this case we already have a plan saved in the schema,
             # and we'll continue (or rollback) according to it.
             # Or, if everything is complete, just exit.
-            self.logger.info(f'main_state_from_prev_run {self.main_state_from_prev_run}')
             if self.main_state_from_prev_run == 'STATE_EXECUTOR_DONE':
                 self.logger.info('Previous run was completed successfully. Please execute cleanup before a new run.')
                 return
@@ -275,56 +264,40 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SETUP_SCHEMA_STARTED(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
-
         # Create schema and status tables.
         # It will also save plan in order to use it for recovering after interruption
         self.rebalance_schema.createSchema(self.plan)
-
         self.trigger('move_to_STATE_SETUP_SCHEMA_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SETUP_SCHEMA_DONE(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
-
         self.logger.info(f'Created "{self.rebalance_schema.getSchemaName()}" schema')
-
         self.trigger('move_to_STATE_EXECUTOR_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_EXECUTOR_STARTED(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
-
         if isinstance(self.plan, ShrinkPlan):
             shrink_state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
             if not self.gg_shrink.state_is_final(shrink_state_from_prev_run):
                 self.trigger('move_to_STATE_SHRINK_STARTED')
                 return
-
         self.trigger('move_to_STATE_REBALANCE_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_EXECUTOR_DONE(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         self.trigger('move_to_STATE_END')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SHRINK_STARTED(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
-
         self.gg_shrink.run(self.plan)
-
         self.trigger('move_to_STATE_SHRINK_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_SHRINK_DONE(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         self.trigger('move_to_STATE_REBALANCE_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_STARTED(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
-
         if self.plan is not None and self.plan.getMoves() is not None:
             # TODO: what if plan is None? for ex., if we recovered after interruption during shrink?...
             self.gg_rebalance.run(self.plan)
@@ -334,12 +307,10 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_DONE(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         self.trigger('move_to_STATE_EXECUTOR_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_END(self) -> None:
-        self.logger.info(f'MAIN STATE: {self.state}')
         self.conn.close()
 
     @wrap_state_func_with_faults

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -12,10 +12,11 @@ try:
     from gprebalance_modules.rebalance_schema import RebalanceSchema
     from gppylib.fault_injection import *
     from gprebalance_modules.shrink import GGShrink, DBNAME
+    from gprebalance_modules.ggrebalance_sm import RebalanceSM
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
-class GGRebalanceSM:
+class GGRebalanceMainSM:
 
     states = [
         'STATE_START',
@@ -163,7 +164,7 @@ class GGRebalanceSM:
         self.trigger('start')
 
     def shutdown(self) -> None:
-        self.logger.info('GGRebalanceSM -  SHUTDOWN')
+        self.logger.info('GGRebalanceMainSM -  SHUTDOWN')
         need_exit = True
         #self.shutdown_requested = True
         if self.gg_shrink is not None:
@@ -340,229 +341,5 @@ class GGRebalanceSM:
     @wrap_state_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:
         raise Exception('Main SM entered STATE_ERROR')
-
-    # state callbacks end here
-
-#################################
-#################################
-
-class RebalanceSM:
-
-    states = [
-        'STATE_REBALANCE_START',
-        'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
-        'STATE_REBALANCE_MOVE_MIRRORS_DONE',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-        'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
-        'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
-        'STATE_REBALANCE_DONE'
-    ]
-
-    transitions = [
-        {
-            'trigger': 'start',
-            'source': 'STATE_REBALANCE_START',
-            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE',
-            'source': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
-            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_DONE'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
-            'source': 'STATE_REBALANCE_MOVE_MIRRORS_DONE',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
-            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
-            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_DONE',
-            'source': ['STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE', 'STATE_REBALANCE_MOVE_MIRRORS_DONE'],
-            'dest': 'STATE_REBALANCE_DONE'
-        }
-    ]
-
-
-    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any):
-        self.logger = logger
-        self.dburl = dburl
-        self.options = options
-        self.shutdown_requested = False
-        self.conn = dbconn.connect(
-            self.dburl, encoding='UTF8', allowSystemTableMods=True)
-
-        self.rebalance_schema = RebalanceSchema(self.conn)
-
-        self.machine = Machine(model = self,
-                               queued=True,
-                               states = self.states,
-                               transitions = self.transitions,
-                               initial = 'STATE_REBALANCE_START',
-                               before_state_change = 'on_every_state')
-
-    def on_every_state(self) -> None:
-        self.logger.info('REBALANCE - on_every_state')
-
-        if self.shutdown_requested:
-            self.logger.info('Rebalance was interrupted')
-            raise Exception('Rebalance was interrupted')
-
-        self.rebalance_schema.storeRebalanceState(self.state)
-
-    def run(self, plan: Plan) -> None:
-        self.rebalance_plan = plan
-        if not self.rebalance_plan.getMoves():
-            return
-
-        # TODO: we actually change the order of moves.
-        # what if it confuses the user?...
-        self.moves_primaries = []
-        self.moves_mirrors = []
-        for move in self.rebalance_plan.getMoves():
-            if move.seg.isSegmentPrimary() :
-                self.moves_primaries.append(move)
-            else:
-                self.moves_mirrors.append(move)
-        
-        self.primary_segids_to_move = [move.seg.getSegmentContentId() for move in self.moves_primaries]
-
-        self.trigger('start')
-
-    def process_moves(self, moves: List[LogicalMove]):
-        filename = self.create_config_file(moves)
-        gpmovemirrors_options = f' -i {filename}'
-
-        if self.options.batch_size is not None:
-            batch_size = self.options.batch_size
-            # gpmovemirrors has its own limitation for batch size,
-            # need to consider it here.
-            if batch_size > MAX_COORDINATOR_NUM_WORKERS:
-                batch_size = MAX_COORDINATOR_NUM_WORKERS
-            gpmovemirrors_options += f' -B {batch_size}'
-
-        try:
-            cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
-            cmd.run(validateAfter=True)
-        except Exception as e:
-            error_msg = f"Error in gpmovemirrors process: {str(e)}"
-            self.logger.error(error_msg)
-
-        # TODO: cleanup config files        
-
-    def execute_role_swaps(self, segids: List[SegmentId]):
-        """Execute multiple role swaps in single gprecoverseg -r call"""
-        dbconn.execSQL(self.conn, "BEGIN")
-        seg_list = ', '.join(str(seg) for seg in segids)
-        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 't' WHERE "
-                       f"content IN ({seg_list}) AND preferred_role = 'm'")
-        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'm' WHERE "
-                       f"content IN ({seg_list}) AND preferred_role = 'p'")
-        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
-                       f"content IN ({seg_list}) AND preferred_role = 't'")
-        dbconn.execSQL(self.conn, "COMMIT")
-
-        # TODO: refactor
-        # TODO: specify log file location?...
-        recoversegOptions = "-r -a"
-        try:
-            cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
-            cmd.run(validateAfter=True)
-        except Exception as e:
-            error_msg = f"Error in gprecoverseg process: {str(e)}"
-            self.logger.error(error_msg)
-
-    def create_config_file(self, moves: List[LogicalMove]) -> str:
-        # TODO: do we really want to use /tmp location?
-        filename = f'/tmp/ggrebalance_move_config_pid{os.getpid()}'
-        with open(filename, 'w') as fp:
-            for move in moves:
-                segment_current_info = move.seg
-                cfg_line = f'{segment_current_info.getSegmentHostName()}|{segment_current_info.getSegmentPort()}|{segment_current_info.getSegmentDataDirectory()} '
-                cfg_line += f'{move.dstHost.hostname}|{move.target_port}|{move.target_datadir}\n'
-                fp.write(cfg_line)
-        return filename
-
-    def shutdown(self) -> None:
-        self.logger.info('Rebalance - shutdown_requested set to True')
-        self.shutdown_requested = True
-
-    def state_is_final(self, state: str) -> bool:
-        return state == self.states[-1]
-
-    # state callbacks start here
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED(self) -> None:
-        self.logger.info('Rebalance - start moving mirrors')
-        self.process_moves(self.moves_mirrors)
-        self.logger.info('Rebalance - end moving mirrors')
-        self.trigger('move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE(self) -> None:
-        if self.primary_segids_to_move:
-            self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED')
-        else:
-            self.trigger('move_to_STATE_REBALANCE_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED(self) -> None:
-        self.execute_role_swaps(self.primary_segids_to_move)
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED(self) -> None:
-        self.logger.info('Rebalance - start moving primaries')
-        self.process_moves(self.moves_primaries)
-        self.logger.info('Rebalance - end moving primaries')
-        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED(self) -> None:
-        self.execute_role_swaps(self.primary_segids_to_move)
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_DONE(self) -> None:
-        self.conn.close()
 
     # state callbacks end here

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -6,12 +6,11 @@ try:
     from gppylib.commands.unix import *
     from gppylib.commands.gp import *
     from gppylib.gplog import *
-    from gppylib.commands.gp import GpMoveMirrors
     from gppylib.system.environment import *
     from gprebalance_modules.planner import *
     from gprebalance_modules.rebalance_schema import RebalanceSchema
     from gppylib.fault_injection import *
-    from gprebalance_modules.shrink import GGShrink, DBNAME
+    from gprebalance_modules.shrink import GGShrink
     from gprebalance_modules.ggrebalance_sm import RebalanceSM
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -128,10 +127,25 @@ class GGRebalanceMainSM:
         self.logger = logger
         self.dburl = dburl
         self.options = options
-        self.shutdown_requested = False
         self.gparray = gpArray
         self.conn = dbconn.connect(
             self.dburl, encoding='UTF8', allowSystemTableMods=True)
+
+        # check if some of the segments are down - it can happen if we're recovering from an
+        # interrupted state, and such segments are left by the interrupted gprecoverseg
+        self.cmd = None
+        dbconn.execSQL(self.conn, "SELECT gp_request_fts_probe_scan()")
+        if 0 != int(dbconn.queryRow(self.conn, f"SELECT COUNT(1) FROM gp_segment_configuration WHERE status='d'")[0]):
+            recoverseg_options = "-a"
+            try:
+                self.cmd = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
+                self.cmd.run(validateAfter=True)
+            except Exception as e:
+                error_msg = f"Error in gprecoverseg process: {str(e)}"
+                self.logger.error(error_msg)
+                raise Exception(error_msg)
+            finally:
+                self.cmd = None
 
         self.rebalance_schema = RebalanceSchema(self.conn)
 
@@ -145,21 +159,12 @@ class GGRebalanceMainSM:
         self.gg_shrink = GGShrink(self.conn, self.rebalance_schema, self.logger, self.options, gpEnv, self.gparray, gpArrayDumpFilename)
         self.gg_rebalance = RebalanceSM(self.conn, self.rebalance_schema, self.logger, self.options, self.gparray)
 
-        # Note: the plan for a shrink later will be provided by the planner component.
-        # But for now we simply create a Plan object from the options directly.
-        # We'll keep this stub till planner is ready.
-        # If shrink_plan is None, we assume that we need to continue previous operation
-        # TODO: remove the comment above?
         self.plan = None
         self.main_state_from_prev_run = self.rebalance_schema.getMainStateFromPreviousRun()
-
 
     def on_every_state(self) -> None:
         self.logger.info(f'MAIN - on_every_state ({self.state})')
 
-        #if self.shutdown_requested:
-        #    self.logger.info('Rebalance was interrupted')
-        #    raise Exception('Rebalance was interrupted')
         if self.state in self.states_logged:
             self.rebalance_schema.storeMainState(self.state)
 
@@ -167,21 +172,20 @@ class GGRebalanceMainSM:
         self.trigger('start')
 
     def shutdown(self) -> None:
-        self.logger.info('GGRebalanceMainSM -  SHUTDOWN')
         need_exit = True
-        #self.shutdown_requested = True
+
         if self.gg_shrink is not None:
-            print('[RELOG] - gg_shrink.shutdown()')
             self.gg_shrink.shutdown()
             need_exit = False
 
         if self.gg_rebalance is not None:
-            print('[RELOG] - gg_rebalance.shutdown()')
             self.gg_rebalance.shutdown()
             need_exit = False
 
+        if self.cmd != None:
+            self.cmd.cancel()
+
         if need_exit:
-            print('[RELOG] - sig_handler exit()')
             sys.exit(1)
 
     # state callbacks start here
@@ -225,8 +229,6 @@ class GGRebalanceMainSM:
 
         if self.options.target_segment_count != None and self.options.show_plan:
             self.logger.info(f"Final plan:\n{self.plan}")
-            #TODO: remove exit?
-            sys.exit(0)
 
         self.trigger('move_to_STATE_PLANNING_DONE')
 
@@ -324,7 +326,7 @@ class GGRebalanceMainSM:
         self.logger.info(f'MAIN STATE: {self.state}')
 
         if self.plan is not None and self.plan.getMoves() is not None:
-            # what if plan is None? for ex., if we recovered after interruption during shrink?...
+            # TODO: what if plan is None? for ex., if we recovered after interruption during shrink?...
             self.gg_rebalance.run(self.plan)
             self.logger.info('Rebalance is complete')
 
@@ -338,7 +340,6 @@ class GGRebalanceMainSM:
     @wrap_state_func_with_faults
     def on_enter_STATE_END(self) -> None:
         self.logger.info(f'MAIN STATE: {self.state}')
-        #TODO: get rid of other connections?...
         self.conn.close()
 
     @wrap_state_func_with_faults

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -9,15 +9,20 @@ try:
     from gppylib.commands.gp import GpMoveMirrors
     from gppylib.system.environment import *
     from gprebalance_modules.planner import *
-    from gprebalance_modules.rebalance_schema import RebalanceSchema
+    from gprebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
     from gppylib.fault_injection import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
 class RebalanceSM:
 
-    states = [
-        'STATE_REBALANCE_START',
+    states_not_logged = [
+        'STATE_REBALANCE_INIT',
+        'STATE_CHECK_PREVIOUS_RUN'
+    ]
+
+    states_main_rebalance_flow = [
+        'STATE_REBALANCE_STARTED',
         'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
         'STATE_REBALANCE_MOVE_MIRRORS_DONE',
         'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
@@ -32,7 +37,17 @@ class RebalanceSM:
     transitions = [
         {
             'trigger': 'start',
-            'source': 'STATE_REBALANCE_START',
+            'source': 'STATE_REBALANCE_INIT',
+            'dest': 'STATE_CHECK_PREVIOUS_RUN'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_STARTED',
+            'source': 'STATE_CHECK_PREVIOUS_RUN',
+            'dest': 'STATE_REBALANCE_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_STARTED',
+            'source': 'STATE_REBALANCE_STARTED',
             'dest': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED'
         },
         {
@@ -78,21 +93,23 @@ class RebalanceSM:
     ]
 
 
-    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any):
+    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any, gpArray: gparray.GpArray):
         self.logger = logger
         self.dburl = dburl
         self.options = options
         self.shutdown_requested = False
+        self.gparray = gpArray
         self.conn = dbconn.connect(
             self.dburl, encoding='UTF8', allowSystemTableMods=True)
 
+        # TODO: move schema creation upper
         self.rebalance_schema = RebalanceSchema(self.conn)
 
         self.machine = Machine(model = self,
                                queued=True,
-                               states = self.states,
+                               states = self.states_main_rebalance_flow + self.states_not_logged,
                                transitions = self.transitions,
-                               initial = 'STATE_REBALANCE_START',
+                               initial = 'STATE_REBALANCE_INIT',
                                before_state_change = 'on_every_state')
 
     def on_every_state(self) -> None:
@@ -102,7 +119,8 @@ class RebalanceSM:
             self.logger.info('Rebalance was interrupted')
             raise Exception('Rebalance was interrupted')
 
-        self.rebalance_schema.storeRebalanceState(self.state)
+        if self.state in self.states_main_rebalance_flow:
+            self.rebalance_schema.storeRebalanceState(self.state)
 
     def run(self, plan: Plan) -> None:
         self.rebalance_plan = plan
@@ -125,7 +143,7 @@ class RebalanceSM:
 
     def process_moves(self, moves: List[LogicalMove]):
         filename = self.create_config_file(moves)
-        gpmovemirrors_options = f' -i {filename}'
+        gpmovemirrors_options = f'-a -i {filename}'
 
         if self.options.batch_size is not None:
             batch_size = self.options.batch_size
@@ -135,12 +153,15 @@ class RebalanceSM:
                 batch_size = MAX_COORDINATOR_NUM_WORKERS
             gpmovemirrors_options += f' -B {batch_size}'
 
+        # TODO: handle continue after interruption in the middle of gpmovemirrors and right after it ended its work
         try:
+            self.logger.info(f'REBALANCE - Running gpmovemirrors {gpmovemirrors_options}')
             cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
             cmd.run(validateAfter=True)
         except Exception as e:
             error_msg = f"Error in gpmovemirrors process: {str(e)}"
             self.logger.error(error_msg)
+            raise Exception(error_msg)
 
         # TODO: cleanup config files        
 
@@ -156,6 +177,8 @@ class RebalanceSM:
                        f"content IN ({seg_list}) AND preferred_role = 't'")
         dbconn.execSQL(self.conn, "COMMIT")
 
+        # TODO: check failure in the middle here
+
         # TODO: refactor
         # TODO: specify log file location?...
         recoversegOptions = "-r -a"
@@ -166,12 +189,25 @@ class RebalanceSM:
             error_msg = f"Error in gprecoverseg process: {str(e)}"
             self.logger.error(error_msg)
 
+    def lookup_seg(self, seg: Segment) -> bool:
+        """ Look up the segment gpdb by address, port, and dataDirectory """
+        # TODO: should we add more checks? equalIgnoringModeAndStatus()?
+        for db in self.gparray.getDbList():
+            if (seg.getSegmentHostName() == db.getSegmentHostName() and
+                seg.getSegmentPort() == db.getSegmentPort() and
+                seg.getSegmentDataDirectory() == db.getSegmentDataDirectory()):
+                return True
+        return False
+
     def create_config_file(self, moves: List[LogicalMove]) -> str:
         # TODO: do we really want to use /tmp location?
         filename = f'/tmp/ggrebalance_move_config_pid{os.getpid()}'
         with open(filename, 'w') as fp:
             for move in moves:
                 segment_current_info = move.seg
+                if not self.lookup_seg(segment_current_info):
+                    self.logger.info(f'Skip segment for gpmovemirrors: {str(segment_current_info)}')
+                    continue
                 cfg_line = f'{segment_current_info.getSegmentHostName()}|{segment_current_info.getSegmentPort()}|{segment_current_info.getSegmentDataDirectory()} '
                 cfg_line += f'{move.dstHost.hostname}|{move.target_port}|{move.target_datadir}\n'
                 fp.write(cfg_line)
@@ -182,9 +218,40 @@ class RebalanceSM:
         self.shutdown_requested = True
 
     def state_is_final(self, state: str) -> bool:
-        return state == self.states[-1]
+        return state == self.states_main_rebalance_flow[-1]
+
+    def get_state_after_interrupt(self, prev_state) -> str:
+        prev_idx = self.states_main_rebalance_flow.index(prev_state)
+        return self.states_main_rebalance_flow[prev_idx + 1]
 
     # state callbacks start here
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_CHECK_PREVIOUS_RUN(self) -> None:
+        self.logger.info('Rebalance - STATE_CHECK_PREVIOUS_RUN')
+
+        state_from_prev_run = self.rebalance_schema.getRebalanceStateFromPreviousRun()
+
+        if state_from_prev_run == STATE_NOT_DEFINED:
+            self.trigger('move_to_STATE_REBALANCE_STARTED')
+        elif self.state_is_final(state_from_prev_run):
+            self.logger.info('Cluster is already rebalanced...')
+        else:
+            # TODO: handle if we need to supply '-C' to gpmovemirrors
+            self.logger.info('Continue interrupted rebalance operation...')
+            self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
+            try:
+                next_state = self.get_state_after_interrupt(state_from_prev_run)
+            except:
+                self.logger.error("Can't determine next state. Try to execute cleanup.")
+                self.trigger('move_to_STATE_ERROR')
+                return
+            # use auto to_«state» method to recover
+            self.trigger(f'to_{next_state}')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_STARTED(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_MOVE_MIRRORS_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED(self) -> None:

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -115,8 +115,6 @@ class RebalanceSM:
                                before_state_change = 'on_every_state')
 
     def on_every_state(self) -> None:
-        self.logger.info('REBALANCE - on_every_state')
-
         if self.shutdown_requested:
             self.logger.info('Rebalance was interrupted')
             raise Exception('Rebalance was interrupted')
@@ -156,7 +154,6 @@ class RebalanceSM:
             gpmovemirrors_options += f' -B {batch_size}'
 
         try:
-            self.logger.info(f'REBALANCE - Running gpmovemirrors {gpmovemirrors_options}')
             self.cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
             self.cmd.run(validateAfter=True)
         except Exception as e:
@@ -197,8 +194,6 @@ class RebalanceSM:
         cnt_role_m = \
             int(dbconn.queryRow(self.conn,
                 f"SELECT COUNT(1) FROM gp_segment_configuration WHERE role = 'm' AND dbid IN ({dbid_list})")[0])
-
-        self.logger.info(f"[DEBUG] dbid_list = ({dbid_list}) cnt_preferred_role_p = {cnt_preferred_role_p}, cnt_role_p = {cnt_role_p}, cnt_preferred_role_m = {cnt_preferred_role_m}, cnt_role_m = {cnt_role_m}")
 
         # if some have 'preferred_role'='p' and some have 'preferred_role'='m' - shouldn't happen, error out, needs to be resolved manually.
         # also some sanity check that there are no other values in catalog except 'm' and 'p' for 'preferred_role'.
@@ -301,8 +296,6 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_CHECK_PREVIOUS_RUN(self) -> None:
-        self.logger.info('Rebalance - STATE_CHECK_PREVIOUS_RUN')
-
         state_from_prev_run = self.rebalance_schema.getRebalanceStateFromPreviousRun()
 
         if state_from_prev_run == STATE_NOT_DEFINED:

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from transitions import Machine
+from enum import Enum
 
 try:
     from gppylib.commands.unix import *
@@ -93,17 +94,17 @@ class RebalanceSM:
     ]
 
 
-    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any, gpArray: gparray.GpArray):
+    class RoleSwapDirection(Enum):
+        PRIMARY_TO_MIRROR = 1
+        MIRROR_TO_PRIMARY = 2
+
+    def __init__(self, conn: dbconn.Connection, schema: RebalanceSchema, logger: Any, options: Any, gpArray: gparray.GpArray):
         self.logger = logger
-        self.dburl = dburl
         self.options = options
         self.shutdown_requested = False
         self.gparray = gpArray
-        self.conn = dbconn.connect(
-            self.dburl, encoding='UTF8', allowSystemTableMods=True)
-
-        # TODO: move schema creation upper
-        self.rebalance_schema = RebalanceSchema(self.conn)
+        self.conn = conn
+        self.rebalance_schema = schema
 
         self.machine = Machine(model = self,
                                queued=True,
@@ -137,7 +138,7 @@ class RebalanceSM:
             else:
                 self.moves_mirrors.append(move)
         
-        self.primary_segids_to_move = [move.seg.getSegmentContentId() for move in self.moves_primaries]
+        self.primary_segments_to_move = [move.seg for move in self.moves_primaries]
 
         self.trigger('start')
 
@@ -153,7 +154,7 @@ class RebalanceSM:
                 batch_size = MAX_COORDINATOR_NUM_WORKERS
             gpmovemirrors_options += f' -B {batch_size}'
 
-        # TODO: handle continue after interruption in the middle of gpmovemirrors and right after it ended its work
+        # TODO: handle continue after interruption in the middle of gpmovemirrors
         try:
             self.logger.info(f'REBALANCE - Running gpmovemirrors {gpmovemirrors_options}')
             cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
@@ -165,29 +166,97 @@ class RebalanceSM:
 
         # TODO: cleanup config files        
 
-    def execute_role_swaps(self, segids: List[SegmentId]):
+    def execute_role_swaps(self, segments_to_move: List[Segment], direction: RoleSwapDirection):
         """Execute multiple role swaps in single gprecoverseg -r call"""
-        dbconn.execSQL(self.conn, "BEGIN")
+
+        assert (len(segments_to_move) > 0)
+
+        segids = [segment.getSegmentContentId() for segment in segments_to_move]
+        dbids = [segment.getSegmentDbId() for segment in segments_to_move]
+
         seg_list = ', '.join(str(seg) for seg in segids)
-        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 't' WHERE "
-                       f"content IN ({seg_list}) AND preferred_role = 'm'")
-        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'm' WHERE "
-                       f"content IN ({seg_list}) AND preferred_role = 'p'")
-        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
-                       f"content IN ({seg_list}) AND preferred_role = 't'")
+        dbid_list = ', '.join(str(dbid) for dbid in dbids)
+
+        dbconn.execSQL(self.conn, "BEGIN")
+
+        # check the current status of 'preferred_role' and 'role' for all requested dbids
+        # in order to recover properly from the previous interrupted run (if any)
+
+        cnt_preferred_role_p = \
+            int(dbconn.queryRow(self.conn,
+                f"SELECT COUNT(1) FROM gp_segment_configuration WHERE preferred_role = 'p' AND dbid IN ({dbid_list})")[0])
+        cnt_role_p = \
+            int(dbconn.queryRow(self.conn,
+                f"SELECT COUNT(1) FROM gp_segment_configuration WHERE role = 'p' AND dbid IN ({dbid_list})")[0])
+        cnt_preferred_role_m = \
+            int(dbconn.queryRow(self.conn,
+                f"SELECT COUNT(1) FROM gp_segment_configuration WHERE preferred_role = 'm' AND dbid IN ({dbid_list})")[0])
+        cnt_role_m = \
+            int(dbconn.queryRow(self.conn,
+                f"SELECT COUNT(1) FROM gp_segment_configuration WHERE role = 'm' AND dbid IN ({dbid_list})")[0])
+
+        self.logger.info(f"[DEBUG] dbid_list = ({dbid_list}) cnt_preferred_role_p = {cnt_preferred_role_p}, cnt_role_p = {cnt_role_p}, cnt_preferred_role_m = {cnt_preferred_role_m}, cnt_role_m = {cnt_role_m}")
+
+        # if some have 'preferred_role'='p' and some have 'preferred_role'='m' - shouldn't happen, error out, needs to be resolved manually.
+        # also some sanity check that there are no other values in catalog except 'm' and 'p' for 'preferred_role'.
+        if ((cnt_preferred_role_p > 0 and cnt_preferred_role_m > 0) or
+             (cnt_preferred_role_p + cnt_preferred_role_m != len(segids))):
+            raise Exception("Error in catalog configuration: "
+                            f"for dbid list ({dbid_list}) "
+                            f"{cnt_preferred_role_p} have 'p' preferred role, and "
+                            f"{cnt_preferred_role_m} have 'm' preferred role")
+
+        is_catalog_update_required = False
+        is_gprecoverseg_required = False
+
+        if direction == self.RoleSwapDirection.PRIMARY_TO_MIRROR:
+            # if all have 'preferred_role'='p' - it is our first run, need to update catalog and launch gprecoverseg
+            if cnt_preferred_role_p == len(segids):
+                is_catalog_update_required = True
+                is_gprecoverseg_required = True
+            else:
+                # if all have 'preferred_role'='m' and not all have 'role'='m' - previous gprecoverseg was interrupted, need to launch it again
+                if cnt_role_m != cnt_preferred_role_m:
+                    is_gprecoverseg_required = True
+                # if all have 'preferred_role'='m' and 'role'='m' - we've done everything on previous interrupted run, nothing to do
+        else:
+            # moving back in MIRROR_TO_PRIMARY direction
+            # if all have 'preferred_role'='m' - it is our first run, need to update catalog and launch gprecoverseg
+            if cnt_preferred_role_m == len(segids):
+                is_catalog_update_required = True
+                is_gprecoverseg_required = True
+            else:
+                # if all have 'preferred_role'='p' and not all have 'role'='p' - previous gprecoverseg was interrupted, need to launch it again
+                if cnt_role_p != cnt_preferred_role_p:
+                    is_gprecoverseg_required = True
+                # if all have 'preferred_role'='p' and 'role'='p' - we've done everything on previous interrupted run, nothing to do
+
+        if is_catalog_update_required:
+            dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 't' WHERE "
+                           f"content IN ({seg_list}) AND preferred_role = 'm'")
+            dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'm' WHERE "
+                           f"content IN ({seg_list}) AND preferred_role = 'p'")
+            dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
+                           f"content IN ({seg_list}) AND preferred_role = 't'")
+
         dbconn.execSQL(self.conn, "COMMIT")
 
-        # TODO: check failure in the middle here
+        # TODO: check failure during gprecoverseg with some delay (and also during movemirrors)
+        if direction == self.RoleSwapDirection.PRIMARY_TO_MIRROR:
+            inject_fault('FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR')
+        else:
+            inject_fault('FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY')
 
-        # TODO: refactor
         # TODO: specify log file location?...
-        recoversegOptions = "-r -a"
-        try:
-            cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
-            cmd.run(validateAfter=True)
-        except Exception as e:
-            error_msg = f"Error in gprecoverseg process: {str(e)}"
-            self.logger.error(error_msg)
+        if is_gprecoverseg_required:
+            recoversegOptions = "-r -a"
+            try:
+                cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
+                cmd.run(validateAfter=True)
+            except Exception as e:
+                error_msg = f"Error in gprecoverseg process: {str(e)}"
+                self.logger.error(error_msg)
+                raise Exception(error_msg)
 
     def lookup_seg(self, seg: Segment) -> bool:
         """ Look up the segment gpdb by address, port, and dataDirectory """
@@ -237,7 +306,6 @@ class RebalanceSM:
         elif self.state_is_final(state_from_prev_run):
             self.logger.info('Cluster is already rebalanced...')
         else:
-            # TODO: handle if we need to supply '-C' to gpmovemirrors
             self.logger.info('Continue interrupted rebalance operation...')
             self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
             try:
@@ -262,14 +330,14 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE(self) -> None:
-        if self.primary_segids_to_move:
+        if self.primary_segments_to_move:
             self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED')
         else:
             self.trigger('move_to_STATE_REBALANCE_DONE')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED(self) -> None:
-        self.execute_role_swaps(self.primary_segids_to_move)
+        self.execute_role_swaps(self.primary_segments_to_move, self.RoleSwapDirection.PRIMARY_TO_MIRROR)
         self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE')
 
     @wrap_state_func_with_faults
@@ -289,7 +357,7 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED(self) -> None:
-        self.execute_role_swaps(self.primary_segids_to_move)
+        self.execute_role_swaps(self.primary_segments_to_move, self.RoleSwapDirection.MIRROR_TO_PRIMARY)
         self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE')
 
     @wrap_state_func_with_faults
@@ -298,6 +366,6 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_DONE(self) -> None:
-        self.conn.close()
+        pass
 
     # state callbacks end here

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -93,7 +93,6 @@ class RebalanceSM:
         }
     ]
 
-
     class RoleSwapDirection(Enum):
         PRIMARY_TO_MIRROR = 1
         MIRROR_TO_PRIMARY = 2

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+from transitions import Machine
+
+try:
+    from gppylib.commands.unix import *
+    from gppylib.commands.gp import *
+    from gppylib.gplog import *
+    from gppylib.commands.gp import GpMoveMirrors
+    from gppylib.system.environment import *
+    from gprebalance_modules.planner import *
+    from gprebalance_modules.rebalance_schema import RebalanceSchema
+    from gppylib.fault_injection import *
+except ImportError as e:
+    sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
+
+class RebalanceSM:
+
+    states = [
+        'STATE_REBALANCE_START',
+        'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
+        'STATE_REBALANCE_MOVE_MIRRORS_DONE',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
+        'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
+        'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
+        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
+        'STATE_REBALANCE_DONE'
+    ]
+
+    transitions = [
+        {
+            'trigger': 'start',
+            'source': 'STATE_REBALANCE_START',
+            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE',
+            'source': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
+            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
+            'source': 'STATE_REBALANCE_MOVE_MIRRORS_DONE',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
+            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE',
+            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
+            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
+            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
+            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
+            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE'
+        },
+        {
+            'trigger': 'move_to_STATE_REBALANCE_DONE',
+            'source': ['STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE', 'STATE_REBALANCE_MOVE_MIRRORS_DONE'],
+            'dest': 'STATE_REBALANCE_DONE'
+        }
+    ]
+
+
+    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any):
+        self.logger = logger
+        self.dburl = dburl
+        self.options = options
+        self.shutdown_requested = False
+        self.conn = dbconn.connect(
+            self.dburl, encoding='UTF8', allowSystemTableMods=True)
+
+        self.rebalance_schema = RebalanceSchema(self.conn)
+
+        self.machine = Machine(model = self,
+                               queued=True,
+                               states = self.states,
+                               transitions = self.transitions,
+                               initial = 'STATE_REBALANCE_START',
+                               before_state_change = 'on_every_state')
+
+    def on_every_state(self) -> None:
+        self.logger.info('REBALANCE - on_every_state')
+
+        if self.shutdown_requested:
+            self.logger.info('Rebalance was interrupted')
+            raise Exception('Rebalance was interrupted')
+
+        self.rebalance_schema.storeRebalanceState(self.state)
+
+    def run(self, plan: Plan) -> None:
+        self.rebalance_plan = plan
+        if not self.rebalance_plan.getMoves():
+            return
+
+        # TODO: we actually change the order of moves.
+        # what if it confuses the user?...
+        self.moves_primaries = []
+        self.moves_mirrors = []
+        for move in self.rebalance_plan.getMoves():
+            if move.seg.isSegmentPrimary() :
+                self.moves_primaries.append(move)
+            else:
+                self.moves_mirrors.append(move)
+        
+        self.primary_segids_to_move = [move.seg.getSegmentContentId() for move in self.moves_primaries]
+
+        self.trigger('start')
+
+    def process_moves(self, moves: List[LogicalMove]):
+        filename = self.create_config_file(moves)
+        gpmovemirrors_options = f' -i {filename}'
+
+        if self.options.batch_size is not None:
+            batch_size = self.options.batch_size
+            # gpmovemirrors has its own limitation for batch size,
+            # need to consider it here.
+            if batch_size > MAX_COORDINATOR_NUM_WORKERS:
+                batch_size = MAX_COORDINATOR_NUM_WORKERS
+            gpmovemirrors_options += f' -B {batch_size}'
+
+        try:
+            cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
+            cmd.run(validateAfter=True)
+        except Exception as e:
+            error_msg = f"Error in gpmovemirrors process: {str(e)}"
+            self.logger.error(error_msg)
+
+        # TODO: cleanup config files        
+
+    def execute_role_swaps(self, segids: List[SegmentId]):
+        """Execute multiple role swaps in single gprecoverseg -r call"""
+        dbconn.execSQL(self.conn, "BEGIN")
+        seg_list = ', '.join(str(seg) for seg in segids)
+        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 't' WHERE "
+                       f"content IN ({seg_list}) AND preferred_role = 'm'")
+        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'm' WHERE "
+                       f"content IN ({seg_list}) AND preferred_role = 'p'")
+        dbconn.execSQL(self.conn, "UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
+                       f"content IN ({seg_list}) AND preferred_role = 't'")
+        dbconn.execSQL(self.conn, "COMMIT")
+
+        # TODO: refactor
+        # TODO: specify log file location?...
+        recoversegOptions = "-r -a"
+        try:
+            cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
+            cmd.run(validateAfter=True)
+        except Exception as e:
+            error_msg = f"Error in gprecoverseg process: {str(e)}"
+            self.logger.error(error_msg)
+
+    def create_config_file(self, moves: List[LogicalMove]) -> str:
+        # TODO: do we really want to use /tmp location?
+        filename = f'/tmp/ggrebalance_move_config_pid{os.getpid()}'
+        with open(filename, 'w') as fp:
+            for move in moves:
+                segment_current_info = move.seg
+                cfg_line = f'{segment_current_info.getSegmentHostName()}|{segment_current_info.getSegmentPort()}|{segment_current_info.getSegmentDataDirectory()} '
+                cfg_line += f'{move.dstHost.hostname}|{move.target_port}|{move.target_datadir}\n'
+                fp.write(cfg_line)
+        return filename
+
+    def shutdown(self) -> None:
+        self.logger.info('Rebalance - shutdown_requested set to True')
+        self.shutdown_requested = True
+
+    def state_is_final(self, state: str) -> bool:
+        return state == self.states[-1]
+
+    # state callbacks start here
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED(self) -> None:
+        self.logger.info('Rebalance - start moving mirrors')
+        self.process_moves(self.moves_mirrors)
+        self.logger.info('Rebalance - end moving mirrors')
+        self.trigger('move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE(self) -> None:
+        if self.primary_segids_to_move:
+            self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED')
+        else:
+            self.trigger('move_to_STATE_REBALANCE_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED(self) -> None:
+        self.execute_role_swaps(self.primary_segids_to_move)
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED(self) -> None:
+        self.logger.info('Rebalance - start moving primaries')
+        self.process_moves(self.moves_primaries)
+        self.logger.info('Rebalance - end moving primaries')
+        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED(self) -> None:
+        self.execute_role_swaps(self.primary_segids_to_move)
+        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_DONE(self) -> None:
+        self.conn.close()
+
+    # state callbacks end here

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -105,6 +105,7 @@ class RebalanceSM:
         self.gparray = gpArray
         self.conn = conn
         self.rebalance_schema = schema
+        self.cmd = None
 
         self.machine = Machine(model = self,
                                queued=True,
@@ -154,17 +155,19 @@ class RebalanceSM:
                 batch_size = MAX_COORDINATOR_NUM_WORKERS
             gpmovemirrors_options += f' -B {batch_size}'
 
-        # TODO: handle continue after interruption in the middle of gpmovemirrors
         try:
             self.logger.info(f'REBALANCE - Running gpmovemirrors {gpmovemirrors_options}')
-            cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
-            cmd.run(validateAfter=True)
+            self.cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
+            self.cmd.run(validateAfter=True)
         except Exception as e:
             error_msg = f"Error in gpmovemirrors process: {str(e)}"
             self.logger.error(error_msg)
             raise Exception(error_msg)
+        finally:
+            self.cmd = None
 
-        # TODO: cleanup config files        
+        if os.path.exists(filename):
+            os.remove(filename)
 
     def execute_role_swaps(self, segments_to_move: List[Segment], direction: RoleSwapDirection):
         """Execute multiple role swaps in single gprecoverseg -r call"""
@@ -241,7 +244,6 @@ class RebalanceSM:
 
         dbconn.execSQL(self.conn, "COMMIT")
 
-        # TODO: check failure during gprecoverseg with some delay (and also during movemirrors)
         if direction == self.RoleSwapDirection.PRIMARY_TO_MIRROR:
             inject_fault('FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR')
         else:
@@ -249,14 +251,16 @@ class RebalanceSM:
 
         # TODO: specify log file location?...
         if is_gprecoverseg_required:
-            recoversegOptions = "-r -a"
+            recoverseg_options = "-r -a"
             try:
-                cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
-                cmd.run(validateAfter=True)
+                self.cmd = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
+                self.cmd.run(validateAfter=True)
             except Exception as e:
                 error_msg = f"Error in gprecoverseg process: {str(e)}"
                 self.logger.error(error_msg)
                 raise Exception(error_msg)
+            finally:
+                self.cmd = None
 
     def lookup_seg(self, seg: Segment) -> bool:
         """ Look up the segment gpdb by address, port, and dataDirectory """
@@ -269,7 +273,6 @@ class RebalanceSM:
         return False
 
     def create_config_file(self, moves: List[LogicalMove]) -> str:
-        # TODO: do we really want to use /tmp location?
         filename = f'/tmp/ggrebalance_move_config_pid{os.getpid()}'
         with open(filename, 'w') as fp:
             for move in moves:
@@ -283,8 +286,9 @@ class RebalanceSM:
         return filename
 
     def shutdown(self) -> None:
-        self.logger.info('Rebalance - shutdown_requested set to True')
         self.shutdown_requested = True
+        if self.cmd != None:
+            self.cmd.cancel()
 
     def state_is_final(self, state: str) -> bool:
         return state == self.states_main_rebalance_flow[-1]

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -154,8 +154,8 @@ class RebalanceSM:
             self.cmd = GpMoveMirrors("Running gpmovemirrors", options=gpmovemirrors_options)
             self.cmd.run(validateAfter=True)
         except Exception as e:
-            error_msg = f"Error in gpmovemirrors process: {str(e)}"
-            self.logger.error(error_msg)
+            logger.error(str(e))
+            error_msg = f"Failed to execute 'gpmovemirrors {gpmovemirrors_options}'"
             raise Exception(error_msg)
         finally:
             self.cmd = None
@@ -247,8 +247,8 @@ class RebalanceSM:
                 self.cmd = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
                 self.cmd.run(validateAfter=True)
             except Exception as e:
-                error_msg = f"Error in gprecoverseg process: {str(e)}"
-                self.logger.error(error_msg)
+                logger.error(str(e))
+                error_msg = f"Failed to execute 'gprecoverseg {recoverseg_options}'"
                 raise Exception(error_msg)
             finally:
                 self.cmd = None

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -126,8 +126,6 @@ class RebalanceSM:
         if not self.rebalance_plan.getMoves():
             return
 
-        # TODO: we actually change the order of moves.
-        # what if it confuses the user?...
         self.moves_primaries = []
         self.moves_mirrors = []
         for move in self.rebalance_plan.getMoves():
@@ -243,7 +241,6 @@ class RebalanceSM:
         else:
             inject_fault('FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY')
 
-        # TODO: specify log file location?...
         if is_gprecoverseg_required:
             recoverseg_options = "-r -a"
             try:
@@ -258,7 +255,6 @@ class RebalanceSM:
 
     def lookup_seg(self, seg: Segment) -> bool:
         """ Look up the segment gpdb by address, port, and dataDirectory """
-        # TODO: should we add more checks? equalIgnoringModeAndStatus()?
         for db in self.gparray.getDbList():
             if (seg.getSegmentHostName() == db.getSegmentHostName() and
                 seg.getSegmentPort() == db.getSegmentPort() and

--- a/gpMgmt/bin/gprebalance_modules/planner.py
+++ b/gpMgmt/bin/gprebalance_modules/planner.py
@@ -584,25 +584,6 @@ class Planner:
         return target_hostname_list, add_hostname_list, remove_hostname_list
                 
     def plan(self) -> Plan:
-        # TODO Remove with future development. Temp code before state machine is implemented.
-        from gprebalance_modules.rebalance_schema import RebalanceSchema
-        conn = dbconn.connect(self.dburl, encoding='UTF8')
-        rebalance_schema = RebalanceSchema(conn)
-        if rebalance_schema.schemaExists():
-            state_from_prev_run = rebalance_schema.getShrinkStateFromPreviousRun()
-            if state_from_prev_run in ['STATE_SHRINK_TABLES_DONE',
-                                       'STATE_SHRINK_CATALOG_STARTED',
-                                       'STATE_SHRINK_CATALOG_DONE',
-                                       'STATE_SHRINK_SEGMENTS_STOP_STARTED',
-                                       'STATE_SHRINK_SEGMENTS_STOP_DONE',
-                                       'STATE_SHRINK_DONE']:
-                plan = ShrinkPlan([])
-                plan.setTargetSegmentCount(self.options.target_segment_count)
-                conn.close()
-                return plan
-        conn.close()
-        
-        # Planning starts here
         plan = Plan()
 
         self.validate_segment_status()

--- a/gpMgmt/bin/gprebalance_modules/planner.py
+++ b/gpMgmt/bin/gprebalance_modules/planner.py
@@ -589,7 +589,7 @@ class Planner:
         conn = dbconn.connect(self.dburl, encoding='UTF8')
         rebalance_schema = RebalanceSchema(conn)
         if rebalance_schema.schemaExists():
-            state_from_prev_run = rebalance_schema.getStateFromPreviousRun()
+            state_from_prev_run = rebalance_schema.getShrinkStateFromPreviousRun()
             if state_from_prev_run in ['STATE_SHRINK_TABLES_DONE',
                                        'STATE_SHRINK_CATALOG_STARTED',
                                        'STATE_SHRINK_CATALOG_DONE',

--- a/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
@@ -4,6 +4,8 @@ from psycopg2.extensions import cursor
 from gppylib.db import dbconn
 from gprebalance_modules.planner import Plan, deserializePlan
 
+STATE_NOT_DEFINED = 'not defined'
+
 def get_table_distr_segment_count(conn: dbconn.Connection, schema_name: str, table_name: str) -> int:
     row = dbconn.queryRow(conn,
                           f'''SELECT p.numsegments
@@ -13,6 +15,10 @@ def get_table_distr_segment_count(conn: dbconn.Connection, schema_name: str, tab
     return int(row[0])
 
 class RebalanceSchema:
+    STATE_CATEGORY_SHRINK = 'SHRINK'
+    STATE_CATEGORY_REBALANCE = 'REBALANCE'
+    STATE_CATEGORY_MAIN = 'MAIN'
+
     def __init__(self, conn: dbconn.Connection):
         self.schema_name = 'ggrebalance'
         self.rebalance_status = 'rebalance_status'
@@ -25,7 +31,7 @@ class RebalanceSchema:
         dbconn.execSQL(self.conn, f'CREATE SCHEMA {self.schema_name}')
         dbconn.execSQL(self.conn,
                        f'''CREATE TABLE {self.schema_name}.{self.rebalance_status}
-                       (status TEXT, updated TIMESTAMP WITH TIME ZONE)
+                       (state TEXT, state_category TEXT, updated TIMESTAMP WITH TIME ZONE)
                        DISTRIBUTED REPLICATED''')
         dbconn.execSQL(self.conn,
                        f'''CREATE TABLE {self.schema_name}.{self.table_rebalance_status_detail}
@@ -70,11 +76,21 @@ class RebalanceSchema:
         row = dbconn.queryRow(self.conn, f"SELECT COUNT(1) FROM pg_namespace WHERE nspname = '{self.schema_name}'")
         return int(row[0]) == 1
 
-    def getStateFromPreviousRun(self) -> str:
-        cursor = dbconn.query(self.conn, f'SELECT status FROM {self.schema_name}.{self.rebalance_status} ORDER BY updated DESC LIMIT 1')
-        if cursor.rowcount > 0:
-            return str(cursor.fetchone()[0])
-        return 'not defined'
+    def getStateFromPreviousRun(self, state_category: str) -> str:
+        if self.schemaExists():
+            cursor = dbconn.query(self.conn, f"SELECT state FROM {self.schema_name}.{self.rebalance_status} WHERE state_category = '{state_category}' ORDER BY updated DESC LIMIT 1")
+            if cursor.rowcount > 0:
+                return str(cursor.fetchone()[0])
+        return STATE_NOT_DEFINED
+
+    def getShrinkStateFromPreviousRun(self) -> str:
+        return self.getStateFromPreviousRun(self.STATE_CATEGORY_SHRINK)
+
+    def getRebalanceStateFromPreviousRun(self) -> str:
+        return self.getStateFromPreviousRun(self.STATE_CATEGORY_REBALANCE)
+
+    def getMainStateFromPreviousRun(self) -> str:
+        return self.getStateFromPreviousRun(self.STATE_CATEGORY_MAIN)
 
     def rebalanceSchema(self, target_segment_count: int) -> None:
         # Before rebalancing check if the tables are already rebalanced
@@ -94,11 +110,20 @@ class RebalanceSchema:
                            f'''ALTER TABLE "{self.schema_name}"."{self.saved_plan}"
                            REBALANCE {target_segment_count}''')
 
-    def storeState(self, state: str) -> None:
+    def storeState(self, state: str, state_category: str) -> None:
         if self.schemaExists():
             dbconn.execSQL(self.conn,
                            f'''INSERT INTO {self.schema_name}.{self.rebalance_status}
-                           VALUES ('{state}', NOW())''')
+                           VALUES ('{state}', '{state_category}', NOW())''')
+
+    def storeShrinkState(self, state: str) -> None:
+        self.storeState(state, self.STATE_CATEGORY_SHRINK)
+
+    def storeRebalanceState(self, state: str) -> None:
+        self.storeState(state, self.STATE_CATEGORY_REBALANCE)
+
+    def storeMainState(self, state: str) -> None:
+        self.storeState(state, self.STATE_CATEGORY_MAIN)
 
     def clearTablesToRebalanceWithStatus(self, status: str) -> None:
         dbconn.execSQL(self.conn,

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -291,8 +291,8 @@ class GGShrink:
         if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
             self.rebalance_schema.storeShrinkState(self.state)
 
-    def cleanup(self, prev_run_complete: bool) -> None:
-        if not prev_run_complete:
+    def cleanup(self, prev_run_was_complete: bool) -> None:
+        if not prev_run_was_complete:
             self.logger.warning("ggrebalance hasn't finished shrink process properly. Previous run was interrupted. "
                                 "Some unbalanced tables can still exist.")
 

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -17,7 +17,7 @@ try:
     from gppylib.commands.gp import SEGMENT_STOP_TIMEOUT_DEFAULT, SegmentStop
     from gppylib.system.environment import *
     from gprebalance_modules.planner import *
-    from gprebalance_modules.rebalance_schema import RebalanceSchema
+    from gprebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -52,12 +52,9 @@ class GGShrink:
 
     states = [
         'STATE_START',
-        'STATE_OPTIONS_VALIDATION',
         'STATE_CHECK_PREVIOUS_RUN',
         'STATE_END',
-        'STATE_CLEANUP',
         'STATE_ERROR',
-        'STATE_ROLLBACK',
         'STATE_END_FROM_ROLLBACK'
     ]
 
@@ -68,8 +65,6 @@ class GGShrink:
     # so they are reflected in the status table inside the schema,
     # and we can re-enter the interrupted state.
     states_main_shrink_flow = [
-        'STATE_SETUP_SHRINK_SCHEMA_STARTED',
-        'STATE_SETUP_SHRINK_SCHEMA_DONE',
         'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED',
         'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE',
         'STATE_PREPARE_SHRINK_SCHEMA_STARTED',
@@ -102,36 +97,11 @@ class GGShrink:
         {
             'trigger': 'start',
             'source': 'STATE_START',
-            'dest': 'STATE_OPTIONS_VALIDATION'
-        },
-        {
-            'trigger': 'move_to_STATE_CLEANUP',
-            'source': 'STATE_OPTIONS_VALIDATION',
-            'dest': 'STATE_CLEANUP'
-        },
-        {
-            'trigger': 'move_to_STATE_ROLLBACK',
-            'source': 'STATE_OPTIONS_VALIDATION',
-            'dest': 'STATE_ROLLBACK'
-        },
-        {
-            'trigger': 'move_to_STATE_CHECK_PREVIOUS_RUN',
-            'source': ['STATE_OPTIONS_VALIDATION', 'STATE_ROLLBACK'],
             'dest': 'STATE_CHECK_PREVIOUS_RUN'
         },
         {
-            'trigger': 'move_to_STATE_SETUP_SHRINK_SCHEMA_STARTED',
-            'source': 'STATE_CHECK_PREVIOUS_RUN',
-            'dest': 'STATE_SETUP_SHRINK_SCHEMA_STARTED'
-        },
-        {
-            'trigger': 'move_to_STATE_SETUP_SHRINK_SCHEMA_DONE',
-            'source': 'STATE_SETUP_SHRINK_SCHEMA_STARTED',
-            'dest': 'STATE_SETUP_SHRINK_SCHEMA_DONE'
-        },
-        {
             'trigger': 'move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED',
-            'source': 'STATE_SETUP_SHRINK_SCHEMA_DONE',
+            'source': 'STATE_CHECK_PREVIOUS_RUN',
             'dest':  'STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED'
         },
         {
@@ -186,7 +156,7 @@ class GGShrink:
         },
         {
             'trigger': 'move_to_STATE_END',
-            'source': ['STATE_SHRINK_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_CLEANUP', 'STATE_END_FROM_ROLLBACK'],
+            'source': ['STATE_SHRINK_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_END_FROM_ROLLBACK'],
             'dest': 'STATE_END'
         },
         {
@@ -231,7 +201,7 @@ class GGShrink:
         },
         {
             'trigger': 'move_to_STATE_END_FROM_ROLLBACK',
-            'source': ['STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE', 'STATE_ROLLBACK', 'STATE_CHECK_PREVIOUS_RUN'],
+            'source': ['STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE', 'STATE_CHECK_PREVIOUS_RUN', 'STATE_START'],
             'dest': 'STATE_END_FROM_ROLLBACK'
         },
         {
@@ -298,100 +268,114 @@ class GGShrink:
         assert self.state in self.states + self.states_main_shrink_flow + self.states_rollback_flow
 
         if self.state in self.states_main_shrink_flow + self.states_rollback_flow:
-            self.rebalance_schema.storeState(self.state)
+            self.rebalance_schema.storeShrinkState(self.state)
+
+    def cleanup(self, prev_run_complete: bool) -> None:
+        if not prev_run_complete:
+            self.logger.warning("ggrebalance hasn't finished shrink process properly. Previous run was interrupted. "
+                                "Some unbalanced tables can still exist.")
+
+            # get default num segments
+            dbconn.execSQL(self.conn, 'BEGIN')
+            dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+            row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set()')
+            numsegments_is_set = bool(row[0])
+            dbconn.execSQL(self.conn, 'END')
+
+            if numsegments_is_set:
+                self.logger.warning('Current numsegments is not equal to default value.')
+                self.logger.info('Suggestion: explicitly reset the value before cleanup. Note: cluster restart will implicitly reset the value.')
+
+            if (self.options.interactive and
+                not userinput.ask_yesno(None, "\nContinue with cleanup?", 'Y')):
+                self.logger.info('Cleanup was interrupted...')
+                return
+
+            if (numsegments_is_set and
+                (not self.options.interactive or userinput.ask_yesno(None, "\nReset numsegments to default?", 'Y'))):
+                dbconn.execSQL(self.conn, 'BEGIN')
+                dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
+                dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
+                dbconn.execSQL(self.conn, 'COMMIT')
+                self.logger.info('Reset numsegments to default is done.')
+
+        if os.path.exists(self.gparray_dump_file):
+            os.remove(self.gparray_dump_file)
+
+    def rollback(self) -> None:
+        if not self.rebalance_schema.schemaExists():
+            self.logger.info("Rebalance schema doesn't exist. Can't perform rollback.")
+            self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+            return
+        else:
+            state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
+            if state_from_prev_run != STATE_NOT_DEFINED:
+                # check maybe the state is the final one
+                if self.state_is_final(state_from_prev_run):
+                    self.logger.info("Previous run was completed successfully. Can't perform rollback.")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                    return
+
+                if not self.state_can_rollback(state_from_prev_run) or self.is_gp_segment_configuration_shrinked():
+                    self.logger.info("Can't perform rollback as the catalog is already updated")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                    return
+
+        self.trigger('start')
+
+    def state_is_final(self, state: str) -> bool:
+        return state == self.states_main_shrink_flow[-1]
 
     # state callbacks start here
-    @wrap_state_func_with_faults
-    def on_enter_STATE_OPTIONS_VALIDATION(self) -> None:
-        if self.options.clean_required:
-            self.trigger('move_to_STATE_CLEANUP')
-        elif self.options.rollback_required:
-            self.trigger('move_to_STATE_ROLLBACK')
-        else:
-            self.trigger('move_to_STATE_CHECK_PREVIOUS_RUN')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_CHECK_PREVIOUS_RUN(self) -> None:
-        # check if rebalance schema exists
-        # and whether we can get the state where we stopped in previous run
+        assert self.rebalance_schema.schemaExists()
+        # check whether we can get the state where we stopped in previous run
         # in order to proceed from the same point
-        if self.rebalance_schema.schemaExists():
-            self.logger.info('Rebalance schema exists')
-            state_from_prev_run = self.rebalance_schema.getStateFromPreviousRun()
-            # check maybe the state is the final one
-            if state_from_prev_run == self.states_main_shrink_flow[-1]:
-                if self.options.rollback_required:
-                    self.logger.info(f"Previous run was completed successfully. Can't perform rollback.")
-                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-                else:
-                    self.logger.error('Previous run was completed successfully. Please execute cleanup before a new run.')
-                    self.trigger('move_to_STATE_END')
-                return
-
-            elif self.shrink_plan != None:
-                self.logger.error("Can't start a new operation, because the previous one was interrupted. "
-                                  "Please try to launch again without a plan to continue from the interrupted state, "
-                                  "or use '--rollback' or '--cleanup' options.")
+        state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
+        # check maybe the state is the final one
+        if self.state_is_final(state_from_prev_run):
+            if self.options.rollback_required:
+                self.logger.info(f"Previous run was completed successfully. Can't perform rollback.")
+                self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+        else:
+            self.shrink_plan = self.rebalance_schema.retrieveSavedPlan()
+            if self.shrink_plan == None:
+                self.logger.error('No saved plan found. Try to execute cleanup.')
                 self.trigger('move_to_STATE_ERROR')
                 return
 
+            if state_from_prev_run in self.states_rollback_flow:
+                self.logger.info('Continue interrupted rollback operation...')
+                self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
+                try:
+                    next_state = self.states_rollback_flow[ self.states_rollback_flow.index(state_from_prev_run) + 1 ]
+                except:
+                    self.logger.error("Can't determine next rollback state")
+                    self.trigger('move_to_STATE_ERROR')
+                    return
             else:
-                self.shrink_plan = self.rebalance_schema.retrieveSavedPlan()
-                if self.shrink_plan == None:
-                    self.logger.error('No saved plan found. Try to execute cleanup.')
+                if self.options.rollback_required:
+                    self.trigger('move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START')
+                    return
+
+                # no state so far, so start from the beginning
+                if state_from_prev_run == STATE_NOT_DEFINED:
+                    self.trigger('move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
+                    return
+
+                self.logger.info('Continue interrupted operation...')
+                self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
+                try:
+                    next_state = self.get_state_after_interrupt(state_from_prev_run)
+                except:
+                    self.logger.error("Can't determine next state. Try to execute cleanup.")
                     self.trigger('move_to_STATE_ERROR')
                     return
 
-                if state_from_prev_run in self.states_rollback_flow:
-                    self.logger.info('Continue interrupted rollback operation...')
-                    self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
-                    try:
-                        next_state = self.states_rollback_flow[ self.states_rollback_flow.index(state_from_prev_run) + 1 ]
-                    except:
-                        self.logger.error("Can't determine next rollback state")
-                        self.trigger('move_to_STATE_ERROR')
-                        return
-                else:
-                    if self.options.rollback_required:
-                        self.trigger('move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START')
-                        return
-
-                    self.logger.info('Continue interrupted operation...')
-                    self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
-                    try:
-                        next_state = self.get_state_after_interrupt(state_from_prev_run)
-                    except:
-                        self.logger.error("Can't determine next state. Try to execute cleanup.")
-                        self.trigger('move_to_STATE_ERROR')
-                        return
-
-                # use auto to_«state» method to recover
-                self.trigger(f'to_{next_state}')
-        else:
-            if self.shrink_plan == None:
-                self.logger.error("Rebalance schema doesn't exists and no shrink plan is supplied. Please specify shrink plan.")
-                self.trigger('move_to_STATE_ERROR')
-                return
-            if self.gparray.get_segment_count() < self.shrink_plan.target_segment_count:
-                logger.error('Target segment count (%s) > current segment count (%s).\n'
-                             'Currently only shrink is supported (target segment count < current segment count).'
-                              % (self.shrink_plan.target_segment_count, self.gparray.get_segment_count()))
-                self.trigger('move_to_STATE_ERROR')
-                return
-
-            self.trigger('move_to_STATE_SETUP_SHRINK_SCHEMA_STARTED')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED(self) -> None:
-        # Create schema and status tables.
-        # It will also save plan in order to use it for recovering after interruption
-        self.rebalance_schema.createSchema(self.shrink_plan)
-        self.trigger('move_to_STATE_SETUP_SHRINK_SCHEMA_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE(self) -> None:
-        self.logger.info(f'Created "{self.rebalance_schema.getSchemaName()}" schema')
-        self.trigger('move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
+            # use auto to_«state» method to recover
+            self.trigger(f'to_{next_state}')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED(self) -> None:
@@ -506,76 +490,13 @@ class GGShrink:
         self.trigger('move_to_STATE_END')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_CLEANUP(self) -> None:
-        if not self.rebalance_schema.schemaExists():
-            self.logger.info(f"Rebalance schema doesn't exist. Cleanup is not required.")
-        else:
-            state_from_prev_run = self.rebalance_schema.getStateFromPreviousRun()
-            if state_from_prev_run != self.states_main_shrink_flow[-1]:
-                self.logger.warning("ggrebalance hasn't finished shrink process properly. Previous run was interrupted. "
-                                    "Some unbalanced tables can still exist.")
-
-                # get default num segments
-                dbconn.execSQL(self.conn, 'BEGIN')
-                dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
-                row = dbconn.queryRow(self.conn, 'SELECT gp_toolkit.gp_rebalance_numsegments_is_set()')
-                numsegments_is_set = bool(row[0])
-                dbconn.execSQL(self.conn, 'END')
-
-                if numsegments_is_set:
-                    self.logger.warning('Current numsegments is not equal to default value.')
-                    self.logger.info('Suggestion: explicitly reset the value before cleanup. Note: cluster restart will implicitly reset the value.')
-
-                if (self.options.interactive and
-                    not userinput.ask_yesno(None, "\nContinue with cleanup?", 'Y')):
-                    self.logger.info('Cleanup was interrupted...')
-                    self.trigger('move_to_STATE_END')
-                    return
-
-                if (numsegments_is_set and
-                    (not self.options.interactive or userinput.ask_yesno(None, "\nReset numsegments to default?", 'Y'))):
-                    dbconn.execSQL(self.conn, 'BEGIN')
-                    dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
-                    dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
-                    dbconn.execSQL(self.conn, 'COMMIT')
-                    self.logger.info('Reset numsegments to default is done.')
-
-            if os.path.exists(self.gparray_dump_file):
-                os.remove(self.gparray_dump_file)
-            self.rebalance_schema.dropSchema()
-            self.logger.info('Cleanup is complete')
-        self.trigger('move_to_STATE_END')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_ROLLBACK(self) -> None:
-        if not self.rebalance_schema.schemaExists():
-            self.logger.info("Rebalance schema doesn't exist. Can't perform rollback.")
-            self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-            return
-        else:
-            state_from_prev_run = self.rebalance_schema.getStateFromPreviousRun()
-            if state_from_prev_run != 'not defined':
-                # check maybe the state is the final one
-                if state_from_prev_run == self.states_main_shrink_flow[-1]:
-                    self.logger.info("Previous run was completed successfully. Can't perform rollback.")
-                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-                    return
-
-                if not self.state_can_rollback(state_from_prev_run) or self.is_gp_segment_configuration_shrinked():
-                    self.logger.info("Can't perform rollback as the catalog is already updated")
-                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-                    return
-
-        self.trigger('move_to_STATE_CHECK_PREVIOUS_RUN')
-
-    @wrap_state_func_with_faults
     def on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START(self) -> None:
         dbconn.execSQL(self.conn, 'BEGIN')
         dbconn.execSQL(self.conn, 'SELECT gp_expand_lock_catalog()')
         dbconn.execSQL(self.conn, 'SELECT gp_toolkit.gp_reset_rebalance_numsegments()')
         # Store state here in case we fail before we enter 'on_every_state()'
         # because after COMMIT we are on a one-way road of rollback.
-        self.rebalance_schema.storeState(self.state)
+        self.rebalance_schema.storeShrinkState(self.state)
         dbconn.execSQL(self.conn, 'COMMIT')
 
         self.trigger('move_to_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_DONE')

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -211,19 +211,18 @@ class GGShrink:
         }
     ]
 
-    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any, gpEnv: GpCoordinatorEnvironment, gpArray: gparray.GpArray, gpArrayDumpFilename: str) -> None:
+    def __init__(self, conn: dbconn.Connection,
+                 schema: RebalanceSchema, logger: Any, options: Any, gpEnv: GpCoordinatorEnvironment, gpArray: gparray.GpArray, gpArrayDumpFilename: str) -> None:
         self.logger = logger
-        self.dburl = dburl
         self.options = options
         self.gpEnv = gpEnv
-        self.conn = dbconn.connect(
-            self.dburl, encoding='UTF8', allowSystemTableMods=True)
+        self.conn = conn
         self.shutdown_requested = False
         self.workers_for_tables_rebalance = None
         self.workers_for_segment_stop = None
         self.gparray = gpArray
         self.gparray_dump_file = gpArrayDumpFilename
-        self.rebalance_schema = RebalanceSchema(self.conn)
+        self.rebalance_schema = schema
         self.shrink_plan = None
         self.needs_repopulate = False
         self.dumped_gparray = gparray.GpArray.initFromFile(self.gparray_dump_file) if os.path.exists(self.gparray_dump_file) else None
@@ -538,7 +537,7 @@ class GGShrink:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_END(self) -> None:
-        self.conn.close()
+        pass
 
     @wrap_state_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:

--- a/gpMgmt/bin/gprebalance_modules/shrink.py
+++ b/gpMgmt/bin/gprebalance_modules/shrink.py
@@ -239,6 +239,28 @@ class GGShrink:
         self.shrink_plan = shrinkPlan
         self.trigger('start')
 
+    def rollback(self, shrinkPlan: ShrinkPlan) -> None:
+        self.shrink_plan = shrinkPlan
+        if not self.rebalance_schema.schemaExists():
+            self.logger.info("Rebalance schema doesn't exist. Can't perform rollback.")
+            self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+            return
+        else:
+            state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
+            if state_from_prev_run != STATE_NOT_DEFINED:
+                # check maybe the state is the final one
+                if self.state_is_final(state_from_prev_run):
+                    self.logger.info("Previous run was completed successfully. Can't perform rollback.")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                    return
+
+                if not self.state_can_rollback(state_from_prev_run) or self.is_gp_segment_configuration_shrinked():
+                    self.logger.info("Can't perform rollback as the catalog is already updated")
+                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
+                    return
+
+        self.trigger('start')
+
     def get_state_after_interrupt(self, prev_state) -> str:
         prev_idx = self.states_main_shrink_flow.index(prev_state)
         lower = self.states_main_shrink_flow.index('STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
@@ -302,27 +324,6 @@ class GGShrink:
         if os.path.exists(self.gparray_dump_file):
             os.remove(self.gparray_dump_file)
 
-    def rollback(self) -> None:
-        if not self.rebalance_schema.schemaExists():
-            self.logger.info("Rebalance schema doesn't exist. Can't perform rollback.")
-            self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-            return
-        else:
-            state_from_prev_run = self.rebalance_schema.getShrinkStateFromPreviousRun()
-            if state_from_prev_run != STATE_NOT_DEFINED:
-                # check maybe the state is the final one
-                if self.state_is_final(state_from_prev_run):
-                    self.logger.info("Previous run was completed successfully. Can't perform rollback.")
-                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-                    return
-
-                if not self.state_can_rollback(state_from_prev_run) or self.is_gp_segment_configuration_shrinked():
-                    self.logger.info("Can't perform rollback as the catalog is already updated")
-                    self.trigger('move_to_STATE_END_FROM_ROLLBACK')
-                    return
-
-        self.trigger('start')
-
     def state_is_final(self, state: str) -> bool:
         return state == self.states_main_shrink_flow[-1]
 
@@ -340,14 +341,8 @@ class GGShrink:
                 self.logger.info(f"Previous run was completed successfully. Can't perform rollback.")
                 self.trigger('move_to_STATE_END_FROM_ROLLBACK')
         else:
-            self.shrink_plan = self.rebalance_schema.retrieveSavedPlan()
-            if self.shrink_plan == None:
-                self.logger.error('No saved plan found. Try to execute cleanup.')
-                self.trigger('move_to_STATE_ERROR')
-                return
-
             if state_from_prev_run in self.states_rollback_flow:
-                self.logger.info('Continue interrupted rollback operation...')
+                self.logger.info('Continue interrupted shrink rollback operation...')
                 self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
                 try:
                     next_state = self.states_rollback_flow[ self.states_rollback_flow.index(state_from_prev_run) + 1 ]
@@ -365,7 +360,7 @@ class GGShrink:
                     self.trigger('move_to_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED')
                     return
 
-                self.logger.info('Continue interrupted operation...')
+                self.logger.info('Continue interrupted shrink operation...')
                 self.logger.info(f"Previous run stopped after state '{state_from_prev_run}', trying to continue from the next state...")
                 try:
                     next_state = self.get_state_after_interrupt(state_from_prev_run)

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -22,7 +22,7 @@ def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
                     'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter', 'ggrebalance']
+                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -125,7 +125,7 @@ def before_scenario(context, scenario):
 
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
                     'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter', 'ggrebalance']
+                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -158,7 +158,7 @@ def after_scenario(context, scenario):
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpinitstandby',
                     'gpconfig', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter', 'ggrebalance']
+                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -1,0 +1,81 @@
+@ggrebalance_basics
+Feature: ggrebalance behave tests
+
+    Scenario Outline: Validate incompatible option combinations
+        Given a standard local demo cluster is running
+        When the user runs "ggrebalance <options>"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "<error_message>" to stdout
+        Given <run_status>
+        
+        Examples: Mutually exclusive options
+          | options                                                     | error_message                                                         | run_status |
+          | --target-hosts sdw1,sdw2 --target-hosts-file /tmp/hosts.txt | Can't use together options '--target-hosts' and '--target-hosts-file' |  stub |
+          | --target-hosts sdw1,sdw2 --add-hosts sdw3                   | Can't use together options '--target-hosts' and '--add-hosts'         | stub       |
+          | --target-hosts sdw1,sdw2 --remove-hosts sdw3                | Can't use together options '--target-hosts' and '--remove-hosts'      | stub       |
+          | --add-hosts sdw3 --add-hosts-file /tmp/add.txt              | Can't use together options '--add-hosts' and '--add-hosts-file'       | stub       |
+          | --remove-hosts sdw3 --remove-hosts-file /tmp/rm.txt         | Can't use together options '--remove-hosts' and '--remove-hosts-file' | stub       |
+          | --add-hosts sdw3 --remove-hosts sdw3                        | Can't use together options '--add-hosts' and '--remove-hosts'         | stub       |
+          | --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' --target-datadirs-file /tmp/datadirs.txt | Can't use together options '--target-datadirs' and '--target-datadirs-file' | stub |
+          | --mirror-mode grouped --skip-rebalance                      | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |
+          | -m spread --skip-rebalance                                  | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |
+          | -c --target-hosts sdw1,sdw2                                 | Can't use together options '--clean-required' and '--target-hosts'    | stub       |
+          | -c --add-hosts sdw3                                         | Can't use together options '--clean-required' and '--add-hosts'       | stub       |
+          | -c --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' | Can't use together options '--clean-required' and '--target-datadirs'   | stub    |
+          | -c -x 2                                                     | Can't use together options '--clean-required' and '--target-segment-count' | stub    |
+          | -c --mirror-mode grouped                                    | Can't use together options '--clean-required' and '--mirror-mode'       | stub     |
+          | -c --skip-rebalance                                         | Can't use together options '--clean-required' and '--skip-rebalance'    | stub     |
+          | -c --show-plan                                              | Can't use together options '--clean-required' and '--show-plan'         | stub     |
+          | -c --skip-resource-estimation                               | Can't use together options '--clean-required' and '--skip-resource-estimation' |  the database is not running |
+
+    Scenario: test 1.1 ggrebalance simple scenarios
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"
+         And segment information for content 1 is saved in context
+         And segment information for content 2 is saved in context
+         And segment information for content 3 is saved in context
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 4 --skip-rebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Skipping rebalance" to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -x 2 --skip-rebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
+         And verify no segment running for saved segment information
+        When the user runs "ggrebalance -x 1 --skip-rebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
+        When the user runs "ggrebalance -r"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Can't perform rollback." to logfile with latest timestamp
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
+
+    Scenario: test 1.2. check cleanup after the target segment count was updated
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1"
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end"
+        When the user runs "ggrebalance -x 1 --skip-rebalance"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+        When the user runs "ggrebalance -c -y"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Reset numsegments to default is done." to logfile with latest timestamp
+         And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -41,7 +41,6 @@ Feature: ggrebalance behave tests
          And ggrebalance should print "Skipping rebalance" to logfile with latest timestamp
         When the user runs "ggrebalance -c"
         Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
         When the user runs "ggrebalance -c"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_basics.feature
@@ -1,7 +1,7 @@
 @ggrebalance_basics
 Feature: ggrebalance behave tests
 
-    Scenario Outline: Validate incompatible option combinations
+    Scenario Outline: test 1. validate incompatible option combinations
         Given a standard local demo cluster is running
         When the user runs "ggrebalance <options>"
         Then ggrebalance should return a return code of 1
@@ -28,7 +28,7 @@ Feature: ggrebalance behave tests
           | -c --show-plan                                              | Can't use together options '--clean-required' and '--show-plan'         | stub     |
           | -c --skip-resource-estimation                               | Can't use together options '--clean-required' and '--skip-resource-estimation' |  the database is not running |
 
-    Scenario: test 1.1 ggrebalance simple scenarios
+    Scenario: test 2. ggrebalance simple scenarios
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"
@@ -64,7 +64,7 @@ Feature: ggrebalance behave tests
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
 
-    Scenario: test 1.2. check cleanup after the target segment count was updated
+    Scenario: test 3. check cleanup after the target segment count was updated
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -5,7 +5,6 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
-         And all files in gpAdminLogs directory are deleted
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
          And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
@@ -14,6 +13,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And schema "test_schema_2" exists in "test_db_2"
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -B <batch_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
@@ -29,10 +29,21 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 6"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+        And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -x 6"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
          And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+        And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -B <batch_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
@@ -48,6 +59,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 6"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -x 6"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
@@ -59,3 +78,38 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | 64         |
         | 128        |
 
+    Scenario: test 1.2. rebalance - check rebalance after shrink.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 3, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 3, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 3, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 3, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 3, row count = 100
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -c"
+        Then ggrebalance should return a return code of 0
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 3"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -78,7 +78,6 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | 64         |
         | 128        |
 
-
     Scenario: test 1.2. rebalance - check rebalance after shrink.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
@@ -114,7 +113,6 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -x 3"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
-
 
     Scenario Outline: test 1.3. rebalance - interrupt and continue.
         Given the database is not running
@@ -160,7 +158,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_begin                              |
         | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_end                                |
         | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_begin |
-#failed        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_end   |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_end   |
         | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_begin    |
         | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_end      |
         | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         |
@@ -171,6 +169,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_end   |
         | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_begin    |
         | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_end      |
+        | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   |
+        | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   |
         | on_enter_STATE_REBALANCE_DONE_begin                                           |
         | on_enter_STATE_REBALANCE_DONE_end                                             |
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -1,0 +1,61 @@
+@ggrebalance_rebalance
+Feature: ggrebalance behave tests (rebalance scenarios)
+
+    Scenario Outline: test 1.1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different batch size).
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And all files in gpAdminLogs directory are deleted
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+        When the user runs "ggrebalance -B <batch_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p'"
+         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm'"
+         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'p'"
+         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'm'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 6, row count = 100
+        When the user runs "ggrebalance -x 6"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -B <batch_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p'"
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'p'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'm'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 6, row count = 100
+        When the user runs "ggrebalance -x 6"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
+
+    Examples:
+        | batch_size |
+        | 1          |
+        | 16         |
+        | 64         |
+        | 128        |
+

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -128,11 +128,14 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
          And set fault inject "<fault_name>"
+         And set fault inject delay <fault_delay_ms> ms
         When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
          And unset fault inject
+         And unset fault inject delay
          And all files in gpAdminLogs directory are deleted
+         And the gprecoverseg lock directory is removed
         When the user runs "ggrebalance"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
@@ -150,27 +153,33 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 6, row count = 100
 
     Examples:
-        | fault_name                                                                    |
-        | on_enter_STATE_REBALANCE_STARTED_begin                                        |
-        | on_enter_STATE_REBALANCE_STARTED_end                                          |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_end                             |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_begin                              |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_end                                |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_begin |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_end   |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_begin    |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_end      |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_end                           |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_begin                            |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_end                              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_begin |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_end   |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_begin    |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_end      |
-        | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   |
-        | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   |
-        | on_enter_STATE_REBALANCE_DONE_begin                                           |
-        | on_enter_STATE_REBALANCE_DONE_end                                             |
+        | fault_name                                                                    | fault_delay_ms |
+        | on_enter_STATE_REBALANCE_STARTED_begin                                        | 0              |
+        | on_enter_STATE_REBALANCE_STARTED_end                                          | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_end                             | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_begin                              | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_end                                | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_begin | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_end   | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_begin    | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_end      | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_end                           | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_begin                            | 0              |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_end                              | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_begin | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_end   | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_begin    | 0              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_end      | 0              |
+        | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   | 0              |
+        | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 0              |
+        | on_enter_STATE_REBALANCE_DONE_begin                                           | 0              |
+        | on_enter_STATE_REBALANCE_DONE_end                                             | 0              |
+        | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   | 1500           |
+        | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   | 3000           |
+        | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 1500           |
+        | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 3000           |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           | 3000           |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         | 3000           |
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -78,6 +78,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | 64         |
         | 128        |
 
+
     Scenario: test 1.2. rebalance - check rebalance after shrink.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
@@ -113,3 +114,63 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -x 3"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
+
+
+    Scenario Outline: test 1.3. rebalance - interrupt and continue.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "<fault_name>"
+        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 6, row count = 100
+
+    Examples:
+        | fault_name                                                                    |
+        | on_enter_STATE_REBALANCE_STARTED_begin                                        |
+        | on_enter_STATE_REBALANCE_STARTED_end                                          |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_end                             |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_begin                              |
+        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_end                                |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_begin |
+#failed        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_end   |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_begin    |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_end      |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_end                           |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_begin                            |
+        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_end                              |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_begin |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_end   |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_begin    |
+        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_end      |
+        | on_enter_STATE_REBALANCE_DONE_begin                                           |
+        | on_enter_STATE_REBALANCE_DONE_end                                             |
+

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -1,7 +1,7 @@
 @ggrebalance_rebalance
 Feature: ggrebalance behave tests (rebalance scenarios)
 
-    Scenario Outline: test 1.1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different batch size).
+    Scenario Outline: test 1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different batch size).
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -78,7 +78,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | 64         |
         | 128        |
 
-    Scenario: test 1.2. rebalance - check rebalance after shrink.
+    Scenario: test 2. rebalance - check rebalance after shrink.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -114,7 +114,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
 
-    Scenario Outline: test 1.3. rebalance - interrupt and continue.
+    Scenario Outline: 3. rebalance - interrupt and continue.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -183,3 +183,74 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           | 3000           |
         | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         | 3000           |
 
+    Scenario: 4. rebalance - check rebalance after interrupted shrink.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "fault_rebalance_table_test_db_2.test_schema_2.test_table_1"
+        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Continue interrupted shrink operation..." to logfile with latest timestamp
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 4, row count = 100
+
+    Scenario: 5. rebalance - check interrupted rebalance after shrink.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And set fault inject "on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_end"
+        When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
+         And unset fault inject
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Continue interrupted rebalance operation..." to logfile with latest timestamp
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
+        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
+        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 4, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -17,12 +17,12 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -B <batch_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
-         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p'"
-         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm'"
-         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'p'"
-         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'm'"
-         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p'"
-         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm'"
+         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 3 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
@@ -36,12 +36,12 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -B <batch_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
-         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p'"
-         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm'"
-         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p'"
-         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm'"
-         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'p'"
-         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'm'"
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
          And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -7,7 +7,7 @@ Feature: ggrebalance behave tests
          And a cluster is created with mirrors on "cdw" and "sdw1"
          And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_begin"
+         And set fault inject "on_enter_STATE_SETUP_SCHEMA_STARTED_begin"
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
          And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
@@ -40,7 +40,7 @@ Feature: ggrebalance behave tests
          And a cluster is created with mirrors on "cdw" and "sdw1"
          And segment information for content 1 is saved in context
          And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end"
+         And set fault inject "on_enter_STATE_SETUP_SCHEMA_STARTED_end"
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
          And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
@@ -107,8 +107,8 @@ Feature: ggrebalance behave tests
 
     Examples:
         | fault_name                                                                  |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_begin                               |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                               |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                 |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
@@ -171,7 +171,7 @@ Feature: ggrebalance behave tests
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
          And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_begin"
+         And set fault inject "on_enter_STATE_SETUP_SCHEMA_STARTED_begin"
          And database "test_db_1" exists
          And schema "test_schema_1" exists in "test_db_1"
          And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
@@ -226,9 +226,9 @@ Feature: ggrebalance behave tests
 
     Examples:
         | fault_name                                                                  |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end                              |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_begin                               |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                              |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                               |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                 |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
@@ -319,9 +319,9 @@ Feature: ggrebalance behave tests
          And distribution information from table "test_schema_2.test_table_4" with data in "test_db_2" is equal to segment count = 2, row count = 300
     Examples:
         | fault_name                                                                  |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_STARTED_end                              |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_begin                               |
-        | on_enter_STATE_SETUP_SHRINK_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                              |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                               |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                 |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -34,41 +34,6 @@ Feature: ggrebalance behave tests
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
 
-    Scenario: test 1.2. shrink - check continue after interrupted state, if interruption is done after the rebalance schema creation, but before any state is saved there
-        Given the database is not running
-         And a working directory of the test as '/data/gpdata/ggrebalance'
-         And a cluster is created with mirrors on "cdw" and "sdw1"
-         And segment information for content 1 is saved in context
-         And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_SETUP_SCHEMA_STARTED_end"
-         And database "test_db_1" exists
-         And schema "test_schema_1" exists in "test_db_1"
-         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
-         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
-         And database "test_db_2" exists
-         And schema "test_schema_2" exists in "test_db_2"
-         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
-         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
-        When the user runs "ggrebalance -x 1 --skip-rebalance"
-        Then ggrebalance should return a return code of 1
-         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
-         And unset fault inject
-        When the user runs "ggrebalance"
-        Then ggrebalance should return a return code of 1
-         And ggrebalance should print "Can't determine next state. Try to execute cleanup." to logfile with latest timestamp
-        When the user runs "ggrebalance -c -y"
-        Then ggrebalance should return a return code of 0
-        When the user runs "ggrebalance -x 1 --skip-rebalance"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
-         And verify no segment running for saved segment information
-         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 1, row count = 100
-         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 1, row count = 100
-         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 1, row count = 100
-         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 1, row count = 100
-        When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
-        Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
-
     Scenario Outline: test 1.3. shrink - check continue after interrupted state
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
@@ -107,6 +72,7 @@ Feature: ggrebalance behave tests
 
     Examples:
         | fault_name                                                                  |
+        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                                     |
         | on_enter_STATE_SETUP_SCHEMA_DONE_begin                                      |
         | on_enter_STATE_SETUP_SCHEMA_DONE_end                                        |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -107,8 +107,8 @@ Feature: ggrebalance behave tests
 
     Examples:
         | fault_name                                                                  |
-        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                               |
-        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                                      |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                        |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
@@ -226,9 +226,9 @@ Feature: ggrebalance behave tests
 
     Examples:
         | fault_name                                                                  |
-        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                              |
-        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                               |
-        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                                     |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                                      |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                        |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |
@@ -319,9 +319,9 @@ Feature: ggrebalance behave tests
          And distribution information from table "test_schema_2.test_table_4" with data in "test_db_2" is equal to segment count = 2, row count = 300
     Examples:
         | fault_name                                                                  |
-        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                              |
-        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                               |
-        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                 |
+        | on_enter_STATE_SETUP_SCHEMA_STARTED_end                                     |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_begin                                      |
+        | on_enter_STATE_SETUP_SCHEMA_DONE_end                                        |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_begin |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end   |
         | on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_DONE_begin    |

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -34,7 +34,7 @@ Feature: ggrebalance behave tests
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
 
-    Scenario Outline: test 1.3. shrink - check continue after interrupted state
+    Scenario Outline: test 1.2. shrink - check continue after interrupted state
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -96,7 +96,7 @@ Feature: ggrebalance behave tests
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
         | fault_segment_stop_dbid_3                                                   |
 
-    Scenario Outline: test 1.4. test shrink continue after cluster restart
+    Scenario Outline: test 1.3. test shrink continue after cluster restart
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_shrink.feature
@@ -1,86 +1,7 @@
-@ggrebalance
+@ggrebalance_shrink
 Feature: ggrebalance behave tests
 
-    Scenario Outline: Validate incompatible option combinations
-        Given a standard local demo cluster is running
-        When the user runs "ggrebalance <options>"
-        Then ggrebalance should return a return code of 1
-         And ggrebalance should print "<error_message>" to stdout
-        Given <run_status>
-        
-        Examples: Mutually exclusive options
-          | options                                                     | error_message                                                         | run_status |
-          | --target-hosts sdw1,sdw2 --target-hosts-file /tmp/hosts.txt | Can't use together options '--target-hosts' and '--target-hosts-file' |  stub |
-          | --target-hosts sdw1,sdw2 --add-hosts sdw3                   | Can't use together options '--target-hosts' and '--add-hosts'         | stub       |
-          | --target-hosts sdw1,sdw2 --remove-hosts sdw3                | Can't use together options '--target-hosts' and '--remove-hosts'      | stub       |
-          | --add-hosts sdw3 --add-hosts-file /tmp/add.txt              | Can't use together options '--add-hosts' and '--add-hosts-file'       | stub       |
-          | --remove-hosts sdw3 --remove-hosts-file /tmp/rm.txt         | Can't use together options '--remove-hosts' and '--remove-hosts-file' | stub       |
-          | --add-hosts sdw3 --remove-hosts sdw3                        | Can't use together options '--add-hosts' and '--remove-hosts'         | stub       |
-          | --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' --target-datadirs-file /tmp/datadirs.txt | Can't use together options '--target-datadirs' and '--target-datadirs-file' | stub |
-          | --mirror-mode grouped --skip-rebalance                      | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |
-          | -m spread --skip-rebalance                                  | Can't use together options '--skip-rebalance' and '--mirror-mode'     | stub       |
-          | -c --target-hosts sdw1,sdw2                                 | Can't use together options '--clean-required' and '--target-hosts'    | stub       |
-          | -c --add-hosts sdw3                                         | Can't use together options '--clean-required' and '--add-hosts'       | stub       |
-          | -c --target-datadirs '/data/p/gpseg{content},/data/m/gpseg{content}' | Can't use together options '--clean-required' and '--target-datadirs'   | stub    |
-          | -c -x 2                                                     | Can't use together options '--clean-required' and '--target-segment-count' | stub    |
-          | -c --mirror-mode grouped                                    | Can't use together options '--clean-required' and '--mirror-mode'       | stub     |
-          | -c --skip-rebalance                                         | Can't use together options '--clean-required' and '--skip-rebalance'    | stub     |
-          | -c --show-plan                                              | Can't use together options '--clean-required' and '--show-plan'         | stub     |
-          | -c --skip-resource-estimation                               | Can't use together options '--clean-required' and '--skip-resource-estimation' |  the database is not running |
-
-    Scenario: test 1.1 ggrebalance simple scenarios
-        Given the database is not running
-         And a working directory of the test as '/data/gpdata/ggrebalance'
-         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2"
-         And segment information for content 1 is saved in context
-         And segment information for content 2 is saved in context
-         And segment information for content 3 is saved in context
-         And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -x 4 --skip-rebalance"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Skipping rebalance" to logfile with latest timestamp
-        When the user runs "ggrebalance -c"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
-        When the user runs "ggrebalance -c"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Rebalance schema doesn't exist. Cleanup is not required." to logfile with latest timestamp
-        When the user runs "ggrebalance -r"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
-        When the user runs "ggrebalance -r"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Rebalance schema doesn't exist. Can't perform rollback." to logfile with latest timestamp
-        When the user runs "ggrebalance -x 2 --skip-rebalance"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Shrink is complete" to logfile with latest timestamp
-         And verify no segment running for saved segment information
-        When the user runs "ggrebalance -x 1 --skip-rebalance"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Previous run was completed successfully. Please execute cleanup before a new run." to logfile with latest timestamp
-        When the user runs "ggrebalance -r"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Previous run was completed successfully. Can't perform rollback." to logfile with latest timestamp
-        When the user runs "ggrebalance -c"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
-
-    Scenario: test 1.2. check cleanup after the target segment count was updated
-        Given the database is not running
-         And a working directory of the test as '/data/gpdata/ggrebalance'
-         And a cluster is created with mirrors on "cdw" and "sdw1"
-         And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_BACKUP_CATALOG_AND_UPDATE_TARGET_SEGMENT_COUNT_STARTED_end"
-        When the user runs "ggrebalance -x 1 --skip-rebalance"
-        Then ggrebalance should return a return code of 1
-         And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp
-         And unset fault inject
-        When the user runs "ggrebalance -c -y"
-        Then ggrebalance should return a return code of 0
-         And ggrebalance should print "Reset numsegments to default is done." to logfile with latest timestamp
-         And ggrebalance should print "Cleanup is complete" to logfile with latest timestamp
-
-    Scenario: test 2.1. shrink - check continue after interrupted state, if interruption is done before the rebalance schema creation
+    Scenario: test 1.1. shrink - check continue after interrupted state, if interruption is done before the rebalance schema creation
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -113,7 +34,7 @@ Feature: ggrebalance behave tests
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
 
-    Scenario: test 2.2. shrink - check continue after interrupted state, if interruption is done after the rebalance schema creation, but before any state is saved there
+    Scenario: test 1.2. shrink - check continue after interrupted state, if interruption is done after the rebalance schema creation, but before any state is saved there
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -148,7 +69,7 @@ Feature: ggrebalance behave tests
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 1, row count = 100
 
-    Scenario Outline: test 2.3. shrink - check continue after interrupted state
+    Scenario Outline: test 1.3. shrink - check continue after interrupted state
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -209,7 +130,7 @@ Feature: ggrebalance behave tests
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
         | fault_segment_stop_dbid_3                                                   |
 
-    Scenario Outline: test 2.4. test shrink continue after cluster restart
+    Scenario Outline: test 1.4. test shrink continue after cluster restart
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -245,7 +166,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_PREPARE_SHRINK_SCHEMA_DONE_begin                             |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin                                     |
 
-    Scenario: test 3.1. shrink - check rollback after interrupted state, if interruption is done before the rebalance schema creation
+    Scenario: test 2.1. shrink - check rollback after interrupted state, if interruption is done before the rebalance schema creation
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -275,7 +196,7 @@ Feature: ggrebalance behave tests
         When there is a "heap" table "test_schema_1.test_table_3" in "test_db_1" with "100" rows
         Then distribution information from table "test_schema_1.test_table_3" with data in "test_db_1" is equal to segment count = 2, row count = 100
 
-    Scenario Outline: test 3.2. shrink - check rollback after interrupted state
+    Scenario Outline: test 2.2. shrink - check rollback after interrupted state
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -323,7 +244,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
 
-    Scenario Outline: test 3.3. shrink - check rollback after interrupted state (interruption is done after the point of no return). Rollback fails. So just continue shrink.
+    Scenario Outline: test 2.3. shrink - check rollback after interrupted state (interruption is done after the point of no return). Rollback fails. So just continue shrink.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -365,7 +286,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_SEGMENTS_STOP_STARTED_end                             |
         | fault_segment_stop_dbid_3                                                   |
 
-    Scenario Outline: test 3.4. shrink - check rollback after interrupted state and cluster restart
+    Scenario Outline: test 2.4. shrink - check rollback after interrupted state and cluster restart
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -416,7 +337,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_SHRINK_CATALOG_STARTED_begin                                 |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1                  |
 
-    Scenario Outline: test 4.1. shrink - check continue after interrupted rollback state. In this case we fail in rollback too early, and normal shrink will be complete.
+    Scenario Outline: test 3.1. shrink - check continue after interrupted rollback state. In this case we fail in rollback too early, and normal shrink will be complete.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -456,7 +377,7 @@ Feature: ggrebalance behave tests
         | on_enter_STATE_PREPARE_SHRINK_SCHEMA_STARTED_end           | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_begin |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_RESTORE_TARGET_SEGMENT_COUNT_START_begin |
 
-    Scenario Outline: test 4.2. shrink - check continue after interrupted rollback state
+    Scenario Outline: test 3.2. shrink - check continue after interrupted rollback state
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -517,7 +438,7 @@ Feature: ggrebalance behave tests
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_START_begin                  |
         | on_enter_STATE_SHRINK_TABLES_DONE_begin                    | fault_rebalance_table_test_db_2.test_schema_2.test_table_1              |
 
-    Scenario Outline: test 4.3. shrink - check continue after interrupted rollback state (interruption is done after rebalance schema is dropped)
+    Scenario Outline: test 3.3. shrink - check continue after interrupted rollback state (interruption is done after rebalance schema is dropped)
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"
@@ -559,7 +480,7 @@ Feature: ggrebalance behave tests
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_begin                   |
         | fault_rebalance_table_test_db_2.test_schema_2.test_table_1 | on_enter_STATE_SHRINK_ROLLBACK_DROP_SCHEMA_DONE_end                     |
 
-    Scenario Outline: test 4.4. shrink - check continue after interrupted rollback state and cluster restart
+    Scenario Outline: test 3.4. shrink - check continue after interrupted rollback state and cluster restart
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1603,6 +1603,15 @@ def impl(context, filter):
     Given the user runs psql with "-c 'BEGIN; CREATE TEMP TABLE tempt(a int); COMMIT'" against database "postgres"
     ''')
 
+@given('the cluster configuration has {segment_count} segments where "{filter}"')
+@when('the cluster configuration has {segment_count} segments where "{filter}"')
+@then('the cluster configuration has {segment_count} segments where "{filter}"')
+def impl(context, segment_count, filter):
+    sql = "SELECT count(*) FROM gp_segment_configuration WHERE %s" % filter
+    with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
+        row = dbconn.queryRow(conn, sql)
+    if int(row[0]) != int(segment_count):
+        raise Exception(f"Expected {segment_count} segments, but got {row[0]}")
 
 @given('the cluster configuration is saved for "{when}"')
 @then('the cluster configuration is saved for "{when}"')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4470,6 +4470,18 @@ def impl(context, fault):
 def impl(context):
     os.environ['GPMGMT_FAULT_POINT'] = ""
 
+@given('set fault inject delay {delay} ms')
+@then('set fault inject delay {delay} ms')
+@when('set fault inject delay {delay} ms')
+def impl(context, delay):
+    os.environ['GPMGMT_FAULT_DELAY_MS'] = delay
+
+@given('unset fault inject delay')
+@then('unset fault inject delay')
+@when('unset fault inject delay')
+def impl(context):
+    os.environ['GPMGMT_FAULT_DELAY_MS'] = ""
+
 @given('stub')
 def impl(context):
     pass


### PR DESCRIPTION
Implement cluster rebalance for ggrebalance utility

List of changes:
1. This patch adds rebalance functionality. Main part of the related logic is
located in the 'RebalanceSM' class. Rebalance is done according to the list of
moves from the supplied plan, and includes following steps:
 - move (via gpmovemirrors) all mirrors from the list of moves;
 - for all primaries from the list of moves switch them with their mirrors;
 - move (via gpmovemirrors) all these segments which were primaries;
 - switch all these segments back to primaries roles.
2. As the rebalance functionality should be correctly coordinated with the
existing shrink logic, this patch adds the high level state-machine
implementation in 'GGRebalanceMainSM' class. It is responsible for proper flow
of high level states like planning, rebalance schema creation and deletion,
invocation of shrink and rebalance execution, invocation of cleanup and shrink.
Therefore:
 - some states and logic are moved from the existing shrink state-machine to
 'GGRebalanceMainSM';
 - temp code is removed from the planner;
 - code in 'ggrebalance' is updated to call only 'GGRebalanceMainSM', that will
 do the rest.
3. As now we need to handle states from shrink, rebalance and main
state-machines, 'RebalanceSchema' code is updated to store and access these
state categories.
4. New behave tests for rebalance functionality are added. As the ggrebalance
test suit became too large and long too execute, it is split into 3 files:
 - 'ggrebalance_basics.feature' - contains the existing basic checks from the
 old file;
 - 'ggrebalance_shrink.feature' - contains the existing checks for shrink from
 the old file;
 - 'ggrebalance_rebalance.feature' - contains the new tests for the rebalance.

Also, some notes about changes related to tests:
 - Old test named 'test 2.2. shrink' is merged into the test with a new name
 'test 1.3. shrink', as the usage of the new top-level state-machine allows now
 to continue shrink execution in this test case;
 - New step definition is added into 'mgmt_util.py', that allows to get the
 number of segments which satisfy a certain condition. It is used in the new
 tests.
 - New step definition is added into 'mgmt_util.py', that allows to set a delay
 for a fault to happen. The respective changes are added into the fault
 injector code. It is used in the new tests, when we test interruption during
 the work of gpmovemirrors or gprecoverseg.