### PR TITLE
Resolve conflicts in src/backend/access/transam/xact.c

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2800,15 +2800,15 @@ CommitTransaction(void)
 	 */
 	PreCommit_on_commit_actions();
 
+	/* This can still fail */
+	AtEOXact_DispatchOids(true);
+
 	/*
 	 * Synchronize files that are created and not WAL-logged during this
 	 * transaction. This must happen before AtEOXact_RelationMap(), so that we
 	 * don't see committed-but-broken files after a crash.
 	 */
 	smgrDoPendingSyncs(true, is_parallel_worker);
-
-	/* This can still fail */
-	AtEOXact_DispatchOids(true);
 
 	/* close large objects before lower-level cleanup */
 	AtEOXact_LargeObject(true);
@@ -3120,14 +3120,14 @@ PrepareTransaction(void)
 	 */
 	PreCommit_on_commit_actions();
 
+	AtEOXact_DispatchOids(true);
+
 	/*
 	 * Synchronize files that are created and not WAL-logged during this
 	 * transaction. This must happen before EndPrepare(), so that we don't see
 	 * committed-but-broken files after a crash and COMMIT PREPARED.
 	 */
 	smgrDoPendingSyncs(true, false);
-
-	AtEOXact_DispatchOids(true);
 
 	/* close large objects before lower-level cleanup */
 	AtEOXact_LargeObject(true);
@@ -3504,7 +3504,6 @@ AbortTransaction(void)
 	AfterTriggerEndXact(false); /* 'false' means it's abort */
 	AtAbort_EndpointExecState();
 	AtAbort_Portals();
-	smgrDoPendingSyncs(false, is_parallel_worker);
 
 	AtAbort_DispatcherState();
 	AtEOXact_SharedSnapshot();
@@ -3514,6 +3513,8 @@ AbortTransaction(void)
 		AtAbort_ResScheduler();
 
 	AtEOXact_DispatchOids(false);
+
+	smgrDoPendingSyncs(false, is_parallel_worker);
 
 	AtEOXact_LargeObject(false);
 	AtAbort_Notify();

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2800,17 +2800,15 @@ CommitTransaction(void)
 	 */
 	PreCommit_on_commit_actions();
 
-<<<<<<< HEAD
-	/* This can still fail */
-	AtEOXact_DispatchOids(true);
-=======
 	/*
 	 * Synchronize files that are created and not WAL-logged during this
 	 * transaction. This must happen before AtEOXact_RelationMap(), so that we
 	 * don't see committed-but-broken files after a crash.
 	 */
 	smgrDoPendingSyncs(true, is_parallel_worker);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+
+	/* This can still fail */
+	AtEOXact_DispatchOids(true);
 
 	/* close large objects before lower-level cleanup */
 	AtEOXact_LargeObject(true);
@@ -3122,16 +3120,14 @@ PrepareTransaction(void)
 	 */
 	PreCommit_on_commit_actions();
 
-<<<<<<< HEAD
-	AtEOXact_DispatchOids(true);
-=======
 	/*
 	 * Synchronize files that are created and not WAL-logged during this
 	 * transaction. This must happen before EndPrepare(), so that we don't see
 	 * committed-but-broken files after a crash and COMMIT PREPARED.
 	 */
 	smgrDoPendingSyncs(true, false);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+
+	AtEOXact_DispatchOids(true);
 
 	/* close large objects before lower-level cleanup */
 	AtEOXact_LargeObject(true);
@@ -3508,7 +3504,8 @@ AbortTransaction(void)
 	AfterTriggerEndXact(false); /* 'false' means it's abort */
 	AtAbort_EndpointExecState();
 	AtAbort_Portals();
-<<<<<<< HEAD
+	smgrDoPendingSyncs(false, is_parallel_worker);
+
 	AtAbort_DispatcherState();
 	AtEOXact_SharedSnapshot();
 
@@ -3518,9 +3515,6 @@ AbortTransaction(void)
 
 	AtEOXact_DispatchOids(false);
 
-=======
-	smgrDoPendingSyncs(false, is_parallel_worker);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	AtEOXact_LargeObject(false);
 	AtAbort_Notify();
 	AtEOXact_RelationMap(false, is_parallel_worker);

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3121,7 +3121,6 @@ PrepareTransaction(void)
 	PreCommit_on_commit_actions();
 
 	AtEOXact_DispatchOids(true);
-
 	/*
 	 * Synchronize files that are created and not WAL-logged during this
 	 * transaction. This must happen before EndPrepare(), so that we don't see
@@ -3504,7 +3503,6 @@ AbortTransaction(void)
 	AfterTriggerEndXact(false); /* 'false' means it's abort */
 	AtAbort_EndpointExecState();
 	AtAbort_Portals();
-
 	AtAbort_DispatcherState();
 	AtEOXact_SharedSnapshot();
 
@@ -3515,7 +3513,6 @@ AbortTransaction(void)
 	AtEOXact_DispatchOids(false);
 
 	smgrDoPendingSyncs(false, is_parallel_worker);
-
 	AtEOXact_LargeObject(false);
 	AtAbort_Notify();
 	AtEOXact_RelationMap(false, is_parallel_worker);


### PR DESCRIPTION
Commit c6b9204 in src/backend/access/transam/xact.c added calls to the
smgrDoPendingSyncsl function in the CommitTransaction, PrepareTransaction, and
AbortTransaction functions. However, the earlier commit f9016da had already
added calls to the AtEOXact_DispatchOids function in these same locations.