### PR TITLE
Resolve conflicts in src/include/storage/smgr.h

### DIFF
--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -147,11 +147,8 @@ extern void smgrclose(SMgrRelation reln);
 extern void smgrcloseall(void);
 extern void smgrclosenode(RelFileNodeBackend rnode);
 extern void smgrcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo);
-<<<<<<< HEAD
 extern void smgrcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo);
-=======
 extern void smgrdosyncall(SMgrRelation *rels, int nrels);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 extern void smgrdounlinkall(SMgrRelation *rels, int nrels, bool isRedo);
 extern void smgrextend(SMgrRelation reln, ForkNumber forknum,
 					   BlockNumber blocknum, char *buffer, bool skipFsync);


### PR DESCRIPTION
Commit c6b9204 added a definition of the new function smgrdosyncall to
src/include/storage/smgr.h, while earlier commit 25a9039 had already added a
definition of the GPDB-specific function smgrcreate_ao to the same location.