### PR TITLE
ADBDEV-9542: Fix modified time for arenadata_toolkit

### DIFF
--- a/gpcontrib/arenadata_toolkit/Makefile
+++ b/gpcontrib/arenadata_toolkit/Makefile
@@ -3,7 +3,7 @@
 MODULES = arenadata_toolkit
 
 EXTENSION = arenadata_toolkit
-EXTENSION_VERSION = 1.8
+EXTENSION_VERSION = 1.9
 DATA = \
        arenadata_toolkit--1.0.sql \
        arenadata_toolkit--1.0--1.1.sql \
@@ -14,6 +14,7 @@ DATA = \
        arenadata_toolkit--1.5--1.6.sql \
        arenadata_toolkit--1.6--1.7.sql \
        arenadata_toolkit--1.7--1.8.sql \
+       arenadata_toolkit--1.8--1.9.sql \
 
 DATA_built = $(EXTENSION)--$(EXTENSION_VERSION).sql
 

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.8--1.9.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.8--1.9.sql
@@ -1,0 +1,113 @@
+-- /* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.8--1.9.sql */
+
+/*
+ This is part of arenadata_toolkit API for ADB Bundle.
+ This function collects information in db_files_current and db_files_history tables.
+ */
+CREATE OR REPLACE FUNCTION arenadata_toolkit.adb_collect_table_stats()
+RETURNS VOID
+AS $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT
+		FROM pg_partition pp
+		JOIN pg_partition_rule pr ON pr.paroid = pp.oid
+		WHERE
+			-- The filter on the line below, which duplicates condition in the 'case',
+			-- is an optimization to fetch less tuples from the pg_partition.
+			pp.parrelid = 'arenadata_toolkit.db_files_history'::regclass
+			AND
+			CASE
+				WHEN pp.parrelid = 'arenadata_toolkit.db_files_history'::regclass
+				THEN
+					now() >= CAST(substring(pg_get_expr(pr.parrangestart, pr.parchildrelid) FROM '#"%#"::%' FOR '#')
+						AS TIMESTAMP WITHOUT TIME ZONE)
+					AND
+					now() < CAST(substring(pg_get_expr(pr.parrangeend, pr.parchildrelid) FROM '#"%#"::%' FOR '#')
+						AS TIMESTAMP WITHOUT TIME ZONE)
+				ELSE FALSE
+			END)
+	THEN
+		EXECUTE FORMAT($fmt$ALTER TABLE arenadata_toolkit.db_files_history SPLIT DEFAULT PARTITION
+			START (date %1$L) INCLUSIVE
+			END (date %2$L) EXCLUSIVE
+			INTO (PARTITION %3$I, default partition);$fmt$,
+				to_char(now(), 'YYYY-MM-01'),
+				to_char(now() + interval '1 month','YYYY-MM-01'),
+				'p'||to_char(now(), 'YYYYMM'));
+	END IF;
+
+	CREATE TEMPORARY TABLE IF NOT EXISTS pg_temp.db_files_current
+	(
+		oid BIGINT,
+		table_name TEXT,
+		table_schema TEXT,
+		type CHAR(1),
+		storage CHAR(1),
+		table_parent_table TEXT,
+		table_parent_schema TEXT,
+		table_database TEXT,
+		table_tablespace TEXT,
+		"content" INTEGER,
+		segment_preferred_role CHAR(1),
+		hostname TEXT,
+		address TEXT,
+		file TEXT,
+		modifiedtime TIMESTAMP WITHOUT TIME ZONE,
+		file_size BIGINT,
+		tablespace_location TEXT
+	)
+	DISTRIBUTED RANDOMLY;
+
+	/*
+		Since this table is temporary and user can call this several times in a session
+		then we need to truncate it (an alternative will be to drop it).
+	 */
+	TRUNCATE TABLE pg_temp.db_files_current;
+
+	/* We use temporary table in this case, because we don't want to add own own unmapped
+	   relfilenode oids in a db_files_current and db_files_history tables. The downside of
+	   this approach that if time between calls to adb_collect_table_stats will be less
+	   then checkpointing interval (there will be no unlink peformed), than these unmapped
+	   files will still go to db_files_current and db_files_history as unmapped.
+	*/
+	INSERT INTO pg_temp.db_files_current
+	SELECT
+		f.oid,
+		f.table_name,
+		f.table_schema,
+		f.type,
+		f.storage,
+		cl.relname AS table_parent_table,
+		n.nspname AS table_parent_schema,
+		f.table_database,
+		f.table_tablespace,
+		f."content",
+		f.segment_preferred_role,
+		f.hostname,
+		f.address,
+		f.file,
+		f.modifiedtime,
+		f.file_size,
+		f.tablespace_location
+	FROM arenadata_toolkit.__db_files_current AS f
+	LEFT JOIN pg_partition_rule pr ON pr.parchildrelid = f.oid
+	LEFT JOIN pg_partition pp ON pr.paroid = pp.oid
+	LEFT JOIN pg_class cl ON cl.oid = pp.parrelid
+	LEFT JOIN pg_namespace n ON cl.relnamespace = n.oid;
+
+	/*
+	 Here we may truncate it, it's relfilenodes aren't in db_files_current temporary table.
+	 */
+	TRUNCATE TABLE arenadata_toolkit.db_files_current;
+
+	INSERT INTO arenadata_toolkit.db_files_current
+	SELECT *
+	FROM pg_temp.db_files_current;
+
+	INSERT INTO arenadata_toolkit.db_files_history
+	SELECT *, now() AS collecttime
+	FROM arenadata_toolkit.db_files_current;
+END$$
+LANGUAGE plpgsql VOLATILE
+EXECUTE ON MASTER;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
@@ -1,5 +1,5 @@
 # arenadata_toolkit extension
 comment = 'extension is used for manipulation of objects created by adb-bundle'
-default_version = '1.8'
+default_version = '1.9'
 module_pathname = '$libdir/arenadata_toolkit'
 relocatable = false

--- a/gpcontrib/arenadata_toolkit/expected/adb_collect_table_stats_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_collect_table_stats_test.out
@@ -405,15 +405,15 @@ select arenadata_toolkit.adb_collect_table_stats();
 (1 row)
 
 select table_name,
-	   abs(extract(epoch from now() - modifiedtime)) < 2 as same_time
+	   abs(extract(epoch from now() - modifiedtime)) > 2 as same_time
 FROM arenadata_toolkit.db_files_current
 where table_name = 'part_table'
 ORDER BY oid;
  table_name | same_time 
 ------------+-----------
- part_table | f
- part_table | f
- part_table | f
+ part_table | t
+ part_table | t
+ part_table | t
 (3 rows)
 
 -- Cleanup

--- a/gpcontrib/arenadata_toolkit/expected/adb_collect_table_stats_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_collect_table_stats_test.out
@@ -392,6 +392,30 @@ ORDER BY oid;
  part_table_1_prt_2_2_prt_2_3_prt_2_4_prt_2_5_prt_sub_prt2 | arenadata_toolkit | part_table         | arenadata_toolkit   |     32768
 (199 rows)
 
+select pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select arenadata_toolkit.adb_collect_table_stats();
+ adb_collect_table_stats 
+-------------------------
+ 
+(1 row)
+
+select table_name,
+	   abs(extract(epoch from now() - modifiedtime)) < 2 as same_time
+FROM arenadata_toolkit.db_files_current
+where table_name = 'part_table'
+ORDER BY oid;
+ table_name | same_time 
+------------+-----------
+ part_table | f
+ part_table | f
+ part_table | f
+(3 rows)
+
 -- Cleanup
 DROP TABLE part_table, part_table_bigint, public.db_files_history;
 DROP FUNCTION remove_partition_from_db_files_history();

--- a/gpcontrib/arenadata_toolkit/expected/adb_collect_table_stats_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_collect_table_stats_test.out
@@ -405,12 +405,12 @@ select arenadata_toolkit.adb_collect_table_stats();
 (1 row)
 
 select table_name,
-	   abs(extract(epoch from now() - modifiedtime)) > 2 as same_time
+	   abs(extract(epoch from now() - modifiedtime)) > 2 as not_same_time
 FROM arenadata_toolkit.db_files_current
 where table_name = 'part_table'
 ORDER BY oid;
- table_name | same_time 
-------------+-----------
+ table_name | not_same_time 
+------------+---------------
  part_table | t
  part_table | t
  part_table | t

--- a/gpcontrib/arenadata_toolkit/expected/upgrade_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/upgrade_test.out
@@ -185,7 +185,12 @@ ORDER BY 1;
  1.7: column tablespace_location check
  1.7: create the latest check
  1.7: only alter check
-(44 rows)
+ 1.8: alter and create_tables check
+ 1.8: alter, create_tables and collect_table_stats check
+ 1.8: column tablespace_location check
+ 1.8: create the latest check
+ 1.8: only alter check
+(49 rows)
 
 -- Cleanup
 DROP FUNCTION do_upgrade_test_for_arenadata_toolkit(TEXT);

--- a/gpcontrib/arenadata_toolkit/sql/adb_collect_table_stats_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_collect_table_stats_test.sql
@@ -147,6 +147,16 @@ FROM arenadata_toolkit.db_files_current
 where table_name LIKE 'part_table%'
 ORDER BY oid;
 
+select pg_sleep(5);
+
+select arenadata_toolkit.adb_collect_table_stats();
+
+select table_name,
+	   abs(extract(epoch from now() - modifiedtime)) < 2 as same_time
+FROM arenadata_toolkit.db_files_current
+where table_name = 'part_table'
+ORDER BY oid;
+
 -- Cleanup
 DROP TABLE part_table, part_table_bigint, public.db_files_history;
 DROP FUNCTION remove_partition_from_db_files_history();

--- a/gpcontrib/arenadata_toolkit/sql/adb_collect_table_stats_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_collect_table_stats_test.sql
@@ -152,7 +152,7 @@ select pg_sleep(5);
 select arenadata_toolkit.adb_collect_table_stats();
 
 select table_name,
-	   abs(extract(epoch from now() - modifiedtime)) > 2 as same_time
+	   abs(extract(epoch from now() - modifiedtime)) > 2 as not_same_time
 FROM arenadata_toolkit.db_files_current
 where table_name = 'part_table'
 ORDER BY oid;

--- a/gpcontrib/arenadata_toolkit/sql/adb_collect_table_stats_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_collect_table_stats_test.sql
@@ -152,7 +152,7 @@ select pg_sleep(5);
 select arenadata_toolkit.adb_collect_table_stats();
 
 select table_name,
-	   abs(extract(epoch from now() - modifiedtime)) < 2 as same_time
+	   abs(extract(epoch from now() - modifiedtime)) > 2 as same_time
 FROM arenadata_toolkit.db_files_current
 where table_name = 'part_table'
 ORDER BY oid;


### PR DESCRIPTION
Fix modified time for arenadata_toolkit

Previously adb_collect_table_stats() put CURRENT_TIMESTAMP into modifiedtime
column. This is incorrect, since it is time of stats collection, not time of
modification. Instead use modifiedtime field from __db_files_current.

Notably, modifiedtime does not have a timezone, so modifiedtime from
__db_files_current is actually in UTC, but CURRENT_TIMESTAMP that was placed
into modifiedtime was in local timezone. To avoid timezone issues, in the test
we simply check if modifiedtime matches CURRENT_TIMESTAMP within 2 seconds.