### PR TITLE
Resolve conflicts in src/backend/executor/nodeHash.c

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -879,10 +879,7 @@ ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
 		dbatch = ceil(inner_rel_bytes / (hash_table_bytes - bucket_bytes));
 		dbatch = Min(dbatch, max_pointers);
 		minbatch = (int) dbatch;
-<<<<<<< HEAD
-		nbatch = 2;
-		while (nbatch < minbatch)
-			nbatch <<= 1;
+		nbatch = pg_nextpower2_32(Max(2, minbatch));
 
 		/*
 		 * Check to see if we're capping the number of workfiles we allow per
@@ -917,9 +914,6 @@ ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
 				nbatch = nbatch_lower;
 			}
 		}
-=======
-		nbatch = pg_nextpower2_32(Max(2, minbatch));
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	}
 	else
 	{


### PR DESCRIPTION
Commit 02a2e8b442002a698336954633b0ccc4e30061e6 replaced nbatch calculation
with function pg_nextpower2_32, however there is a GPDB-specific block from
GPDB initial commit after it.