### PR TITLE
Use CTAS approach for rebalancing the materialized view

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17515,7 +17515,7 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 	}
 	else
 	{
-		ATExecRebalanceTableCTAS(rootCmd, rel, cmd, 0);
+		ATExecRebalanceTableCTAS(rootCmd, rel, cmd, getgpsegmentCount());
 	}
 
 	/* Update numsegments to cluster size */
@@ -17827,8 +17827,7 @@ ATExecRebalanceTableCTAS(AlterTableCmd *rootCmd, Relation rel,
 
 		/* Step (b) - build CTAS */
 		distby = make_distributedby_for_rel(rel);
-		distby->numsegments =
-			(targetNumSegments > 0) ? targetNumSegments : getgpsegmentCount();
+		distby->numsegments = targetNumSegments;
 
 		queryDesc = build_ctas_with_dist(rel, distby,
 						untransformRelOptions(get_rel_opts(rel)),

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -513,7 +513,9 @@ static void ATExecRebalanceTable(List **wqueue, Relation rel, AlterTableCmd *cmd
 
 static void ATRepackTable(Relation origTable, AlteredTableInfo *tab);
 static void ATExecExpandPartitionTablePrepare(Relation rel);
-static void ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd);
+static void ATExecRebalanceTableCTAS(AlterTableCmd *rootCmd,
+                                     Relation rel, AlterTableCmd *cmd,
+                                     int targetNumSegments);
 
 static void ATExecSetDistributedBy(Relation rel, Node *node,
 								   AlterTableCmd *cmd);
@@ -17513,7 +17515,7 @@ ATExecExpandTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 	}
 	else
 	{
-		ATExecExpandTableCTAS(rootCmd, rel, cmd);
+		ATExecRebalanceTableCTAS(rootCmd, rel, cmd, 0);
 	}
 
 	/* Update numsegments to cluster size */
@@ -17651,11 +17653,6 @@ ATExecRebalanceTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 		 * child partitions.
 		 */
 	}
-	else if (rel->rd_rel->relkind == RELKIND_MATVIEW)
-	{
-		ereport((Gp_role == GP_ROLE_EXECUTE) ? DEBUG1 : NOTICE,
-				(errmsg("Materialized view requires REFRESH after rebalance")));
-	}
 	else if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
 	{
 		if (rel_is_external_table(relid))
@@ -17676,6 +17673,18 @@ ATExecRebalanceTable(List **wqueue, Relation rel, AlterTableCmd *cmd)
 			/* Skip expanding foreign table, since data is not located inside gpdb */
 			return;
 		}
+	}
+	else if (rel->rd_rel->relkind == RELKIND_MATVIEW)
+	{
+		/*
+		 * We can't insert data directly to an existing matview,
+		 * therefore the approach from ATExecShrinkTable() is not suitable,
+		 * and we use CTAS method for matviews.
+		 */
+		AlteredTableInfo	*tab = linitial(*wqueue);
+		AlterTableCmd		*rootCmd =
+			(AlterTableCmd *)linitial(tab->subcmds[AT_PASS_MISC]);
+		ATExecRebalanceTableCTAS(rootCmd, rel, cmd, targetNumSegments);
 	}
 	else
 	{
@@ -17778,7 +17787,8 @@ ATExecExpandPartitionTablePrepare(Relation rel)
 }
 
 static void
-ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
+ATExecRebalanceTableCTAS(AlterTableCmd *rootCmd, Relation rel,
+						 AlterTableCmd *cmd, int targetNumSegments)
 {
 	RangeVar			*tmprv;
 	Oid					tmprelid;
@@ -17817,7 +17827,8 @@ ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 
 		/* Step (b) - build CTAS */
 		distby = make_distributedby_for_rel(rel);
-		distby->numsegments = getgpsegmentCount();
+		distby->numsegments =
+			(targetNumSegments > 0) ? targetNumSegments : getgpsegmentCount();
 
 		queryDesc = build_ctas_with_dist(rel, distby,
 						untransformRelOptions(get_rel_opts(rel)),

--- a/src/test/regress/expected/alter_rebalance.out
+++ b/src/test/regress/expected/alter_rebalance.out
@@ -3561,8 +3561,6 @@ insert into test_table select generate_series(1, 10);
 create materialized view mv_test_table as select a from test_table distributed by (a);
 alter table test_table rebalance 1;
 alter materialized view mv_test_table rebalance 1;
-NOTICE:  Materialized view requires REFRESH after rebalance
-refresh materialized view mv_test_table;
 select count(1), gp_segment_id from test_table group by gp_segment_id;
  count | gp_segment_id 
 -------+---------------
@@ -3600,8 +3598,6 @@ select count(1), gp_segment_id from mv_test_table group by gp_segment_id order b
 begin;
 alter table test_table rebalance 1;
 alter materialized view mv_test_table rebalance 1;
-NOTICE:  Materialized view requires REFRESH after rebalance
-refresh materialized view mv_test_table;
 rollback;
 select count(1), gp_segment_id from test_table group by gp_segment_id order by gp_segment_id;
  count | gp_segment_id 

--- a/src/test/regress/sql/alter_rebalance.sql
+++ b/src/test/regress/sql/alter_rebalance.sql
@@ -463,7 +463,6 @@ create materialized view mv_test_table as select a from test_table distributed b
 
 alter table test_table rebalance 1;
 alter materialized view mv_test_table rebalance 1;
-refresh materialized view mv_test_table;
 
 select count(1), gp_segment_id from test_table group by gp_segment_id;
 select count(1), gp_segment_id from mv_test_table group by gp_segment_id;
@@ -483,7 +482,6 @@ select count(1), gp_segment_id from mv_test_table group by gp_segment_id order b
 begin;
 alter table test_table rebalance 1;
 alter materialized view mv_test_table rebalance 1;
-refresh materialized view mv_test_table;
 rollback;
 
 select count(1), gp_segment_id from test_table group by gp_segment_id order by gp_segment_id;


### PR DESCRIPTION
Use CTAS approach for rebalancing the materialized view

Problem description:
Before this patch, in order to rebalance a materialized view, 2 steps were
required: the actual rebalance where distribution policy was updated, and the
refresh step to update the data in the materialized view. This approach had 2
problems with respect to usage in 'ggrebalance' tool for cluster shrink:
1. It could change the actual data in the materialized view before the cluster
shrink, and after the shrink, if the view was not up-to-date. We intend to keep
the logical data in the cluster not altered.
2. If a materialized view depends on another materialized view, there could be
a race condition when doing the refresh, when we try to refresh based on the
yet-not-refreshed one.

Fix:
Use the CTAS approach from the EXPAND TABLE specifically when we are rebalancing
a materialized view. It creates a temp table with a correct distribution policy,
where all data from the materialized view is copied, and then the relfilenode
of the materialized view is swapped with the temp table. It keeps the data as it
was before the rebalance, even if it was not up-to-date (therefore we will not
surprise the user with the not expected view content), and it eliminates
dependencies on other objects besides the materialized view itself.