### PR TITLE
ADBDEV-9459: Fix handling unicode characters in commands result

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -129,7 +129,7 @@ def gpscp(src, dst):
     if GV.opt['-v']:
         print('[Info]', strcmd(c))
     p = subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    out = p.stdout.read(-1).decode('utf-8')
+    out = p.stdout.read(-1)
     rc = p.wait()
     if rc:
         sys.exit('[Error] command failed: gpscp {0} =:{1} with output: {2}'.format(src, dst, out))
@@ -166,7 +166,7 @@ def gpsync(src, dst):
 
     for p in proc:
         for line in p.stdout.readlines():
-            print('[Out {0}] {1}' .format(p.x_peer, line.decode('utf-8')))
+            print('[Out {0}] {1}' .format(p.x_peer, line))
         rc = p.wait()
         if rc:
             sys.exit('[Error] command failed for host:{0} cmd:{1} with status:{2} error: "{3}"'

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -130,6 +130,8 @@ def gpscp(src, dst):
         print('[Info]', strcmd(c))
     p = subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out = p.stdout.read(-1)
+    if sys.version_info[0] == 3:
+        out = out.decode('utf-8')
     rc = p.wait()
     if rc:
         sys.exit('[Error] command failed: gpscp {0} =:{1} with output: {2}'.format(src, dst, out))
@@ -166,6 +168,8 @@ def gpsync(src, dst):
 
     for p in proc:
         for line in p.stdout.readlines():
+            if sys.version_info[0] == 3:
+                line = line.decode('utf-8')
             print('[Out {0}] {1}' .format(p.x_peer, line))
         rc = p.wait()
         if rc:

--- a/gpMgmt/bin/gppylib/heapchecksum.py
+++ b/gpMgmt/bin/gppylib/heapchecksum.py
@@ -1,6 +1,7 @@
 from builtins import object
 from gppylib.commands.base import REMOTE, WorkerPool
 from gppylib.commands.pg import PgControlData
+import sys
 
 
 class HeapChecksum(object):
@@ -55,9 +56,15 @@ class HeapChecksum(object):
             result = pg_control_data.get_results()
             gparray_gpdb = pg_control_data.gparray_gpdb
             if result.rc == 0:
+                stdout = result.stdout
+                stderr = result.stderr
+                if sys.version_info[0] == 2:
+                    stdout = stdout.encode('utf-8')
+                    stderr = stderr.encode('utf-8')
+
                 self.logger.info("Successfully finished pg_controldata {} for dbid {}:\nstdout: {}\nstderr: {}".format(
-                    gparray_gpdb.getSegmentDataDirectory(), gparray_gpdb.getSegmentDbId(), result.stdout,
-                    result.stderr))
+                    gparray_gpdb.getSegmentDataDirectory(), gparray_gpdb.getSegmentDbId(), stdout,
+                    stderr))
                 try:
                     checksum = pg_control_data.get_value('Data page checksum version')
                     gparray_gpdb.heap_checksum = checksum

--- a/gpMgmt/bin/gppylib/util/ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/ssh_utils.py
@@ -302,7 +302,10 @@ class Session(cmd.Cmd):
         for s in self.pxssh_list:
             # Split the output into an array of lines so that we can add text to the beginning of
             #    each line
-            output = s.before.decode('utf-8').split('\n')
+            output_raw = s.before
+            if sys.version_info[0] == 3:
+                output_raw = output_raw.decode('utf-8')
+            output = output_raw.split('\n')
             output = output[1:-1]
 
             commandoutput.append(output)

--- a/gpMgmt/bin/lib/pexpect/__init__.py
+++ b/gpMgmt/bin/lib/pexpect/__init__.py
@@ -63,12 +63,6 @@ PEXPECT LICENSE
 
 '''
 
-from builtins import chr
-from builtins import zip
-from builtins import bytes
-from builtins import range
-from past.builtins import basestring
-from builtins import object
 try:
     import os
     import sys
@@ -1774,9 +1768,9 @@ class spawnu(spawn):
         linesep = os.linesep
         crlf = '\r\n'
     else:
-        string_type = str
-        allowed_string_types = (str, )
-        _chr = staticmethod(chr)
+        string_type = unicode
+        allowed_string_types = (unicode, )
+        _chr = staticmethod(unichr)
         linesep = os.linesep.decode('ascii')
         crlf = '\r\n'.decode('ascii')
     # This can handle unicode in both Python 2 and 3


### PR DESCRIPTION
The result of some commands may contain unicode characters, which leads to a
UnicodeDecodeError when trying to cast it to str in Python 2. Also remove the
futurize changes from the pexpect module since this module already supports
Python 3.