### PR TITLE
ADBDEV-9338: Fix arenadata_toolkit isolation2 test

### DIFF
--- a/gpcontrib/arenadata_toolkit/isolation2/Makefile
+++ b/gpcontrib/arenadata_toolkit/isolation2/Makefile
@@ -3,6 +3,6 @@ top_builddir = ../../../
 ISOLATION2_ROOT = $(top_builddir)/src/test/isolation2
 
 installcheck:
-	cd $(ISOLATION2_ROOT) && ./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --psqldir='$(PSQLDIR)' \
+	cd $(ISOLATION2_ROOT) && $(MAKE) install && ./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --psqldir='$(PSQLDIR)' \
 	--dbname=toolkitisolation --schedule=${CURDIR}/toolkit_schedule --inputdir=${CURDIR} --outputdir=${CURDIR} \
 	--load-extension=gp_inject_fault --load-extension=plpythonu


### PR DESCRIPTION
Fix arenadata_toolkit isolation2 test

arenadata_toolkit isolation2 tests were previously relying on a hidden
dependency: it assumed that ./pg_isolation2_regress was already built before
tests are run. This happened to be true because main isolation2 tests built
it, but it might not be the case in general. Instead, run make install in
isolation2 directory explicitly.

---

Successful [CI run](https://gitlab.adsw.io/arenadata/github_mirroring/gpdb/-/jobs/4746253) after this patch and [ADBDEV-9345](https://github.com/GreengageDB/greengage/pull/302)