### PR TITLE
Resolve conflicts in src/include/optimizer/paths.h

### DIFF
--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -108,14 +108,7 @@ extern bool have_join_order_restriction(PlannerInfo *root,
 										RelOptInfo *rel1, RelOptInfo *rel2);
 extern bool have_dangerous_phv(PlannerInfo *root,
 							   Relids outer_relids, Relids inner_params);
-<<<<<<< HEAD
 extern void mark_dummy_rel(PlannerInfo *root, RelOptInfo *rel);
-extern bool have_partkey_equi_join(RelOptInfo *joinrel,
-								   RelOptInfo *rel1, RelOptInfo *rel2,
-								   JoinType jointype, List *restrictlist);
-=======
-extern void mark_dummy_rel(RelOptInfo *rel);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 /*
  * equivclass.c


### PR DESCRIPTION
Commit 0568e7a in src/include/optimizer/paths.h removed the declaration of the
have_partkey_equi_join function, although the earlier commit 19cd1cf had
already added a new rel argument to the mark_dummy_rel function above.