### PR TITLE
Resolve conflicts in src/include/nodes/execnodes.h

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2937,14 +2937,11 @@ typedef struct LimitState
 	LimitStateCond lstate;		/* state machine status, as above */
 	int64		position;		/* 1-based index of last tuple returned */
 	TupleTableSlot *subSlot;	/* tuple last obtained from subplan */
-<<<<<<< HEAD
 
 	bool		expect_rescan;
-=======
 	ExprState  *eqfunction;		/* tuple equality qual in case of WITH TIES
 								 * option */
 	TupleTableSlot *last_slot;	/* slot for evaluation of ties */
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 } LimitState;
 
 /*

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2420,13 +2420,12 @@ typedef struct SortState
 	bool		am_worker;		/* are we a worker? */
 	SharedSortInfo *shared_info;	/* one entry per worker */
 
-<<<<<<< HEAD
 	bool		delayEagerFree;		/* is it safe to free memory used by this node,
 									 * when this node has outputted its last row? */
 	TuplesortInstrumentation sortstats; /* holds stats, if the Sort is eagerly free'd */
 
 } SortState;
-=======
+
 /* ----------------
  *	 Instrumentation information for IncrementalSort
  * ----------------
@@ -2502,7 +2501,6 @@ typedef struct GroupState
 	ExprState  *eqfunction;		/* equality function */
 	bool		grp_done;		/* indicates completion of Group scan */
 } GroupState;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 /* ---------------------
  *	AggState information


### PR DESCRIPTION
1) Commit d2d8a22 added new structures IncrementalSortGroupInfo,
IncrementalSortInfo, SharedIncrementalSortInfo, SharedIncrementalSortInfo, and
the IncrementalSortExecutionStatus enumeration to
src/include/nodes/execnodes.h. Earlier commits 19cd1cf and 6195b96 had already
added the GPDB-specific fields delayEagerFree and sortstats to the SortState
structure above.

2) Commit 357889e added new fields eqfunction and last_slot to the LimitState
structure in src/include/nodes/execnodes.h, while the earlier commit a7df6f9
had already added the GPDB-specific expect_rescan field in the same location.