### PR TITLE
Resolve conflicts in src/include/commands/explain.h

### DIFF
--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -42,13 +42,10 @@ typedef struct ExplainState
 	bool		analyze;		/* print actual times */
 	bool		costs;			/* print estimated costs */
 	bool		buffers;		/* print buffer usage */
-<<<<<<< HEAD
 	bool		dxl;			/* CDB: print DXL */
 	bool		slicetable;		/* CDB: print slice table */
 	bool		memory_detail;	/* CDB: print per-node memory usage */
-=======
 	bool		wal;			/* print WAL usage */
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	bool		timing;			/* print detailed node timing */
 	bool		summary;		/* print total planning and execution timing */
 	bool		settings;		/* print modified settings */


### PR DESCRIPTION
Commit 33e05f8 added a new field, wal, to the ExplainState structure in
src/include/commands/explain.h. Earlier commits 5ec5c30, 08d8dba, and 91f86ca
had already added the GPDB-specific fields dxl, slicetable, and memory_detail
to the same location.