### PR TITLE
Add a batch of ggrebalance behave tests

### DIFF
--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -196,7 +196,18 @@ def check_running_gputils(dburl: dbconn.DbURL, coordinator_data_directory: str):
         except IOError:
             pass
 
+    gpexpand_status_file = 'gpexpand.status'
+    if os.path.exists(os.path.join(coordinator_data_directory, gpexpand_status_file)):
+        logger.error(f'{gpexpand_status_file} file exists. Assuming gpexpand is already running.')
+        sys.exit(1)
+
     with closing(dbconn.connect(dburl, encoding='UTF8')) as conn:
+        cursor = dbconn.query(conn, "SELECT oid FROM pg_namespace WHERE nspname='gpexpand'")
+        if cursor.rowcount > 0:
+            logger.error(
+                '''gpexpand schema exists. Assuming gpexpand is already running.''')
+            sys.exit(1)
+
         cursor = dbconn.query(conn, '''SELECT datid
                     FROM pg_stat_activity
                     WHERE application_name LIKE 'gpbackup%' OR

--- a/gpMgmt/bin/ggrebalance
+++ b/gpMgmt/bin/ggrebalance
@@ -16,6 +16,7 @@ try:
     from gprebalance_modules.shrink import GGShrink, DBNAME
     from gprebalance_modules.ggrebalance_main_sm import GGRebalanceMainSM
     from gprebalance_modules.planner import *
+    from gppylib.programs.clsRecoverSegment_triples import get_segments_with_running_basebackup
 except ImportError as e:
     sys.exit('ERROR: Cannot import modules.  Please check that you have sourced greenplum_path.sh.  Detail: ' + str(e))
 
@@ -220,6 +221,12 @@ def check_running_gputils(dburl: dbconn.DbURL, coordinator_data_directory: str):
     if is_gprecoverseg_running():
         logger.error(
             '''gprecoverseg is already running.''')
+        sys.exit(1)
+
+    segments_with_running_basebackup = get_segments_with_running_basebackup()
+    if len(segments_with_running_basebackup) > 0:
+        logger.error(
+            f'''Segments {segments_with_running_basebackup} have running pg_basebackup.''')
         sys.exit(1)
 
 

--- a/gpMgmt/bin/gprebalance_modules/planner.py
+++ b/gpMgmt/bin/gprebalance_modules/planner.py
@@ -480,6 +480,9 @@ class Planner:
         self.logger = logger
         self.virtual_gparray = deepcopy(self.gparray)
 
+        if not self.virtual_gparray.hasMirrors:
+            raise ValidationError("Cluster has mirroring disabled. Can't proceed with rebalance")
+
         if self.options.target_hosts_file:
                 self.options.target_hosts = get_hosts_from_file(self.options.target_hosts_file, "target-hosts-file")
         if self.options.add_hosts_file:
@@ -739,9 +742,6 @@ class Planner:
 
     def form_moves(self) -> List[LogicalMove]:
         self.logger.info("Validation of rebalance possibility")
-
-        if not self.virtual_gparray.hasMirrors:
-            raise ValidationError("Cluster has mirroring disabled. Can't proceed with rebalance")
 
         for pair in self.virtual_gparray.segmentPairs:
             prim = pair.primaryDB

--- a/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
@@ -554,15 +554,15 @@ def validate_hosts_basic(hosts: str, option_name: str):
         raise ValidationError(f" --{option_name} must not contain IP adress and hostname simultaniously")
 
 def get_hosts_from_file(file, option_name) -> str:
-    result = ""
+    hosts = []
     with open(file, 'r') as fp:
         i = 0
         for line in fp:
             i += 1
             if i >= 1000:
                 raise ValidationError(f" --{option_name} contains more than 1000 hosts")
-            result = ", ".join(line.strip())
-    return result
+            hosts.append(line.strip())
+    return ", ".join(hosts)
 
 @dataclass
 class SegmentId:

--- a/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_commons.py
@@ -558,10 +558,14 @@ def get_hosts_from_file(file, option_name) -> str:
     with open(file, 'r') as fp:
         i = 0
         for line in fp:
-            i += 1
             if i >= 1000:
                 raise ValidationError(f" --{option_name} contains more than 1000 hosts")
-            hosts.append(line.strip())
+            hostname = line.strip()
+            if hostname != '':
+                hosts.append(line.strip())
+                i += 1
+    if len(hosts) == 0:
+        raise Exception(f"Empty '{file}' file")
     return ", ".join(hosts)
 
 @dataclass

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -22,7 +22,7 @@ def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
                     'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance']
+                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance', 'ggrebalance_misc_options']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -125,7 +125,7 @@ def before_scenario(context, scenario):
 
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
                     'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance']
+                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance', 'ggrebalance_misc_options']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -158,7 +158,7 @@ def after_scenario(context, scenario):
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpinitstandby',
                     'gpconfig', 'gpstop', 'gpinitsystem', 'cross_subnet',
-                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance']
+                    'gplogfilter', 'ggrebalance_basics', 'ggrebalance_shrink', 'ggrebalance_rebalance', 'ggrebalance_misc_options']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -313,3 +313,30 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And the background pid is killed on "coordinator" segment
          And the gprecoverseg lock directory is removed
          And all files in gpAdminLogs directory are deleted
+
+    Scenario: test 14.  Check ggrebalance if pg_basebackup is already running
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 1 segments on each
+         And all the segments are running
+         And the segments are synchronized
+         And all files in gpAdminLogs directory are deleted
+         And the information of contents 0,1,2 is saved
+         And user immediately stops all mirror processes for content 0,1,2
+         And user can start transactions
+         And the user suspend the walsender on the primary on content 0
+         And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+         And the user just waits until recovery_progress.file is created in gpAdminLogs
+         And user waits until gp_stat_replication table has no pg_basebackup entries for content 1,2
+         And an FTS probe is triggered
+         And the user waits until mirror on content 1,2 is up
+         And verify that mirror on content 0 is down
+         And the gprecoverseg lock directory is removed
+         And user immediately stops all mirror processes for content 1,2
+         And the user waits until mirror on content 1,2 is down
+        When the user runs "ggrebalance"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Segments {0} have running pg_basebackup." to logfile with latest timestamp
+         And the user reset the walsender on the primary on content 0
+         And the user waits until saved async process is completed
+         And verify that mirror on content 0 is up

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -35,7 +35,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance  -n 1 -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance -n 1 -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "group" configuration
@@ -57,7 +57,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance  -n 1 -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance -n 1 -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "spread" configuration
@@ -65,3 +65,12 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+
+    Scenario: test 5. Check rebalance against coordinator-only mode.
+        Given the database is not running
+         And the user runs "gpstart -ma"
+         And "gpstart -ma" should return a return code of 0
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 1"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "System was started in single node mode - only utility mode connections are allowed" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -35,7 +35,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -n 1 -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "group" configuration
@@ -57,7 +57,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-        When the user runs "ggrebalance -n 1 -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When the user runs "ggrebalance -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And verify that mirror segments are in "spread" configuration
@@ -74,3 +74,30 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "ggrebalance -x 1"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "System was started in single node mode - only utility mode connections are allowed" to logfile with latest timestamp
+
+    Scenario: test 6. Check rebalance with '--target-hosts'.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1", with 4 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 4 --target-hosts 'sdw2, sdw3' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -4,7 +4,7 @@ Feature: ggrebalance behave tests (misc options scenarios)
     Scenario: test 1. Check if cluster has no mirroring.
         Given the database is not running
          And a working directory of the test as '/data/gpdata/ggrebalance'
-         And a cluster is created without mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And a cluster is created with no mirrors on "cdw" and "sdw1, sdw2, sdw3"
          And all files in gpAdminLogs directory are deleted
         When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -259,3 +259,47 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
          And the temporary file "/tmp/ggrebalance_target_datadirs" is removed
+
+    Scenario: test 13. Check ggrebalance launch when pid file (or any other mark) for other tool exists.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And all files in gpAdminLogs directory are deleted
+        When we run a sample background script to generate a pid on "coordinator" segment
+         And a sample ggrebalance.pid file is created using the background pid in the coordinator_data_directory
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "ggrebalance is already running." to logfile with latest timestamp
+         And the background pid is killed on "coordinator" segment
+         And a sample ggrebalance.pid file is removed from the coordinator_data_directory
+         And all files in gpAdminLogs directory are deleted
+        When we run a sample background script to generate a pid on "coordinator" segment
+         And a sample gpexpand.pid file is created using the background pid in the coordinator_data_directory
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "gpexpand is already running." to logfile with latest timestamp
+         And the background pid is killed on "coordinator" segment
+         And a sample gpexpand.pid file is removed from the coordinator_data_directory
+         And all files in gpAdminLogs directory are deleted
+        When schema "gpexpand" exists in "postgres"
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "gpexpand schema exists. Assuming gpexpand is already running." to logfile with latest timestamp
+         And schema "gpexpand" is removed in "postgres"
+         And all files in gpAdminLogs directory are deleted
+        When we run a sample background script to generate a pid on "coordinator" segment
+         And a sample gpexpand.status file is created using the background pid in the coordinator_data_directory
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "gpexpand.status file exists. Assuming gpexpand is already running." to logfile with latest timestamp
+         And the background pid is killed on "coordinator" segment
+         And a sample gpexpand.status file is removed from the coordinator_data_directory
+         And all files in gpAdminLogs directory are deleted
+        When we run a sample background script to generate a pid on "coordinator" segment
+         And a sample gprecoverseg.lock directory is created using the background pid in coordinator_data_directory
+         And the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "gprecoverseg is already running." to logfile with latest timestamp
+         And the background pid is killed on "coordinator" segment
+         And the gprecoverseg lock directory is removed
+         And all files in gpAdminLogs directory are deleted

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -188,3 +188,49 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And the temporary file "/tmp/ggrebalance_remove_hosts" is removed
+
+    Scenario: test 10. Check rebalance with '--target-datadirs' plain paths (without template substitution).
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 2 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 --target-datadirs '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_new/dbfast/gpseg_'"
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_new/dbfast_mirror/gpseg_'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+
+    Scenario: test 11. Check rebalance with '--target-datadirs' {content} and {hostname} substitution.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 2 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 --target-datadirs '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast/new_seg{content}_on_host_{hostname}, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_new/dbfast_mirror/new_seg{content}_on_host_{hostname}'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_new/dbfast/new\_seg_\_on\_host\_sdw_'"
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_new/dbfast\_mirror/new\_seg_\_on\_host\_sdw_'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -21,3 +21,47 @@ Feature: ggrebalance behave tests (misc options scenarios)
         When the user runs "ggrebalance -x 6 --remove-hosts 'sdw2, sdw3' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "Cannot perform rebalance at 1 host" to logfile with latest timestamp
+
+    Scenario: test 3. Check rebalance with 'grouped' mirror configuration.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 3 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance  -n 1 -x 6 --mirror-mode grouped -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And verify that mirror segments are in "group" configuration
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+
+    Scenario: test 4. Check rebalance with 'spread' mirror configuration.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 3 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance  -n 1 -x 6 --mirror-mode spread -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And verify that mirror segments are in "spread" configuration
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -1,0 +1,12 @@
+@ggrebalance_misc_options
+Feature: ggrebalance behave tests (misc options scenarios)
+
+    Scenario: test 1. Check if cluster has no mirroring.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created without mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Cluster has mirroring disabled. Can't proceed with rebalance" to logfile with latest timestamp
+

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -115,8 +115,18 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
          And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
          And all files in gpAdminLogs directory are deleted
-         And there is a file "/tmp/ggrebalance_target_hosts" with hosts "sdw2|sdw3"
-        When the user runs "ggrebalance -x 4 --target-hosts-file /tmp/ggrebalance_target_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        When there is a file "/tmp/ggrebalance_target_hosts" with hosts " "
+         And the user runs "ggrebalance -x 4 --target-hosts-file /tmp/ggrebalance_target_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Empty '/tmp/ggrebalance_target_hosts' file" to logfile with latest timestamp
+         And the temporary file "/tmp/ggrebalance_target_hosts" is removed
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 4 --target-hosts-file /tmp/ggrebalance_non_existing_file -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "No such file or directory: '/tmp/ggrebalance_non_existing_file'" to logfile with latest timestamp
+         And all files in gpAdminLogs directory are deleted
+        When there is a file "/tmp/ggrebalance_target_hosts" with hosts "sdw2|sdw3"
+         And the user runs "ggrebalance -x 4 --target-hosts-file /tmp/ggrebalance_target_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
         Then ggrebalance should return a return code of 0
          And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
          And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -234,3 +234,28 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+
+    Scenario: test 12. Check rebalance with '--target-datadirs-file' {content} and {hostname} substitution.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 2 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And there is a file "/tmp/ggrebalance_target_datadirs" with hosts "/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_{hostname}/dbfast/new_seg{content}|/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs_{hostname}/dbfast_mirror/new_seg{content}"
+        When the user runs "ggrebalance -x 6 --remove-hosts sdw3 --target-datadirs-file /tmp/ggrebalance_target_datadirs"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/dbfast/new\_seg_'"
+         And the cluster configuration has some segments where "datadir like '/home/gpadmin/gpdb\_src/gpAux/gpdemo/datadirs\_sdw_/dbfast\_mirror/new\_seg_'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 6, row count = 100
+         And the temporary file "/tmp/ggrebalance_target_datadirs" is removed

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -101,3 +101,32 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
+
+    Scenario: test 7. Check rebalance with '--target-hosts-file'.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1", with 4 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And there is a file "/tmp/ggrebalance_target_hosts" with hosts "sdw2|sdw3"
+        When the user runs "ggrebalance -x 4 --target-hosts-file /tmp/ggrebalance_target_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And the temporary file "/tmp/ggrebalance_target_hosts" is removed

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -130,3 +130,61 @@ Feature: ggrebalance behave tests (misc options scenarios)
          And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
          And the temporary file "/tmp/ggrebalance_target_hosts" is removed
+
+    Scenario: test 8. Check rebalance with '--add-hosts-file'.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1", with 3 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And there is a file "/tmp/ggrebalance_add_hosts" with hosts "sdw2|sdw3"
+        When the user runs "ggrebalance -x 3 --add-hosts-file /tmp/ggrebalance_add_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 1 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 3, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 3, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 3, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 3, row count = 100
+         And the temporary file "/tmp/ggrebalance_add_hosts" is removed
+
+    Scenario: test 9. Check rebalance with '--remove-hosts-file'.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3", with 2 segments on each
+         And database "test_db_1" exists
+         And schema "test_schema_1" exists in "test_db_1"
+         And there is a "heap" table "test_schema_1.test_table_1" in "test_db_1" with "100" rows
+         And there is a "ao" table "test_schema_1.test_table_2" in "test_db_1" with "100" rows
+         And database "test_db_2" exists
+         And schema "test_schema_2" exists in "test_db_2"
+         And there is a "heap" table "test_schema_2.test_table_1" in "test_db_2" with "100" rows
+         And there is a "ao" table "test_schema_2.test_table_2" in "test_db_2" with "100" rows
+         And all files in gpAdminLogs directory are deleted
+         And there is a file "/tmp/ggrebalance_remove_hosts" with hosts "sdw3"
+        When the user runs "ggrebalance -x 4 --remove-hosts-file /tmp/ggrebalance_remove_hosts -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 0
+         And ggrebalance should print "Rebalance is complete" to logfile with latest timestamp
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw1' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 2 segments where "hostname='sdw2' and content > -1 and role = 'm' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'p' and status = 'u'"
+         And the cluster configuration has 0 segments where "hostname='sdw3' and content > -1 and role = 'm' and status = 'u'"
+         And distribution information from table "test_schema_1.test_table_1" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_1.test_table_2" with data in "test_db_1" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_1" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And distribution information from table "test_schema_2.test_table_2" with data in "test_db_2" is equal to segment count = 4, row count = 100
+         And the temporary file "/tmp/ggrebalance_remove_hosts" is removed

--- a/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
+++ b/gpMgmt/test/behave/mgmt_utils/ggrebalance_misc_options.feature
@@ -10,3 +10,14 @@ Feature: ggrebalance behave tests (misc options scenarios)
         Then ggrebalance should return a return code of 1
          And ggrebalance should print "Cluster has mirroring disabled. Can't proceed with rebalance" to logfile with latest timestamp
 
+    Scenario: test 2. Check if cluster can't be rebalanced to a balanced state with given parameters.
+        Given the database is not running
+         And a working directory of the test as '/data/gpdata/ggrebalance'
+         And a cluster is created with mirrors on "cdw" and "sdw1, sdw2, sdw3"
+         And all files in gpAdminLogs directory are deleted
+        When the user runs "ggrebalance -x 5 --remove-hosts sdw3 -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Cannot evenly distribute 5 segments across 2 hosts." to logfile with latest timestamp
+        When the user runs "ggrebalance -x 6 --remove-hosts 'sdw2, sdw3' -d '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast, /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror'"
+        Then ggrebalance should return a return code of 1
+         And ggrebalance should print "Cannot perform rebalance at 1 host" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -19,6 +19,7 @@ def impl(context):
         fp.write("full:5: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
         fp.write("incremental:6: 1/1371875 kB (1%)")
 
+@when('a sample {lock_file} directory is created using the background pid in coordinator_data_directory')
 @then('a sample {lock_file} directory is created using the background pid in coordinator_data_directory')
 @given('a sample {lock_file} directory is created using the background pid in coordinator_data_directory')
 def impl(context, lock_file):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -990,6 +990,8 @@ def create_value_list_file_locally(context, filename, value_list, location=os.ge
 @then('there is a file "{filename}" with tables "{list}"')
 @given('there is a file "{filename}" with hosts "{list}"')
 @then('there is a file "{filename}" with hosts "{list}"')
+@given('there is a file "{filename}" with datadirs "{list}"')
+@then('there is a file "{filename}" with datadirs "{list}"')
 def impl(context, filename, list):
     create_value_list_file_locally(context, filename, list)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -963,12 +963,20 @@ def impl(context, tname, dbname, nrows):
     check_row_count(context, tname, dbname, int(nrows))
 
 @given('schema "{schema_list}" exists in "{dbname}"')
+@when('schema "{schema_list}" exists in "{dbname}"')
 @then('schema "{schema_list}" exists in "{dbname}"')
 def impl(context, schema_list, dbname):
     schemas = [s.strip() for s in schema_list.split(',')]
     for s in schemas:
         drop_schema_if_exists(context, s.strip(), dbname)
         create_schema(context, s.strip(), dbname)
+
+@given('schema "{schema_list}" is removed in "{dbname}"')
+@then('schema "{schema_list}" is removed in "{dbname}"')
+def impl(context, schema_list, dbname):
+    schemas = [s.strip() for s in schema_list.split(',')]
+    for s in schemas:
+        drop_schema_if_exists(context, s.strip(), dbname)
 
 
 @then('the temporary file "{filename}" is removed')
@@ -1687,6 +1695,30 @@ def impl(context, seg):
     cmd = Command(name="remove pid", cmdStr='rm -rf /tmp/bgpid', remoteHost=hostname, ctxt=REMOTE)
     cmd.run(validateAfter=True)
 
+
+@given('a sample {lock_file} file is created using the background pid in the coordinator_data_directory')
+@when('a sample {lock_file} file is created using the background pid in the coordinator_data_directory')
+@then('a sample {lock_file} file is created using the background pid in the coordinator_data_directory')
+def impl(context, lock_file):
+    if 'bg_pid' in context:
+        bg_pid = context.bg_pid
+        if not unix.check_pid(bg_pid):
+            raise Exception("The background process with PID {} is not running.".format(bg_pid))
+    else:
+        bg_pid = ""
+
+    utility_pidfile = os.path.join(get_coordinatordatadir(), lock_file)
+
+    with open(utility_pidfile, 'w') as f:
+        f.write(bg_pid)
+
+@given('a sample {lock_file} file is removed from the coordinator_data_directory')
+@when('a sample {lock_file} file is removed from the coordinator_data_directory')
+@then('a sample {lock_file} file is removed from the coordinator_data_directory')
+def impl(context, lock_file):
+    utility_pidfile = os.path.join(get_coordinatordatadir(), lock_file)
+    if os.path.exists(utility_pidfile):
+        os.remove(utility_pidfile)
 
 @when('{process} is killed on mirror with content {contentids}')
 @then('{process} is killed on mirror with content {contentids}')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2897,6 +2897,10 @@ def impl(context, coordinator_host, segment_host_list, hba_hostnames):
 def impl(context, coordinator_host, segment_host_list):
     _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=True, mirroring_configuration='group')
 
+@given('a cluster is created without mirrors on "{coordinator_host}" and "{segment_host_list}"')
+def impl(context, coordinator_host, segment_host_list):
+    _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=False)
+
 @given('a cluster is created with "{mirroring_configuration}" segment mirroring on "{coordinator_host}" and "{segment_host_list}"')
 def impl(context, mirroring_configuration, coordinator_host, segment_host_list):
     _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=True, mirroring_configuration=mirroring_configuration)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2854,7 +2854,7 @@ def _create_working_directory(context, working_directory, mode=''):
         os.mkdir(context.working_directory)
 
 
-def _create_cluster(context, coordinator_host, segment_host_list, hba_hostnames='0', with_mirrors=False, mirroring_configuration='group'):
+def _create_cluster(context, coordinator_host, segment_host_list, hba_hostnames='0', with_mirrors=False, mirroring_configuration='group', number_of_segments=2):
     if segment_host_list == "":
         segment_host_list = []
     else:
@@ -2876,7 +2876,10 @@ def _create_cluster(context, coordinator_host, segment_host_list, hba_hostnames=
     except:
         pass
 
-    testcluster = TestCluster(hosts=[coordinator_host]+segment_host_list, base_dir=context.working_directory,hba_hostnames=hba_hostnames)
+    testcluster = TestCluster(hosts=[coordinator_host]+segment_host_list,
+                              base_dir=context.working_directory,
+                              hba_hostnames=hba_hostnames,
+                              number_of_segments=number_of_segments)
     testcluster.reset_cluster()
     testcluster.create_cluster(with_mirrors=with_mirrors, mirroring_configuration=mirroring_configuration)
     context.gpexpand_mirrors_enabled = with_mirrors
@@ -2900,6 +2903,10 @@ def impl(context, coordinator_host, segment_host_list):
 @given('a cluster is created with "{mirroring_configuration}" segment mirroring on "{coordinator_host}" and "{segment_host_list}"')
 def impl(context, mirroring_configuration, coordinator_host, segment_host_list):
     _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=True, mirroring_configuration=mirroring_configuration)
+
+@given('a cluster is created with mirrors on "{coordinator_host}" and "{segment_host_list}", with {number_of_segments} segments on each')
+def impl(context, coordinator_host, segment_host_list, number_of_segments):
+    _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=True, mirroring_configuration='group', number_of_segments=int(number_of_segments))
 
 @given('the user runs gpexpand interview to add {num_of_segments} new segment and {num_of_hosts} new host "{hostnames}"')
 @when('the user runs gpexpand interview to add {num_of_segments} new segment and {num_of_hosts} new host "{hostnames}"')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1612,7 +1612,10 @@ def impl(context, segment_count, filter):
     sql = "SELECT count(*) FROM gp_segment_configuration WHERE %s" % filter
     with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
         row = dbconn.queryRow(conn, sql)
-    if int(row[0]) != int(segment_count):
+    if segment_count == 'some':
+        if int(row[0]) == 0:
+            raise Exception(f"Expected some segments, but got 0")
+    elif int(row[0]) != int(segment_count):
         raise Exception(f"Expected {segment_count} segments, but got {row[0]}")
 
 @given('the cluster configuration is saved for "{when}"')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -997,8 +997,10 @@ def create_value_list_file_locally(context, filename, value_list, location=os.ge
 @given('there is a file "{filename}" with tables "{list}"')
 @then('there is a file "{filename}" with tables "{list}"')
 @given('there is a file "{filename}" with hosts "{list}"')
+@when('there is a file "{filename}" with hosts "{list}"')
 @then('there is a file "{filename}" with hosts "{list}"')
 @given('there is a file "{filename}" with datadirs "{list}"')
+@when('there is a file "{filename}" with datadirs "{list}"')
 @then('there is a file "{filename}" with datadirs "{list}"')
 def impl(context, filename, list):
     create_value_list_file_locally(context, filename, list)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2897,10 +2897,6 @@ def impl(context, coordinator_host, segment_host_list, hba_hostnames):
 def impl(context, coordinator_host, segment_host_list):
     _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=True, mirroring_configuration='group')
 
-@given('a cluster is created without mirrors on "{coordinator_host}" and "{segment_host_list}"')
-def impl(context, coordinator_host, segment_host_list):
-    _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=False)
-
 @given('a cluster is created with "{mirroring_configuration}" segment mirroring on "{coordinator_host}" and "{segment_host_list}"')
 def impl(context, mirroring_configuration, coordinator_host, segment_host_list):
     _create_cluster(context, coordinator_host, segment_host_list, with_mirrors=True, mirroring_configuration=mirroring_configuration)

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -977,19 +977,21 @@ def impl(context, filename):
         os.remove(filename)
 
 
-def create_table_file_locally(context, filename, table_list, location=os.getcwd()):
-    tables = table_list.split('|')
+def create_value_list_file_locally(context, filename, value_list, location=os.getcwd()):
+    values = value_list.split('|')
     file_path = os.path.join(location, filename)
     with open(file_path, 'w') as fp:
-        for t in tables:
+        for t in values:
             fp.write(t + '\n')
     context.filename = file_path
 
 
-@given('there is a file "{filename}" with tables "{table_list}"')
-@then('there is a file "{filename}" with tables "{table_list}"')
-def impl(context, filename, table_list):
-    create_table_file_locally(context, filename, table_list)
+@given('there is a file "{filename}" with tables "{list}"')
+@then('there is a file "{filename}" with tables "{list}"')
+@given('there is a file "{filename}" with hosts "{list}"')
+@then('there is a file "{filename}" with hosts "{list}"')
+def impl(context, filename, list):
+    create_value_list_file_locally(context, filename, list)
 
 
 @given('the row "{row_values}" is inserted into "{table}" in "{dbname}"')

--- a/gpMgmt/test/behave_utils/cluster_setup.py
+++ b/gpMgmt/test/behave_utils/cluster_setup.py
@@ -21,7 +21,7 @@ class GpDeleteSystem(Command):
 
 
 class TestCluster:
-    def __init__(self, hosts = None, base_dir = '/tmp/default_gpinitsystem', hba_hostnames='0'):
+    def __init__(self, hosts = None, base_dir = '/tmp/default_gpinitsystem', hba_hostnames='0', number_of_segments = 2):
         """
         hosts: lists of cluster hosts. coordinator host will be assumed to be the first element.
         base_dir: cluster directory
@@ -55,7 +55,7 @@ class TestCluster:
         # Test metadata
         # Whether to do gpinitsystem or not
         self.mirror_enabled = False
-        self.number_of_segments = 2
+        self.number_of_segments = number_of_segments
         self.number_of_hosts = len(self.hosts)-1
 
         self.number_of_expansion_hosts = 0


### PR DESCRIPTION
Add a batch of ggrebalance behave tests

This patch adds a new 'ggrebalance_misc_options' test suite, which currently
has checks for:
1. '--target-hosts-file' option;
2. '--target-hosts' option;
3. '--target-datadirs-file' option;
4. '--target-datadirs' option;
5. '--mirror-mode' option;
6. '--add-hosts-file' option;
7. '--remove-hosts-file' option;
8. scenario with no mirrors in the cluster;
9. scenario when the cluster can't be rebalanced with the given parameters;
10. scenario when the cluster is in coordinator-only mode;
11. scenario when another instance of ggrebalance is running;
12. scenario when another conflicting tool is running;

Also, this patch updates and adds some new step definitions, required by the
new tests. Noticeable change: now we can bring up a test cluster with
configurable number of segments (before it was hardcoded to 2 segments).

And this patch adds a set of small fixes in the ggrebalance code to support the
tested scenarios:
 - Move the validation that the cluster has mirrors to an earlier stage.
Otherwise, without this check, ggrebalance crashed on accessing the non-existing
mirror information, before it actually checked the mirror's presence.
 - Fix function 'get_hosts_from_file()'. Before this change, it tried to split
hostname into letters (for ex., instead of 'sdw1', it returned 4 hosts:
's', 'd', 'w', '1'). Also, added a validation that the file is not empty.
 - Add checks for 'gpexpand' and 'pg_basebackup' tools running in parallel.