### PR TITLE
Resolve conflicts in src/include/executor/instrument.h

### DIFF
--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -52,12 +52,9 @@ typedef enum InstrumentOption
 	INSTRUMENT_TIMER = 1 << 0,	/* needs timer (and row counts) */
 	INSTRUMENT_BUFFERS = 1 << 1,	/* needs buffer usage (not implemented yet) */
 	INSTRUMENT_ROWS = 1 << 2,	/* needs row count */
-<<<<<<< HEAD
+	INSTRUMENT_WAL = 1 << 3,	/* needs WAL usage */
 	INSTRUMENT_MEMORY_DETAIL = 0x20000000,	/* needs detailed memory accounting */
 	INSTRUMENT_CDB = 0x40000000,	/* needs cdb statistics */
-=======
-	INSTRUMENT_WAL = 1 << 3,	/* needs WAL usage */
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	INSTRUMENT_ALL = PG_INT32_MAX
 } InstrumentOption;
 
@@ -73,14 +70,9 @@ typedef struct Instrumentation
 	instr_time	starttime;		/* start time of current iteration of node */
 	instr_time	counter;		/* accumulated runtime for this node */
 	double		firsttuple;		/* time for first tuple of this cycle */
-<<<<<<< HEAD
 	uint64		tuplecount;		/* # of tuples emitted so far this cycle */
-	BufferUsage	bufusage_start;	/* buffer usage at start */
-=======
-	double		tuplecount;		/* # of tuples emitted so far this cycle */
 	BufferUsage bufusage_start; /* buffer usage at start */
 	WalUsage	walusage_start; /* WAL usage at start */
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	/* Accumulated statistics across all completed cycles: */
 	double		startup;		/* total startup time (in seconds) */
 	double		total;			/* total time (in seconds) */
@@ -89,8 +81,8 @@ typedef struct Instrumentation
 	uint64		nloops;			/* # of run cycles for this node */
 	double		nfiltered1;		/* # of tuples removed by scanqual or joinqual */
 	double		nfiltered2;		/* # of tuples removed by "other" quals */
-<<<<<<< HEAD
 	BufferUsage	bufusage;		/* total buffer usage */
+	WalUsage	walusage;		/* total WAL usage */
 
 	double		execmemused;	/* CDB: executor memory used (bytes) */
 	double		workmemused;	/* CDB: work_mem actually used (bytes) */
@@ -103,10 +95,6 @@ typedef struct Instrumentation
 	const char *sortSpaceType;	/* CDB: Sort space type (Memory / Disk) */
 	long		sortSpaceUsed;	/* CDB: Memory / Disk used by sort(KBytes) */
 	struct CdbExplain_NodeSummary *cdbNodeSummary;	/* stats from all qExecs */
-=======
-	BufferUsage bufusage;		/* total buffer usage */
-	WalUsage	walusage;		/* total WAL usage */
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 } Instrumentation;
 
 typedef struct WorkerInstrumentation


### PR DESCRIPTION
Commit df3b181 added a new INSTRUMENT_WAL option to the InstrumentOption enum
in src/include/executor/instrument.h, and new walusage_start and walusage
fields to the Instrumentation structure. Earlier commits 91f86ca and 67db427
had already added the GPDB-specific INSTRUMENT_MEMORY_DETAIL and INSTRUMENT_CDB
options, as well as many GPDB-specific fields to these same locations.