### PR TITLE
Resolve conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302512151
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202005121
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#define CATALOG_VERSION_NO	302604061
 
 #endif


### PR DESCRIPTION
Commit 7b48f1b updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.