### PR TITLE
Resolve conflicts in copyfuncs.c, readfuncs.c and readfast.c

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -5980,15 +5980,14 @@ copyObjectImpl(const void *from)
 		case T_Sort:
 			retval = _copySort(from);
 			break;
-<<<<<<< HEAD
-=======
 		case T_IncrementalSort:
 			retval = _copyIncrementalSort(from);
 			break;
+#ifdef NOT_USED
 		case T_Group:
 			retval = _copyGroup(from);
 			break;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#endif
 		case T_Agg:
 			retval = _copyAgg(from);
 			break;

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -389,6 +389,7 @@ _readSelectStmt(void)
 	READ_NODE_FIELD(scatterClause);
 	READ_NODE_FIELD(limitOffset);
 	READ_NODE_FIELD(limitCount);
+	READ_ENUM_FIELD(limitOption, LimitOption);
 	READ_NODE_FIELD(lockingClause);
 	READ_NODE_FIELD(withClause);
 	READ_ENUM_FIELD(op, SetOperation);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -778,6 +778,8 @@ _readIndexStmt(void)
 	READ_STRING_FIELD(idxcomment);
 	READ_OID_FIELD(indexOid);
 	READ_OID_FIELD(oldNode);
+	READ_UINT_FIELD(oldCreateSubid);
+	READ_UINT_FIELD(oldFirstRelfilenodeSubid);
 	READ_BOOL_FIELD(unique);
 	READ_BOOL_FIELD(primary);
 	READ_BOOL_FIELD(isconstraint);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -4721,13 +4721,12 @@ parseNodeString(void)
 		return_value = _readMaterial();
 	else if (MATCH("SORT", 4))
 		return_value = _readSort();
-<<<<<<< HEAD
-=======
 	else if (MATCH("INCREMENTALSORT", 15))
 		return_value = _readIncrementalSort();
+#ifdef NOT_USED
 	else if (MATCH("GROUP", 5))
 		return_value = _readGroup();
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#endif
 	else if (MATCH("AGG", 3))
 		return_value = _readAgg();
 	else if (MATCH("TupleSplit", 10))


### PR DESCRIPTION
1. Commit d2d8a229bc58a2014dce1c7a4fcdb6c5ab9fb8da added new node type
IncrementalSort, so a new copy and read functions were added. However,
an earlier commit 38d88155520790b268b1a380caa9a2d9508edc66
had already removed node type Group as unsupported in the GPDB.

2. Commit c6b92041d38512a4176ed76ad06f713d2e6c01a8 added new fields
oldCreateSubid and oldFirstRelfilenodeSubid to _outIndexStmt, but hasn't
updated readfuncs.c since _readIndexStmt is only present in GPDB.

3. Commit 357889eb17bb9c9336c4f324ceb1651da616fe57 added new field limitOption
to _outSelectStmt, but hasn't updated readfast.c since _readSelectStmt is only
present in GPDB.