### PR TITLE
Resolve conflicts in src/include/utils/selfuncs.h

### DIFF
--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -155,12 +155,7 @@ extern double histogram_selectivity(VariableStatData *vardata, FmgrInfo *opproc,
 									Datum constval, bool varonleft,
 									int min_hist_size, int n_skip,
 									int *hist_size);
-<<<<<<< HEAD
-/* GPDB: avoid C++ keyword "operator" for header include in gpopt C++ code */
-extern double generic_restriction_selectivity(PlannerInfo *root, Oid operOid,
-=======
 extern double generic_restriction_selectivity(PlannerInfo *root, Oid oproid,
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 											  List *args, int varRelid,
 											  double default_selectivity);
 extern double ineq_histogram_selectivity(PlannerInfo *root,


### PR DESCRIPTION
Commit 9d25e1a renamed the operator argument to oproid in the
generic_restriction_selectivity function definition in
src/include/utils/selfuncs.h, although an earlier commit 290e8a2(4cecf9a) had
already done the same, but in a different way.