### PR TITLE
Fix ALTER MATERIALIZED VIEW ... REBALANCE

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17651,6 +17651,11 @@ ATExecRebalanceTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 		 * child partitions.
 		 */
 	}
+	else if (rel->rd_rel->relkind == RELKIND_MATVIEW)
+	{
+		ereport((Gp_role == GP_ROLE_EXECUTE) ? DEBUG1 : NOTICE,
+				(errmsg("Materialized view requires REFRESH after rebalance")));
+	}
 	else if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
 	{
 		if (rel_is_external_table(relid))

--- a/src/test/regress/expected/alter_rebalance.out
+++ b/src/test/regress/expected/alter_rebalance.out
@@ -3555,3 +3555,69 @@ alter table table_distr_hashed rebalance 3;
 ERROR:  cannot rebalance table "table_distr_hashed"
 DETAIL:  table has already been rebalanced
 drop table table_distr_hashed;
+-- Check rebalance of materialized view
+create table test_table(a int) distributed by (a);
+insert into test_table select generate_series(1, 10);
+create materialized view mv_test_table as select a from test_table distributed by (a);
+alter table test_table rebalance 1;
+alter materialized view mv_test_table rebalance 1;
+NOTICE:  Materialized view requires REFRESH after rebalance
+refresh materialized view mv_test_table;
+select count(1), gp_segment_id from test_table group by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+    10 |             0
+(1 row)
+
+select count(1), gp_segment_id from mv_test_table group by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+    10 |             0
+(1 row)
+
+drop materialized view mv_test_table;
+drop table test_table;
+-- Check rollback of the rebalance of materialized view
+create table test_table(a int) distributed by (a);
+insert into test_table select generate_series(1, 10);
+create materialized view mv_test_table as select a from test_table distributed by (a);
+select count(1), gp_segment_id from test_table group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+     5 |             0
+     1 |             1
+     4 |             2
+(3 rows)
+
+select count(1), gp_segment_id from mv_test_table group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+     5 |             0
+     1 |             1
+     4 |             2
+(3 rows)
+
+begin;
+alter table test_table rebalance 1;
+alter materialized view mv_test_table rebalance 1;
+NOTICE:  Materialized view requires REFRESH after rebalance
+refresh materialized view mv_test_table;
+rollback;
+select count(1), gp_segment_id from test_table group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+     5 |             0
+     1 |             1
+     4 |             2
+(3 rows)
+
+select count(1), gp_segment_id from mv_test_table group by gp_segment_id order by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+     5 |             0
+     1 |             1
+     4 |             2
+(3 rows)
+
+drop materialized view mv_test_table;
+drop table test_table;

--- a/src/test/regress/sql/alter_rebalance.sql
+++ b/src/test/regress/sql/alter_rebalance.sql
@@ -449,3 +449,45 @@ select count(1), gp_segment_id from table_distr_hashed group by gp_segment_id or
 alter table table_distr_hashed rebalance 3;
 
 drop table table_distr_hashed;
+
+-- Check rebalance of materialized view
+-- start_ignore
+drop materialized view if exists mv_test_table;
+drop table if exists test_table;
+-- end_ignore
+
+create table test_table(a int) distributed by (a);
+insert into test_table select generate_series(1, 10);
+
+create materialized view mv_test_table as select a from test_table distributed by (a);
+
+alter table test_table rebalance 1;
+alter materialized view mv_test_table rebalance 1;
+refresh materialized view mv_test_table;
+
+select count(1), gp_segment_id from test_table group by gp_segment_id;
+select count(1), gp_segment_id from mv_test_table group by gp_segment_id;
+
+drop materialized view mv_test_table;
+drop table test_table;
+
+-- Check rollback of the rebalance of materialized view
+create table test_table(a int) distributed by (a);
+insert into test_table select generate_series(1, 10);
+
+create materialized view mv_test_table as select a from test_table distributed by (a);
+
+select count(1), gp_segment_id from test_table group by gp_segment_id order by gp_segment_id;
+select count(1), gp_segment_id from mv_test_table group by gp_segment_id order by gp_segment_id;
+
+begin;
+alter table test_table rebalance 1;
+alter materialized view mv_test_table rebalance 1;
+refresh materialized view mv_test_table;
+rollback;
+
+select count(1), gp_segment_id from test_table group by gp_segment_id order by gp_segment_id;
+select count(1), gp_segment_id from mv_test_table group by gp_segment_id order by gp_segment_id;
+
+drop materialized view mv_test_table;
+drop table test_table;


### PR DESCRIPTION
Fix 'ALTER MATERIALIZED VIEW ... REBALANCE' command

Problem description:
Attempts to rebalance a materialized view via
'ALTER MATERIALIZED VIEW ... REBALANCE' command (or via equivalently working for
materialized views 'ALTER TABLE ... REBALANCE') ended with an error:
'ERROR:  cannot change materialized view ...'

Root cause:
The table rebalance logic tried to insert the data directly into the
materialized view as if it were an ordinary table. It is prohibited for
materialized views.

Fix:
Skip the call of 'ATExecShrinkTable()' for the materialized views. So during
'ALTER ... REBALANCE' only the distribution policy for the materialized view is
updated. And the user needs to perform 'REFRESH MATERIALIZED VIEW ...' after
the rebalance.