### PR TITLE
Resolve conflicts in src/include/nodes/nodes.h

### DIFF
--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -94,11 +94,10 @@ typedef enum NodeTag
 	T_HashJoin,
 	T_Material,
 	T_Sort,
-<<<<<<< HEAD
-=======
 	T_IncrementalSort,
+#ifdef NOT_USED /* Group nodes are not used in GPDB */
 	T_Group,
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#endif
 	T_Agg,
 	T_TupleSplit,
 	T_WindowAgg,
@@ -171,11 +170,10 @@ typedef enum NodeTag
 	T_HashJoinState,
 	T_MaterialState,
 	T_SortState,
-<<<<<<< HEAD
-=======
 	T_IncrementalSortState,
+#ifdef NOT_USED /* GroupState nodes are not used in GPDB */
 	T_GroupState,
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#endif
 	T_AggState,
 	T_TupleSplitState,
 	T_WindowAggState,


### PR DESCRIPTION
Commit d2d8a22 added new options T_IncrementalSort and T_IncrementalSortState
to the NodeTag enum in src/include/nodes/nodes.h. However, an earlier commit,
38d8815, had already removed the options T_Group and T_GroupState as
unsupported in the GPDB.