### PR TITLE
Resolve conflicts in src/include/catalog/pg_amproc.dat

### DIFF
--- a/src/include/catalog/pg_amproc.dat
+++ b/src/include/catalog/pg_amproc.dat
@@ -287,15 +287,12 @@
   amprocrighttype => 'anyrange', amprocnum => '1', amproc => 'range_cmp' },
 { amprocfamily => 'btree/jsonb_ops', amproclefttype => 'jsonb',
   amprocrighttype => 'jsonb', amprocnum => '1', amproc => 'jsonb_cmp' },
-<<<<<<< HEAD
-{ amprocfamily => 'btree/complex_ops', amproclefttype => 'complex',
-  amprocrighttype => 'complex', amprocnum => '1', amproc => 'complex_cmp' },
-=======
 { amprocfamily => 'btree/xid8_ops', amproclefttype => 'xid8',
   amprocrighttype => 'xid8', amprocnum => '1', amproc => 'xid8cmp' },
 { amprocfamily => 'btree/xid8_ops', amproclefttype => 'xid8',
   amprocrighttype => 'xid8', amprocnum => '4', amproc => 'btequalimage' },
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+{ amprocfamily => 'btree/complex_ops', amproclefttype => 'complex',
+  amprocrighttype => 'complex', amprocnum => '1', amproc => 'complex_cmp' },
 
 # hash
 { amprocfamily => 'hash/bpchar_ops', amproclefttype => 'bpchar',


### PR DESCRIPTION
Commit aeec457 added functions for the xid8 type to
src/include/catalog/pg_proc.dat, while the earlier commit 19cd1cf had already
added a function for the complex type in the same location.