### PR TITLE
[ADBDEV-9115] Fix infinite recursion in ProcessUtility hook chain

### DIFF
--- a/gpcontrib/arenadata_toolkit/src/track_files.c
+++ b/gpcontrib/arenadata_toolkit/src/track_files.c
@@ -96,8 +96,8 @@ static bool callbackRegistered = false;
 static uint32 CurrentVersion = InvalidVersion;
 
 static bool isExecutorExplainMode = false;
-ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
-ExecutorEnd_hook_type next_ExecutorEnd_hook = NULL;
+static ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
+static ExecutorEnd_hook_type next_ExecutorEnd_hook = NULL;
 
 static inline void
 tf_check_shmem_error(void)


### PR DESCRIPTION
Loading arenadata_toolkit together with gpadcc caused stack overflow due to
infinite recursion in adcc_ProcessUtility_hook() when executing simple queries.

Both gpadcc and arenadata_toolkit declared next_ProcessUtility_hook as a global
variable with the same name. When extensions are loaded in order 'gpadcc,
arenadata_toolkit', the toolkit's initialization overwrites the global
next_ProcessUtility_hook symbol, making it point back to
adcc_ProcessUtility_hook() instead of the standart hook. This creates a circular
reference. If they are loaded in different order, the next next_ProcessUtility_hook
points to toolkit's one leading to the same issue.

This patch solves the issue by declaring next_ProcessUtility_hook as static in
toolkit extension.