### PR TITLE
Resolve conflicts in src/include/pg_config_manual.h

### DIFF
--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -356,17 +356,8 @@
  * Enable tracing of syncscan operations (see also the trace_syncscan GUC var).
  */
 /* #define TRACE_SYNCSCAN */
-<<<<<<< HEAD
 
 /*
  * Disable tuplesort_set_bound feature; see also optimize_bounded_sort GUC var.
  */
 /* #define DEBUG_BOUNDED_SORT */
-
-/*
- * Other debug #defines (documentation, anyone?)
- */
-/* #define HEAPDEBUGALL */
-/* #define ACLDEBUG */
-=======
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452


### PR DESCRIPTION
Commit aaf069a removed the commented-out HEAPDEBUGALL define in
src/include/pg_config_manual.h, and commit 3436c5e removed the commented-out
ACLDEBUG define and the comments before it. However, an earlier commit,
b990d89, had already added a commented-out DEBUG_BOUNDED_SORT define before
these same defines.