### PR TITLE
Resolve conflicts in src/backend/access/nbtree/nbtree.c

### DIFF
--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -1492,14 +1492,10 @@ backtrack:
 		 * (doesn't seem worth adding more complexity to deal with that).
 		 */
 		if (minoff > maxoff)
-<<<<<<< HEAD
-			delete_now = (blkno == orig_blkno);
+			attempt_pagedel = (blkno == scanblkno);
 		else if (callback == NULL)
 			/* GPDB_13_MERGE_FIXME: Commit 02c9386 has alternative fix */
 			stats->num_index_tuples += maxoff - minoff + 1;
-=======
-			attempt_pagedel = (blkno == scanblkno);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 		else
 			stats->num_index_tuples += nhtidslive;
 


### PR DESCRIPTION
Commit 9dc7251 in src/backend/access/nbtree/nbtree.c in the btvacuumpage
function renamed the local variable delete_now to attempt_pagedel, while an
earlier commit e54c51f had already added a callback check in one place.