### PR TITLE
Implement proper parallel flow of the rebalance execution

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -267,6 +267,7 @@ def check_down_segments(logger: Any, dburl: dbconn.DbURL):
             cmd_recoverseg = None
 
 def main(options, args, parser):
+    conn = None
     try:
         signal.signal(signal.SIGTERM, sig_handler)
         signal.signal(signal.SIGHUP, sig_handler)
@@ -313,8 +314,10 @@ def main(options, args, parser):
             logger.error(f"{str(ex)}")
             sys.exit(1)
 
+        conn = dbconn.connect(dburl, encoding='UTF8', allowSystemTableMods=True)
+
         global gg_main_rebalance_SM
-        gg_main_rebalance_SM = GGRebalanceMainSM(logger, dburl, options, gpenv, gparray, gparray_dump_filename)
+        gg_main_rebalance_SM = GGRebalanceMainSM(conn, logger, dburl, options, gpenv, gparray, gparray_dump_filename)
         gg_main_rebalance_SM.run()
 
         sys.exit(0)
@@ -322,6 +325,8 @@ def main(options, args, parser):
         logger.error(f'ggrebalance failed: {e} \n\nExiting...')
         sys.exit(1)
     finally:
+        if conn != None:
+            conn.close()
         remove_pid_file(get_coordinatordatadir())
 
 if __name__ == '__main__':

--- a/gpMgmt/bin/gprebalance_modules/Makefile
+++ b/gpMgmt/bin/gprebalance_modules/Makefile
@@ -12,7 +12,7 @@ shrink.py planner.py \
 rebalance_commons.py \
 rebalance_schema.py \
 solver.py ggrebalance_sm.py \
-ggrebalance_main_sm.py
+ggrebalance_main_sm.py rebalance_step.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/gprebalance_modules'

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_main_sm.py
@@ -123,13 +123,12 @@ class GGRebalanceMainSM:
         }
     ]
 
-    def __init__(self, logger: Any, dburl: dbconn.DbURL, options: Any, gpEnv: GpCoordinatorEnvironment, gpArray: gparray.GpArray, gpArrayDumpFilename: str):
+    def __init__(self, conn: dbconn.Connection, logger: Any, dburl: dbconn.DbURL, options: Any, gpEnv: GpCoordinatorEnvironment, gpArray: gparray.GpArray, gpArrayDumpFilename: str):
         self.logger = logger
         self.dburl = dburl
         self.options = options
         self.gparray = gpArray
-        self.conn = dbconn.connect(
-            self.dburl, encoding='UTF8', allowSystemTableMods=True)
+        self.conn = conn
 
         self.rebalance_schema = RebalanceSchema(self.conn)
 
@@ -292,7 +291,7 @@ class GGRebalanceMainSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_END(self) -> None:
-        self.conn.close()
+        pass
 
     @wrap_state_func_with_faults
     def on_enter_STATE_ERROR(self) -> None:

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -292,7 +292,7 @@ class RebalanceSM:
 
     def get_state_after_interrupt(self, prev_state) -> str:
         if (prev_state == 'STATE_REBALANCE_EXECUTION_STARTED' or
-            prev_state == 'STATE_REBALANCE_EXECUTION_SUCCEEDED' or
+            prev_state == 'STATE_REBALANCE_MOVES_SUCCEEDED' or
             prev_state == 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE'):
             return 'STATE_REBALANCE_EXECUTION_STARTED'
 
@@ -314,7 +314,7 @@ class RebalanceSM:
         #   1st is switchover with the mirror;
         #   2nd is movement itself;
         #   3rd is the back switchover.
-        # If there are several consequent primary movements, we assume that they can ve done in parallel,
+        # If there are several consequent primary movements, we assume that they can be done in parallel,
         # and, to allow batch processing for them, we re-order their steps to combine together
         # the respective switchover and movement steps.
         rebalance_steps = []

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -241,6 +241,15 @@ class RebalanceSM:
 
         if is_gprecoverseg_required:
             recoverseg_options = "-r -a"
+
+            if self.options.parallel is not None:
+                batch_size = self.options.parallel
+                # gprecoverseg has its own limitation for batch size,
+                # need to consider it here.
+                if batch_size > MAX_COORDINATOR_NUM_WORKERS:
+                    batch_size = MAX_COORDINATOR_NUM_WORKERS
+                recoverseg_options += f' -B {batch_size}'
+
             try:
                 self.cmd = GpRecoverSeg("Running gprecoverseg", options=recoverseg_options)
                 self.cmd.run(validateAfter=True)

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -11,6 +11,7 @@ try:
     from gppylib.system.environment import *
     from gprebalance_modules.planner import *
     from gprebalance_modules.rebalance_schema import RebalanceSchema, STATE_NOT_DEFINED
+    from gprebalance_modules.rebalance_step import *
     from gppylib.fault_injection import *
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
@@ -24,14 +25,13 @@ class RebalanceSM:
 
     states_main_rebalance_flow = [
         'STATE_REBALANCE_STARTED',
-        'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
-        'STATE_REBALANCE_MOVE_MIRRORS_DONE',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-        'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
-        'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
-        'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
+        'STATE_REBALANCE_PREPARE_MOVES_STARTED',
+        'STATE_REBALANCE_PREPARE_MOVES_DONE',
+        'STATE_REBALANCE_EXECUTION_STARTED',
+        'STATE_REBALANCE_MOVES_SUCCEEDED',
+        'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED',
+        'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE',
+        'STATE_REBALANCE_EXECUTION_DONE',
         'STATE_REBALANCE_DONE'
     ]
 
@@ -43,52 +43,47 @@ class RebalanceSM:
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_STARTED',
-            'source': 'STATE_CHECK_PREVIOUS_RUN',
+            'source': ['STATE_CHECK_PREVIOUS_RUN', 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE'],
             'dest': 'STATE_REBALANCE_STARTED'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_STARTED',
+            'trigger': 'move_to_STATE_REBALANCE_PREPARE_MOVES_STARTED',
             'source': 'STATE_REBALANCE_STARTED',
-            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED'
+            'dest': 'STATE_REBALANCE_PREPARE_MOVES_STARTED'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE',
-            'source': 'STATE_REBALANCE_MOVE_MIRRORS_STARTED',
-            'dest': 'STATE_REBALANCE_MOVE_MIRRORS_DONE'
+            'trigger': 'move_to_STATE_REBALANCE_PREPARE_MOVES_DONE',
+            'source': 'STATE_REBALANCE_PREPARE_MOVES_STARTED',
+            'dest': 'STATE_REBALANCE_PREPARE_MOVES_DONE'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
-            'source': 'STATE_REBALANCE_MOVE_MIRRORS_DONE',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED'
+            'trigger': 'move_to_STATE_REBALANCE_EXECUTION_STARTED',
+            'source': ['STATE_REBALANCE_PREPARE_MOVES_DONE', 'STATE_REBALANCE_MOVES_SUCCEEDED', 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE'],
+            'dest': 'STATE_REBALANCE_EXECUTION_STARTED'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE'
+            'trigger': 'move_to_STATE_REBALANCE_MOVES_SUCCEEDED',
+            'source': 'STATE_REBALANCE_EXECUTION_STARTED',
+            'dest': 'STATE_REBALANCE_MOVES_SUCCEEDED'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE',
-            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED'
+            'trigger': 'move_to_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED',
+            'source': 'STATE_REBALANCE_EXECUTION_STARTED',
+            'dest': 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_STARTED',
-            'dest': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE'
+            'trigger': 'move_to_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE',
+            'source': 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED',
+            'dest': 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE'
         },
         {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
-            'source': 'STATE_REBALANCE_MOVE_PRIMARIES_DONE',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED'
-        },
-        {
-            'trigger': 'move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE',
-            'source': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED',
-            'dest': 'STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE'
+            'trigger': 'move_to_STATE_REBALANCE_EXECUTION_DONE',
+            'source': 'STATE_REBALANCE_EXECUTION_STARTED',
+            'dest': 'STATE_REBALANCE_EXECUTION_DONE'
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_DONE',
-            'source': ['STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE', 'STATE_REBALANCE_MOVE_MIRRORS_DONE'],
+            'source': 'STATE_REBALANCE_EXECUTION_DONE',
             'dest': 'STATE_REBALANCE_DONE'
         }
     ]
@@ -139,6 +134,9 @@ class RebalanceSM:
         self.trigger('start')
 
     def process_moves(self, moves: List[LogicalMove]):
+        if len(moves) == 0:
+            return
+
         filename = self.create_config_file(moves)
         gpmovemirrors_options = f'-a -i {filename}'
 
@@ -284,7 +282,13 @@ class RebalanceSM:
         return state == self.states_main_rebalance_flow[-1]
 
     def get_state_after_interrupt(self, prev_state) -> str:
+        if prev_state == 'STATE_REBALANCE_EXECUTION_STARTED' or \
+           prev_state == 'STATE_REBALANCE_EXECUTION_SUCCEEDED' or \
+           prev_state == 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE':
+            return 'STATE_REBALANCE_EXECUTION_STARTED'
+
         prev_idx = self.states_main_rebalance_flow.index(prev_state)
+
         return self.states_main_rebalance_flow[prev_idx + 1]
 
     # state callbacks start here
@@ -311,50 +315,117 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_STARTED(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_MOVE_MIRRORS_STARTED')
+        self.trigger('move_to_STATE_REBALANCE_PREPARE_MOVES_STARTED')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED(self) -> None:
-        self.logger.info('Rebalance - start moving mirrors')
-        self.process_moves(self.moves_mirrors)
-        self.logger.info('Rebalance - end moving mirrors')
-        self.trigger('move_to_STATE_REBALANCE_MOVE_MIRRORS_DONE')
+    def on_enter_STATE_REBALANCE_PREPARE_MOVES_STARTED(self) -> None:
+        if not self.rebalance_plan.getMoves():
+            raise Exception('Rebalance executor was launched with a plan without segment movements')
+
+        rebalance_steps = []
+        id = 0
+        for move in self.rebalance_plan.getMoves():
+            if move.seg.isSegmentPrimary():
+                rebalance_steps.append(RebalanceStepSwitchoverToMirror(id, move))
+                id += 1
+                rebalance_steps.append(RebalanceStepMoveMirror(id, move))
+                id += 1
+                rebalance_steps.append(RebalanceStepSwitchoverToPrimary(id, move))
+                id += 1
+            else:
+                rebalance_steps.append(RebalanceStepMoveMirror(id, move))
+                id += 1
+
+        # TODO: remove this dump
+        #for step in rebalance_steps:
+        #    self.logger.info(str(step))
+
+        self.rebalance_schema.saveExecutionSteps(rebalance_steps)
+
+        self.trigger('move_to_STATE_REBALANCE_PREPARE_MOVES_DONE')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE(self) -> None:
-        if self.primary_segments_to_move:
-            self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED')
-        else:
-            self.trigger('move_to_STATE_REBALANCE_DONE')
+    def on_enter_STATE_REBALANCE_PREPARE_MOVES_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_EXECUTION_STARTED')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED(self) -> None:
-        self.execute_role_swaps(self.primary_segments_to_move, self.RoleSwapDirection.PRIMARY_TO_MIRROR)
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE')
+    def on_enter_STATE_REBALANCE_EXECUTION_STARTED(self) -> None:
+
+        if self.rebalance_schema.allExecutionStepsAreDone():
+            self.trigger('move_to_STATE_REBALANCE_EXECUTION_DONE')
+            return
+
+        rebalance_steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIERED])
+
+        if len(rebalance_steps) > 0:
+
+            if rebalance_steps[0].getStatus() == RebalanceStep.Status.APPROVE_REQUIERED:
+                self.trigger('move_to_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED')
+                return
+
+            moves = []
+            switchover_step = None
+            for step in rebalance_steps:
+                if step.getStatus() == RebalanceStep.Status.APPROVE_REQUIERED:
+                    break;
+
+                # TODO: if we re-enter - some may be already IN_PROGRESS, so will will not see them in this list...
+                step.setStatus(RebalanceStep.Status.IN_PROGRESS)
+                self.rebalance_schema.updateExecutionStep(step)
+                moves.append(step.getMove())
+                if not isinstance(step, RebalanceStepMoveMirror):
+                    switchover_step = step
+                    break;
+
+            if switchover_step != None:
+                direction = self.RoleSwapDirection.PRIMARY_TO_MIRROR
+                if not isinstance(switchover_step, RebalanceStepSwitchoverToMirror):
+                    direction = self.RoleSwapDirection.MIRROR_TO_PRIMARY
+                self.logger.info(f'Rebalance - start role swap {str(direction)}, segment {str(step.getMove().seg)}')
+                self.execute_role_swaps([step.getMove().seg], direction)
+                self.logger.info('Rebalance - end role swap')
+            else:
+                self.logger.info('Rebalance - start moving segments:')
+                for move in moves:
+                    self.logger.info(str(move))
+                self.process_moves(moves)
+                self.logger.info('Rebalance - end moving segments')
+
+            # TODO: check the errored segments
+            for step in rebalance_steps:
+                if step.getStatus() == RebalanceStep.Status.IN_PROGRESS:
+                    step.setStatus(RebalanceStep.Status.DONE)
+                    self.rebalance_schema.updateExecutionStep(step)
+
+        self.trigger('move_to_STATE_REBALANCE_MOVES_SUCCEEDED')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_STARTED')
+    def on_enter_STATE_REBALANCE_MOVES_SUCCEEDED(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_EXECUTION_STARTED')
 
     @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED(self) -> None:
-        self.logger.info('Rebalance - start moving primaries')
-        self.process_moves(self.moves_primaries)
-        self.logger.info('Rebalance - end moving primaries')
-        self.trigger('move_to_STATE_REBALANCE_MOVE_PRIMARIES_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE(self) -> None:
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED(self) -> None:
-        self.execute_role_swaps(self.primary_segments_to_move, self.RoleSwapDirection.MIRROR_TO_PRIMARY)
-        self.trigger('move_to_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE')
-
-    @wrap_state_func_with_faults
-    def on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE(self) -> None:
+    def on_enter_STATE_REBALANCE_EXECUTION_DONE(self) -> None:
         self.trigger('move_to_STATE_REBALANCE_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED(self) -> None:
+        rebalance_steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIERED])
+
+        assert len(rebalance_steps) > 0
+
+        step_to_approve = rebalance_steps[0]
+
+        # TODO: we'll need to add logic here to get approval from the user in the interactive mode,
+        # once we start implementing the interactive mode.
+        # In non-interactive mode we assume that the switchover is always approved.
+        step_to_approve.setStatus(RebalanceStep.Status.PLANNED)
+        self.rebalance_schema.updateExecutionStep(step_to_approve)
+
+        self.trigger('move_to_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE')
+
+    @wrap_state_func_with_faults
+    def on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE(self) -> None:
+        self.trigger('move_to_STATE_REBALANCE_EXECUTION_STARTED')
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_DONE(self) -> None:

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -432,7 +432,7 @@ class RebalanceSM:
                 if (step.getStatus() == RebalanceStep.Status.APPROVE_REQUIRED or
                     # or till the type of RebalanceStep changes.
                     (len(current_batch) > 0 and (type(current_batch[0]) is not type(step)))):
-                    break;
+                    break
 
                 step.setStatus(RebalanceStep.Status.IN_PROGRESS)
                 self.rebalance_schema.updateExecutionStep(step)
@@ -484,7 +484,7 @@ class RebalanceSM:
 
         for step in steps:
             if step.getStatus() != RebalanceStep.Status.APPROVE_REQUIRED:
-                break;
+                break
             # TODO: we'll need to add logic here to get approval from the user in the interactive mode,
             # once we start implementing the interactive mode.
             # In non-interactive mode we assume that the switchover is always approved.

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -43,7 +43,7 @@ class RebalanceSM:
         },
         {
             'trigger': 'move_to_STATE_REBALANCE_STARTED',
-            'source': ['STATE_CHECK_PREVIOUS_RUN', 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE'],
+            'source': 'STATE_CHECK_PREVIOUS_RUN',
             'dest': 'STATE_REBALANCE_STARTED'
         },
         {
@@ -291,9 +291,9 @@ class RebalanceSM:
         return state == self.states_main_rebalance_flow[-1]
 
     def get_state_after_interrupt(self, prev_state) -> str:
-        if prev_state == 'STATE_REBALANCE_EXECUTION_STARTED' or \
-           prev_state == 'STATE_REBALANCE_EXECUTION_SUCCEEDED' or \
-           prev_state == 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE':
+        if (prev_state == 'STATE_REBALANCE_EXECUTION_STARTED' or
+            prev_state == 'STATE_REBALANCE_EXECUTION_SUCCEEDED' or
+            prev_state == 'STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE'):
             return 'STATE_REBALANCE_EXECUTION_STARTED'
 
         prev_idx = self.states_main_rebalance_flow.index(prev_state)
@@ -337,15 +337,27 @@ class RebalanceSM:
         if not self.rebalance_plan.getMoves():
             raise Exception('Rebalance executor was launched with a plan without segment movements')
 
+        # In the loop below we create a list of rebalance execution steps from the plan's list of moves.
+        # Mirror's movemenet is simply translated into single step.
+        # But primary's movement is translated into 3 steps:
+        #   1st is switchover with the mirror;
+        #   2nd is movement itself;
+        #   3rd is the back switchover.
+        # If there are several consequent primary movements, we assume that they can ve done in parallel,
+        # and, to allow batch processing for them, we re-order their steps to combine together
+        # the respective switchover and movement steps.
         rebalance_steps = []
         for move in self.rebalance_plan.getMoves():
-            if move.seg.isSegmentPrimary():
-                step_switch_to_mirror = RebalanceStepSwitchoverToMirror(0, move)
-                step_move = RebalanceStepMoveMirror(0, move)
-                step_switch_to_primary = RebalanceStepSwitchoverToPrimary(0, move)
+            if move.seg.isSegmentMirror():
+                rebalance_steps.append(RebalanceStepMoveMirror(move))
+            else:
+                step_switch_to_mirror = RebalanceStepSwitchoverToMirror(move)
+                step_move = RebalanceStepMoveMirror(move)
+                step_switch_to_primary = RebalanceStepSwitchoverToPrimary(move)
+
                 if (len(rebalance_steps) > 0 and
                     isinstance(rebalance_steps[-1], RebalanceStepSwitchoverToPrimary)):
-                    # if current last element of the list is related to primary movement,
+                    # If current last element of the list is related to primary movement,
                     # try to combine the steps with the same steps of preceding primary movement,
                     # so they can be executed together is parallel.
                     condition = lambda x: isinstance(x, RebalanceStepSwitchoverToMirror)
@@ -362,21 +374,23 @@ class RebalanceSM:
                     last_idx_switch_to_primary = \
                         len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
                     rebalance_steps.insert(last_idx_switch_to_primary, step_switch_to_primary)
-                    pass
                 else:
                     # simply add to the end of the list
                     rebalance_steps.append(step_switch_to_mirror)
                     rebalance_steps.append(step_move)
                     rebalance_steps.append(step_switch_to_primary)
-            else:
-                rebalance_steps.append(RebalanceStepMoveMirror(0, move))
 
-        id = 0
+        self.logger.info('Saving following rebalance execution steps:')
+
+        move_order = 0
         for step in rebalance_steps:
-            step.setId(id)
-            id += 1
+            step.setMoveOrder(move_order)
+            move_order += 1
+            self.logger.info(str(step))
 
         self.rebalance_schema.saveExecutionSteps(rebalance_steps)
+
+        self.logger.info('Saved rebalance execution steps')
 
         self.trigger('move_to_STATE_REBALANCE_PREPARE_MOVES_DONE')
 
@@ -436,7 +450,9 @@ class RebalanceSM:
                 self.execute_role_swaps(segments, direction)
                 self.logger.info('Rebalance - end role swap')
 
-            # TODO: check the errored segments
+            # TODO: check the errored segments here, once we implement rollback for the rebalance.
+            # For now if some error happened, the entire tool will halt its work, so if we reached this point
+            # just mark all steps as done.
             for step in steps_to_execute:
                 if step.getStatus() == RebalanceStep.Status.IN_PROGRESS:
                     step.setStatus(RebalanceStep.Status.DONE)

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -306,6 +306,54 @@ class RebalanceSM:
             step.setStatus(RebalanceStep.Status.PLANNED)
             self.rebalance_schema.updateExecutionStep(step)
 
+    @staticmethod
+    def convert_moves_to_rebalance_steps(moves: List[LogicalMove]) -> List[RebalanceStep]:
+        # In the loop below we create a list of rebalance execution steps from the plan's list of moves.
+        # Mirror's movemenet is simply translated into single step.
+        # But primary's movement is translated into 3 steps:
+        #   1st is switchover with the mirror;
+        #   2nd is movement itself;
+        #   3rd is the back switchover.
+        # If there are several consequent primary movements, we assume that they can ve done in parallel,
+        # and, to allow batch processing for them, we re-order their steps to combine together
+        # the respective switchover and movement steps.
+        rebalance_steps = []
+
+        batch_mirror_steps = []
+        batch_primary_steps = [[],[],[]]
+
+        def fill_rebalance_steps():
+            nonlocal rebalance_steps
+            nonlocal batch_mirror_steps
+            nonlocal batch_primary_steps
+            assert not (len(batch_mirror_steps) > 0 and len(batch_primary_steps[0]) > 0)
+            if len(batch_mirror_steps) > 0:
+                rebalance_steps = rebalance_steps + batch_mirror_steps
+            if len(batch_primary_steps[0]) > 0:
+                flattened_batch_primary_steps = [step for sublist in batch_primary_steps for step in sublist]
+                rebalance_steps = rebalance_steps + flattened_batch_primary_steps
+            # clear the batches
+            batch_mirror_steps = []
+            batch_primary_steps = [[],[],[]]
+
+        prev_move = None
+        for move in moves:
+            # if the move type switched, fill rebalance_steps with the content of
+            # previously gathered batches
+            if prev_move != None and prev_move.seg.getSegmentRole() != move.seg.getSegmentRole():
+                fill_rebalance_steps()
+            prev_move = move
+            # add steps to the current batch
+            if move.seg.isSegmentMirror():
+                batch_mirror_steps.append(RebalanceStepMoveMirror(move))
+            else:
+                batch_primary_steps[0].append(RebalanceStepSwitchoverToMirror(move))
+                batch_primary_steps[1].append(RebalanceStepMoveMirror(move))
+                batch_primary_steps[2].append(RebalanceStepSwitchoverToPrimary(move))
+        fill_rebalance_steps() # fill what's left
+
+        return rebalance_steps
+
     # state callbacks start here
 
     @wrap_state_func_with_faults
@@ -337,48 +385,7 @@ class RebalanceSM:
         if not self.rebalance_plan.getMoves():
             raise Exception('Rebalance executor was launched with a plan without segment movements')
 
-        # In the loop below we create a list of rebalance execution steps from the plan's list of moves.
-        # Mirror's movemenet is simply translated into single step.
-        # But primary's movement is translated into 3 steps:
-        #   1st is switchover with the mirror;
-        #   2nd is movement itself;
-        #   3rd is the back switchover.
-        # If there are several consequent primary movements, we assume that they can ve done in parallel,
-        # and, to allow batch processing for them, we re-order their steps to combine together
-        # the respective switchover and movement steps.
-        rebalance_steps = []
-        for move in self.rebalance_plan.getMoves():
-            if move.seg.isSegmentMirror():
-                rebalance_steps.append(RebalanceStepMoveMirror(move))
-            else:
-                step_switch_to_mirror = RebalanceStepSwitchoverToMirror(move)
-                step_move = RebalanceStepMoveMirror(move)
-                step_switch_to_primary = RebalanceStepSwitchoverToPrimary(move)
-
-                if (len(rebalance_steps) > 0 and
-                    isinstance(rebalance_steps[-1], RebalanceStepSwitchoverToPrimary)):
-                    # If current last element of the list is related to primary movement,
-                    # try to combine the steps with the same steps of preceding primary movement,
-                    # so they can be executed together is parallel.
-                    condition = lambda x: isinstance(x, RebalanceStepSwitchoverToMirror)
-                    last_idx_switch_to_mirror = \
-                        len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
-                    rebalance_steps.insert(last_idx_switch_to_mirror, step_switch_to_mirror)
-
-                    condition = lambda x: isinstance(x, RebalanceStepMoveMirror)
-                    last_idx_move = \
-                        len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
-                    rebalance_steps.insert(last_idx_move, step_move)
-
-                    condition = lambda x: isinstance(x, RebalanceStepSwitchoverToPrimary)
-                    last_idx_switch_to_primary = \
-                        len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
-                    rebalance_steps.insert(last_idx_switch_to_primary, step_switch_to_primary)
-                else:
-                    # simply add to the end of the list
-                    rebalance_steps.append(step_switch_to_mirror)
-                    rebalance_steps.append(step_move)
-                    rebalance_steps.append(step_switch_to_primary)
+        rebalance_steps = self.convert_moves_to_rebalance_steps(self.rebalance_plan.getMoves())
 
         self.logger.info('Saving following rebalance execution steps:')
 

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -291,6 +291,12 @@ class RebalanceSM:
 
         return self.states_main_rebalance_flow[prev_idx + 1]
 
+    def reset_in_progress_execution_steps(self) -> None:
+        in_progress_steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.IN_PROGRESS])
+        for step in in_progress_steps:
+            step.setStatus(RebalanceStep.Status.PLANNED)
+            self.rebalance_schema.updateExecutionStep(step)
+
     # state callbacks start here
 
     @wrap_state_func_with_faults
@@ -355,6 +361,11 @@ class RebalanceSM:
             self.trigger('move_to_STATE_REBALANCE_EXECUTION_DONE')
             return
 
+        # In normal execution we shouldn't have IN_PROGRESS steps at this moment.
+        # If they are presented, it means they are left from previous interrupted run.
+        # Bring them back to PLANNED state, so we can try to process them again.
+        self.reset_in_progress_execution_steps()
+
         rebalance_steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIERED])
 
         if len(rebalance_steps) > 0:
@@ -369,7 +380,6 @@ class RebalanceSM:
                 if step.getStatus() == RebalanceStep.Status.APPROVE_REQUIERED:
                     break;
 
-                # TODO: if we re-enter - some may be already IN_PROGRESS, so will will not see them in this list...
                 step.setStatus(RebalanceStep.Status.IN_PROGRESS)
                 self.rebalance_schema.updateExecutionStep(step)
                 moves.append(step.getMove())

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -140,8 +140,8 @@ class RebalanceSM:
         filename = self.create_config_file(moves)
         gpmovemirrors_options = f'-a -i {filename}'
 
-        if self.options.batch_size is not None:
-            batch_size = self.options.batch_size
+        if self.options.parallel is not None:
+            batch_size = self.options.parallel
             # gpmovemirrors has its own limitation for batch size,
             # need to consider it here.
             if batch_size > MAX_COORDINATOR_NUM_WORKERS:
@@ -329,22 +329,43 @@ class RebalanceSM:
             raise Exception('Rebalance executor was launched with a plan without segment movements')
 
         rebalance_steps = []
-        id = 0
         for move in self.rebalance_plan.getMoves():
             if move.seg.isSegmentPrimary():
-                rebalance_steps.append(RebalanceStepSwitchoverToMirror(id, move))
-                id += 1
-                rebalance_steps.append(RebalanceStepMoveMirror(id, move))
-                id += 1
-                rebalance_steps.append(RebalanceStepSwitchoverToPrimary(id, move))
-                id += 1
-            else:
-                rebalance_steps.append(RebalanceStepMoveMirror(id, move))
-                id += 1
+                step_switch_to_mirror = RebalanceStepSwitchoverToMirror(0, move)
+                step_move = RebalanceStepMoveMirror(0, move)
+                step_switch_to_primary = RebalanceStepSwitchoverToPrimary(0, move)
+                if (len(rebalance_steps) > 0 and
+                    isinstance(rebalance_steps[-1], RebalanceStepSwitchoverToPrimary)):
+                    # if current last element of the list is related to primary movement,
+                    # try to combine the steps with the same steps of preceding primary movement,
+                    # so they can be executed together is parallel.
+                    condition = lambda x: isinstance(x, RebalanceStepSwitchoverToMirror)
+                    last_idx_switch_to_mirror = \
+                        len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
+                    rebalance_steps.insert(last_idx_switch_to_mirror, step_switch_to_mirror)
 
-        # TODO: remove this dump
-        #for step in rebalance_steps:
-        #    self.logger.info(str(step))
+                    condition = lambda x: isinstance(x, RebalanceStepMoveMirror)
+                    last_idx_move = \
+                        len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
+                    rebalance_steps.insert(last_idx_move, step_move)
+
+                    condition = lambda x: isinstance(x, RebalanceStepSwitchoverToPrimary)
+                    last_idx_switch_to_primary = \
+                        len(rebalance_steps) - next(i for i, x in enumerate(reversed(rebalance_steps)) if condition(x))
+                    rebalance_steps.insert(last_idx_switch_to_primary, step_switch_to_primary)
+                    pass
+                else:
+                    # simply add to the end of the list
+                    rebalance_steps.append(step_switch_to_mirror)
+                    rebalance_steps.append(step_move)
+                    rebalance_steps.append(step_switch_to_primary)
+            else:
+                rebalance_steps.append(RebalanceStepMoveMirror(0, move))
+
+        id = 0
+        for step in rebalance_steps:
+            step.setId(id)
+            id += 1
 
         self.rebalance_schema.saveExecutionSteps(rebalance_steps)
 
@@ -366,43 +387,48 @@ class RebalanceSM:
         # Bring them back to PLANNED state, so we can try to process them again.
         self.reset_in_progress_execution_steps()
 
-        rebalance_steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIERED])
+        steps_to_execute = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIRED])
 
-        if len(rebalance_steps) > 0:
+        if len(steps_to_execute) > 0:
 
-            if rebalance_steps[0].getStatus() == RebalanceStep.Status.APPROVE_REQUIERED:
+            if steps_to_execute[0].getStatus() == RebalanceStep.Status.APPROVE_REQUIRED:
                 self.trigger('move_to_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED')
                 return
 
-            moves = []
-            switchover_step = None
-            for step in rebalance_steps:
-                if step.getStatus() == RebalanceStep.Status.APPROVE_REQUIERED:
+            current_batch = []
+            for step in steps_to_execute:
+                # fill current batch until we found a step that requires approve
+                # (it will be handled the next time we enter this state),
+                # or till the type of RebalanceStep changes.
+                if step.getStatus() == RebalanceStep.Status.APPROVE_REQUIRED:
+                    break;
+                if len(current_batch) > 0 and (type(current_batch[0]) is not type(step)):
                     break;
 
                 step.setStatus(RebalanceStep.Status.IN_PROGRESS)
                 self.rebalance_schema.updateExecutionStep(step)
-                moves.append(step.getMove())
-                if not isinstance(step, RebalanceStepMoveMirror):
-                    switchover_step = step
-                    break;
+                current_batch.append(step)
 
-            if switchover_step != None:
-                direction = self.RoleSwapDirection.PRIMARY_TO_MIRROR
-                if not isinstance(switchover_step, RebalanceStepSwitchoverToMirror):
-                    direction = self.RoleSwapDirection.MIRROR_TO_PRIMARY
-                self.logger.info(f'Rebalance - start role swap {str(direction)}, segment {str(step.getMove().seg)}')
-                self.execute_role_swaps([step.getMove().seg], direction)
-                self.logger.info('Rebalance - end role swap')
-            else:
+            if isinstance(current_batch[0], RebalanceStepMoveMirror):
                 self.logger.info('Rebalance - start moving segments:')
+                moves = [step.getMove() for step in current_batch]
                 for move in moves:
                     self.logger.info(str(move))
                 self.process_moves(moves)
                 self.logger.info('Rebalance - end moving segments')
+            else:
+                direction = self.RoleSwapDirection.PRIMARY_TO_MIRROR
+                if not isinstance(current_batch[0], RebalanceStepSwitchoverToMirror):
+                    direction = self.RoleSwapDirection.MIRROR_TO_PRIMARY
+                segments = [step.getMove().seg for step in current_batch]
+                self.logger.info(f'Rebalance - start role swap {str(direction)} for segments:')
+                for segment in segments:
+                    self.logger.info(str(segment))
+                self.execute_role_swaps(segments, direction)
+                self.logger.info('Rebalance - end role swap')
 
             # TODO: check the errored segments
-            for step in rebalance_steps:
+            for step in steps_to_execute:
                 if step.getStatus() == RebalanceStep.Status.IN_PROGRESS:
                     step.setStatus(RebalanceStep.Status.DONE)
                     self.rebalance_schema.updateExecutionStep(step)
@@ -419,17 +445,20 @@ class RebalanceSM:
 
     @wrap_state_func_with_faults
     def on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED(self) -> None:
-        rebalance_steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIERED])
 
-        assert len(rebalance_steps) > 0
+        # Approve all consequent steps that require approval
+        steps = self.rebalance_schema.getExecutionSteps([RebalanceStep.Status.PLANNED, RebalanceStep.Status.APPROVE_REQUIRED])
 
-        step_to_approve = rebalance_steps[0]
+        assert len(steps) > 0
 
-        # TODO: we'll need to add logic here to get approval from the user in the interactive mode,
-        # once we start implementing the interactive mode.
-        # In non-interactive mode we assume that the switchover is always approved.
-        step_to_approve.setStatus(RebalanceStep.Status.PLANNED)
-        self.rebalance_schema.updateExecutionStep(step_to_approve)
+        for step in steps:
+            if step.getStatus() != RebalanceStep.Status.APPROVE_REQUIRED:
+                break;
+            # TODO: we'll need to add logic here to get approval from the user in the interactive mode,
+            # once we start implementing the interactive mode.
+            # In non-interactive mode we assume that the switchover is always approved.
+            step.setStatus(RebalanceStep.Status.PLANNED)
+            self.rebalance_schema.updateExecutionStep(step)
 
         self.trigger('move_to_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE')
 

--- a/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
+++ b/gpMgmt/bin/gprebalance_modules/ggrebalance_sm.py
@@ -422,10 +422,9 @@ class RebalanceSM:
             for step in steps_to_execute:
                 # fill current batch until we found a step that requires approve
                 # (it will be handled the next time we enter this state),
-                # or till the type of RebalanceStep changes.
-                if step.getStatus() == RebalanceStep.Status.APPROVE_REQUIRED:
-                    break;
-                if len(current_batch) > 0 and (type(current_batch[0]) is not type(step)):
+                if (step.getStatus() == RebalanceStep.Status.APPROVE_REQUIRED or
+                    # or till the type of RebalanceStep changes.
+                    (len(current_batch) > 0 and (type(current_batch[0]) is not type(step)))):
                     break;
 
                 step.setStatus(RebalanceStep.Status.IN_PROGRESS)

--- a/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
@@ -2,7 +2,9 @@
 
 from psycopg2.extensions import cursor
 from gppylib.db import dbconn
+from typing import List
 from gprebalance_modules.planner import Plan, deserializePlan
+from gprebalance_modules.rebalance_step import *
 
 STATE_NOT_DEFINED = 'not defined'
 
@@ -24,6 +26,7 @@ class RebalanceSchema:
         self.rebalance_status = 'rebalance_status'
         self.table_rebalance_status_detail = 'table_rebalance_status_detail'
         self.saved_plan = 'saved_plan'
+        self.segment_move_steps = 'segment_move_steps'
         self.conn = conn
 
     def createSchema(self, plan: Plan) -> None:
@@ -42,7 +45,6 @@ class RebalanceSchema:
                        f'''CREATE TABLE {self.schema_name}.{self.saved_plan}
                        (plan BYTEA)
                        DISTRIBUTED REPLICATED''')
-
         self.savePlan(plan)
 
         dbconn.execSQL(self.conn, 'COMMIT')
@@ -143,3 +145,47 @@ class RebalanceSchema:
     def getTablesToRebalanceWithStatus(self, status: str) -> cursor:
         return dbconn.query(self.conn, f"""SELECT db_name, schema_name, rel_name FROM
                             {self.schema_name}.{self.table_rebalance_status_detail} WHERE status = '{status}'""")
+
+    def saveExecutionSteps(self, steps: List[RebalanceStep]) -> None:
+        dbconn.execSQL(self.conn, 'BEGIN')
+
+        dbconn.execSQL(self.conn, f'DROP TABLE IF EXISTS {self.schema_name}.{self.segment_move_steps}')
+
+        dbconn.execSQL(self.conn,
+                       f'''CREATE TABLE {self.schema_name}.{self.segment_move_steps}
+                       (move_id INT NOT NULL UNIQUE, status TEXT, step BYTEA)
+                       DISTRIBUTED REPLICATED''')
+        
+        for step in steps:
+            dbconn.execSQL(self.conn,
+                       f'''INSERT INTO {self.schema_name}.{self.segment_move_steps}
+                       VALUES ({step.getId()}, '{str(step.getStatus())}', '\\x{step.serializeStep().hex()}')''')
+
+        dbconn.execSQL(self.conn, 'COMMIT')
+
+    def updateExecutionStep(self, step: RebalanceStep) -> None:
+        dbconn.execSQL(self.conn,
+                       f'''UPDATE {self.schema_name}.{self.segment_move_steps}
+                       SET status='{str(step.getStatus())}', step='\\x{step.serializeStep().hex()}' WHERE move_id = {step.getId()}''')
+
+    def allExecutionStepsAreDone(self) -> bool:
+        row = dbconn.queryRow(self.conn,
+                              f"SELECT count(1) FROM {self.schema_name}.{self.segment_move_steps} WHERE status <> '{str(RebalanceStep.Status.DONE)}'")
+        not_done_count = int(row[0])
+        return not_done_count == 0
+
+    def getExecutionSteps(self, status_filter: List[RebalanceStep.Status]) -> List[RebalanceStep]:
+        result = []
+
+        filter = ""
+        if len(status_filter) > 0:
+            status_list = ', '.join("'" +  str(status)+ "'" for status in status_filter)
+            filter = f" WHERE status IN ({status_list})"
+
+        cursor = dbconn.query(self.conn,
+                              f'SELECT step FROM {self.schema_name}.{self.segment_move_steps} {filter} ORDER BY move_id')
+        for row in cursor:
+            result.append(deserializeStep(row[0]))
+
+        return result
+

--- a/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
@@ -160,18 +160,18 @@ class RebalanceSchema:
         for step in steps:
             dbconn.execSQL(self.conn,
                        f'''INSERT INTO {self.schema_name}.{self.segment_move_steps}
-                       VALUES ({step.getMoveOrder()}, '{str(step.getStatus())}', '\\x{step.serializeStep().hex()}')''')
+                       VALUES ({step.getMoveOrder()}, '{step.getStatus().name}', '\\x{step.serializeStep().hex()}')''')
 
         dbconn.execSQL(self.conn, 'COMMIT')
 
     def updateExecutionStep(self, step: RebalanceStep) -> None:
         dbconn.execSQL(self.conn,
                        f'''UPDATE {self.schema_name}.{self.segment_move_steps}
-                       SET status='{str(step.getStatus())}', step='\\x{step.serializeStep().hex()}' WHERE move_order = {step.getMoveOrder()}''')
+                       SET status='{step.getStatus().name}', step='\\x{step.serializeStep().hex()}' WHERE move_order = {step.getMoveOrder()}''')
 
     def allExecutionStepsAreDone(self) -> bool:
         row = dbconn.queryRow(self.conn,
-                              f"SELECT count(1) FROM {self.schema_name}.{self.segment_move_steps} WHERE status <> '{str(RebalanceStep.Status.DONE)}'")
+                              f"SELECT count(1) FROM {self.schema_name}.{self.segment_move_steps} WHERE status <> '{RebalanceStep.Status.DONE.name}'")
         not_done_count = int(row[0])
         return not_done_count == 0
 
@@ -180,7 +180,7 @@ class RebalanceSchema:
 
         filter = ""
         if len(status_filter) > 0:
-            status_list = ', '.join("'" +  str(status)+ "'" for status in status_filter)
+            status_list = ', '.join("'" +  status.name + "'" for status in status_filter)
             filter = f" WHERE status IN ({status_list})"
 
         cursor = dbconn.query(self.conn,

--- a/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_schema.py
@@ -45,6 +45,7 @@ class RebalanceSchema:
                        f'''CREATE TABLE {self.schema_name}.{self.saved_plan}
                        (plan BYTEA)
                        DISTRIBUTED REPLICATED''')
+
         self.savePlan(plan)
 
         dbconn.execSQL(self.conn, 'COMMIT')
@@ -153,20 +154,20 @@ class RebalanceSchema:
 
         dbconn.execSQL(self.conn,
                        f'''CREATE TABLE {self.schema_name}.{self.segment_move_steps}
-                       (move_id INT NOT NULL UNIQUE, status TEXT, step BYTEA)
+                       (move_order INT NOT NULL UNIQUE, status TEXT, step BYTEA)
                        DISTRIBUTED REPLICATED''')
         
         for step in steps:
             dbconn.execSQL(self.conn,
                        f'''INSERT INTO {self.schema_name}.{self.segment_move_steps}
-                       VALUES ({step.getId()}, '{str(step.getStatus())}', '\\x{step.serializeStep().hex()}')''')
+                       VALUES ({step.getMoveOrder()}, '{str(step.getStatus())}', '\\x{step.serializeStep().hex()}')''')
 
         dbconn.execSQL(self.conn, 'COMMIT')
 
     def updateExecutionStep(self, step: RebalanceStep) -> None:
         dbconn.execSQL(self.conn,
                        f'''UPDATE {self.schema_name}.{self.segment_move_steps}
-                       SET status='{str(step.getStatus())}', step='\\x{step.serializeStep().hex()}' WHERE move_id = {step.getId()}''')
+                       SET status='{str(step.getStatus())}', step='\\x{step.serializeStep().hex()}' WHERE move_order = {step.getMoveOrder()}''')
 
     def allExecutionStepsAreDone(self) -> bool:
         row = dbconn.queryRow(self.conn,
@@ -183,7 +184,7 @@ class RebalanceSchema:
             filter = f" WHERE status IN ({status_list})"
 
         cursor = dbconn.query(self.conn,
-                              f'SELECT step FROM {self.schema_name}.{self.segment_move_steps} {filter} ORDER BY move_id')
+                              f'SELECT step FROM {self.schema_name}.{self.segment_move_steps} {filter} ORDER BY move_order')
         for row in cursor:
             result.append(deserializeStep(row[0]))
 

--- a/gpMgmt/bin/gprebalance_modules/rebalance_step.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_step.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+from enum import Enum
+import pickle
+from gprebalance_modules.planner import *
+
+class RebalanceStep:
+    class Status(Enum):
+        APPROVE_REQUIERED = 1
+        PLANNED = 2
+        IN_PROGRESS = 3
+        ERROR = 4
+        ROLLBACK_PLANNED = 5
+        ROLLED_BACK = 6
+        CANCELLED = 7
+        DONE = 8
+
+    def __init__(self, id: int, move: LogicalMove):
+        self.id = id
+        self.move = move
+        self.status = self.Status.PLANNED
+
+    def __str__(self):
+        return (
+            f"id: {self.getId()}, status: {self.getStatus()}"
+        )
+
+    def getId(self):
+        return self.id
+
+    def getStatus(self):
+        return self.status
+
+    def getMove(self):
+        return self.move
+
+    def setStatus(self, status: Status):
+        self.status = status
+
+    def serializeStep(self) -> bytes:
+        return pickle.dumps(self)
+
+class RebalanceStepMoveMirror(RebalanceStep):
+    def __init__(self, id: int, move: LogicalMove):
+        super().__init__(id, move)
+
+    def __str__(self):
+        return (
+            f"RebalanceStepMoveMirror - {super().__str__()}:\n"
+            f"{str(self.move)}"
+        )
+
+class RebalanceStepSwitchoverToMirror(RebalanceStep):
+    def __init__(self, id: int, move: LogicalMove):
+        super().__init__(id, move)
+        self.status = self.Status.APPROVE_REQUIERED
+
+    def __str__(self):
+        return (
+            f"RebalanceStepSwitchoverToMirror - {super().__str__()}"
+        )
+
+class RebalanceStepSwitchoverToPrimary(RebalanceStep):
+    def __init__(self, id: int, move: LogicalMove):
+        super().__init__(id, move)
+        self.status = self.Status.APPROVE_REQUIERED
+
+    def __str__(self):
+        return (
+            f"RebalanceStepSwitchoverToPrimary - {super().__str__()}"
+        )
+
+def deserializeStep(input: bytes) -> RebalanceStep:
+    return pickle.loads(input)

--- a/gpMgmt/bin/gprebalance_modules/rebalance_step.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_step.py
@@ -15,21 +15,21 @@ class RebalanceStep:
         CANCELLED = 7
         DONE = 8
 
-    def __init__(self, id: int, move: LogicalMove):
-        self.id = id
+    def __init__(self, move: LogicalMove):
+        self.move_order = -1
         self.move = move
         self.status = self.Status.PLANNED
 
     def __str__(self):
         return (
-            f"id: {self.getId()}, status: {self.getStatus()}"
+            f"Rebalance step with move_order: {self.getMoveOrder()}, status: {self.getStatus()}"
         )
 
-    def getId(self):
-        return self.id
+    def getMoveOrder(self):
+        return self.move_order
 
-    def setId(self, id: int):
-        self.id = id
+    def setMoveOrder(self, move_order: int):
+        self.move_order = move_order
 
     def getStatus(self):
         return self.status
@@ -44,33 +44,33 @@ class RebalanceStep:
         return pickle.dumps(self)
 
 class RebalanceStepMoveMirror(RebalanceStep):
-    def __init__(self, id: int, move: LogicalMove):
-        super().__init__(id, move)
+    def __init__(self, move: LogicalMove):
+        super().__init__(move)
 
     def __str__(self):
         return (
-            f"RebalanceStepMoveMirror - {super().__str__()}:\n"
+            f"{super().__str__()}, type: RebalanceStepMoveMirror:\n"
             f"{str(self.move)}"
         )
 
 class RebalanceStepSwitchoverToMirror(RebalanceStep):
-    def __init__(self, id: int, move: LogicalMove):
-        super().__init__(id, move)
+    def __init__(self, move: LogicalMove):
+        super().__init__(move)
         self.status = self.Status.APPROVE_REQUIRED
 
     def __str__(self):
         return (
-            f"RebalanceStepSwitchoverToMirror - {super().__str__()}"
+            f"{super().__str__()}, type: RebalanceStepSwitchoverToMirror, DBID {str(self.move.seg.getSegmentDbId())}"
         )
 
 class RebalanceStepSwitchoverToPrimary(RebalanceStep):
-    def __init__(self, id: int, move: LogicalMove):
-        super().__init__(id, move)
+    def __init__(self, move: LogicalMove):
+        super().__init__(move)
         self.status = self.Status.APPROVE_REQUIRED
 
     def __str__(self):
         return (
-            f"RebalanceStepSwitchoverToPrimary - {super().__str__()}"
+            f"{super().__str__()}, type: RebalanceStepSwitchoverToPrimary, DBID {str(self.move.seg.getSegmentDbId())}"
         )
 
 def deserializeStep(input: bytes) -> RebalanceStep:

--- a/gpMgmt/bin/gprebalance_modules/rebalance_step.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_step.py
@@ -6,7 +6,7 @@ from gprebalance_modules.planner import *
 
 class RebalanceStep:
     class Status(Enum):
-        APPROVE_REQUIERED = 1
+        APPROVE_REQUIRED = 1
         PLANNED = 2
         IN_PROGRESS = 3
         ERROR = 4
@@ -27,6 +27,9 @@ class RebalanceStep:
 
     def getId(self):
         return self.id
+
+    def setId(self, id: int):
+        self.id = id
 
     def getStatus(self):
         return self.status
@@ -53,7 +56,7 @@ class RebalanceStepMoveMirror(RebalanceStep):
 class RebalanceStepSwitchoverToMirror(RebalanceStep):
     def __init__(self, id: int, move: LogicalMove):
         super().__init__(id, move)
-        self.status = self.Status.APPROVE_REQUIERED
+        self.status = self.Status.APPROVE_REQUIRED
 
     def __str__(self):
         return (
@@ -63,7 +66,7 @@ class RebalanceStepSwitchoverToMirror(RebalanceStep):
 class RebalanceStepSwitchoverToPrimary(RebalanceStep):
     def __init__(self, id: int, move: LogicalMove):
         super().__init__(id, move)
-        self.status = self.Status.APPROVE_REQUIERED
+        self.status = self.Status.APPROVE_REQUIRED
 
     def __str__(self):
         return (

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -1,7 +1,7 @@
 @ggrebalance_rebalance
 Feature: ggrebalance behave tests (rebalance scenarios)
 
-    Scenario Outline: test 1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different batch size).
+    Scenario Outline: test 1. rebalance - check scenario, when we remove/add a host and rebalance the cluster (with different parallel size).
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
          And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -14,7 +14,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -B <batch_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --parallel <parallel_size> -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 3 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -44,7 +44,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         When the user runs "ggrebalance -c"
         Then ggrebalance should return a return code of 0
         And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -B <batch_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance --parallel <parallel_size> -x 6 --add-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
@@ -72,11 +72,11 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And ggrebalance should print "Cluster is already balanced, no segment moves will be held." to logfile with latest timestamp
 
     Examples:
-        | batch_size |
-        | 1          |
-        | 16         |
-        | 64         |
-        | 128        |
+        | parallel_size |
+        | 1             |
+        | 16            |
+        | 64            |
+        | 96            |
 
     Scenario: test 2. rebalance - check rebalance after shrink.
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -179,7 +179,6 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 1500           |
         | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 3000           |
         | on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin                              | 3000           |
-        | on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin                              | 3000           |
 
     Scenario: 4. rebalance - check rebalance after interrupted shrink.
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_rebalance.feature
@@ -156,22 +156,20 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | fault_name                                                                    | fault_delay_ms |
         | on_enter_STATE_REBALANCE_STARTED_begin                                        | 0              |
         | on_enter_STATE_REBALANCE_STARTED_end                                          | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_end                             | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_begin                              | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_DONE_end                                | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_begin | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_STARTED_end   | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_begin    | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_PRIMARY_TO_MIRROR_DONE_end      | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_end                           | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_begin                            | 0              |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_DONE_end                              | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_begin | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_STARTED_end   | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_begin    | 0              |
-        | on_enter_STATE_REBALANCE_SWAP_PREFERRED_ROLES_MIRROR_TO_PRIMARY_DONE_end      | 0              |
+        | on_enter_STATE_REBALANCE_PREPARE_MOVES_STARTED_begin                          | 0              |
+        | on_enter_STATE_REBALANCE_PREPARE_MOVES_STARTED_end                            | 0              |
+        | on_enter_STATE_REBALANCE_PREPARE_MOVES_DONE_begin                             | 0              |
+        | on_enter_STATE_REBALANCE_PREPARE_MOVES_DONE_end                               | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin                              | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_STARTED_end                                | 0              |
+        | on_enter_STATE_REBALANCE_MOVES_SUCCEEDED_begin                                | 0              |
+        | on_enter_STATE_REBALANCE_MOVES_SUCCEEDED_end                                  | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED_begin  | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_STARTED_end    | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE_begin     | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_AWAITING_SWITCHOVER_APPROVE_DONE_end       | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_DONE_begin                                 | 0              |
+        | on_enter_STATE_REBALANCE_EXECUTION_DONE_end                                   | 0              |
         | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   | 0              |
         | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 0              |
         | on_enter_STATE_REBALANCE_DONE_begin                                           | 0              |
@@ -180,8 +178,8 @@ Feature: ggrebalance behave tests (rebalance scenarios)
         | FAULT_BEFORE_GPRECOVERSEG_PRIMARY_TO_MIRROR                                   | 3000           |
         | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 1500           |
         | FAULT_BEFORE_GPRECOVERSEG_MIRROR_TO_PRIMARY                                   | 3000           |
-        | on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_begin                           | 3000           |
-        | on_enter_STATE_REBALANCE_MOVE_PRIMARIES_STARTED_begin                         | 3000           |
+        | on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin                              | 3000           |
+        | on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin                              | 3000           |
 
     Scenario: 4. rebalance - check rebalance after interrupted shrink.
         Given the database is not running
@@ -232,7 +230,7 @@ Feature: ggrebalance behave tests (rebalance scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-         And set fault inject "on_enter_STATE_REBALANCE_MOVE_MIRRORS_STARTED_end"
+         And set fault inject "on_enter_STATE_REBALANCE_EXECUTION_STARTED_begin"
         When the user runs "ggrebalance -x 4 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "ggrebalance failed" to logfile with latest timestamp


### PR DESCRIPTION
Implement proper parallel flow of the rebalance execution

Problem description:
Need to update rebalance execution flow in a way that it can support parallel
segment movement, and at the same time the flow must consider following
limitations:
 - ggrebalance should save every move step and it's status in persistance
storage so that failed steps may be retried, rollbacked or cancelled (rollback,
retry or cancel of particular movement will be implemented later in a separate
patch);
 - switchover actions (primary to mirror, mirror to primary) will require user
approval once we implement interactive mode (later in a separate patch);
 - ggrebalance should consider the order of the planned movements in the
primary-mirror swap scenario using 3rd intermediate, transitional host. It means
that the executor can't swap the order of mirror and primary movements.

Therefore, this patch:
1. Adds an entity of RebalanceStep, that contain the state of execution together
with the movement definition. List of such steps is now saved to the rebalance
schema.
2. Updates the state machine of the rebalance execution. Now new states, where
approval will be later requested from the user, are added. And the state machine
can switch between segment processing and approval request as many times as
required, till all steps are processed. Execution of the rebalance steps is
performed in batches. Each batch is comprised from the same type of rebalance
steps, without duplication of dbids.
3. Updates the code to use '--parallel' option to config
'gpmovemirrors'/'gprecoverseg'.
4. Updates behave tests according to changes described above.