### PR TITLE
Resolve conflicts in src/backend/access/transam/xlog.c

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10181,7 +10181,7 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 		 * will use Checkpoint redo location prior to restart_lsn as cut-off
 		 * point.
 		 */
-		if (max_slot_wal_keep_size_mb > 0 && !XLogRecPtrIsInvalid(PriorRedoPtr))
+		if (!XLogRecPtrIsInvalid(PriorRedoPtr))
 		{
 			if (PriorRedoPtr < keep)
 			{
@@ -10193,6 +10193,7 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 		}
 
 		XLByteToSeg(keep, segno, wal_segment_size);
+		setvalue = true;
 
 		/* Cap by max_slot_wal_keep_size ... */
 		if (max_slot_wal_keep_size_mb >= 0)
@@ -10204,8 +10205,6 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 
 			if (currSegNo - segno > slot_keep_segs)
 				segno = currSegNo - slot_keep_segs;
-
-			setvalue = true;
 		}
 	}
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9595,12 +9595,8 @@ CreateCheckPoint(int flags)
 	 * prevent the disk holding the xlog from growing full.
 	 */
 	XLByteToSeg(RedoRecPtr, _logSegNo, wal_segment_size);
-<<<<<<< HEAD
 	KeepLogSeg(recptr, &_logSegNo, PriorRedoPtr);
-=======
-	KeepLogSeg(recptr, &_logSegNo);
 	InvalidateObsoleteReplicationSlots(_logSegNo);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	_logSegNo--;
 	RemoveOldXlogFiles(_logSegNo, RedoRecPtr, recptr);
 
@@ -9984,12 +9980,8 @@ CreateRestartPoint(int flags)
 	receivePtr = GetWalRcvFlushRecPtr(NULL, NULL);
 	replayPtr = GetXLogReplayRecPtr(&replayTLI);
 	endptr = (receivePtr < replayPtr) ? replayPtr : receivePtr;
-<<<<<<< HEAD
 	KeepLogSeg(endptr, &_logSegNo, InvalidXLogRecPtr);
-=======
-	KeepLogSeg(endptr, &_logSegNo);
 	InvalidateObsoleteReplicationSlots(_logSegNo);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	_logSegNo--;
 
 	/*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10155,7 +10155,12 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 	XLByteToSeg(recptr, currSegNo, wal_segment_size);
 	segno = currSegNo;
 
-<<<<<<< HEAD
+	/*
+	 * Calculate how many segments are kept by slots first, adjusting for
+	 * max_slot_wal_keep_size.
+	 */
+	keep = XLogGetReplicationSlotMinimumLSN();
+
 #ifdef FAULT_INJECTOR
 	/*
 	 * Let the WAL still needed be removed.  This is used to test if WAL sender
@@ -10169,23 +10174,24 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 	}
 #endif
 
-	/* compute limit for wal_keep_segments first */
-	if (wal_keep_segments > 0)
-	{
-		/* avoid underflow, don't go below 1 */
-		if (segno <= wal_keep_segments)
-			segno = 1;
-		else
-			segno = segno - wal_keep_segments;
-		setvalue = true;
-=======
-	/*
-	 * Calculate how many segments are kept by slots first, adjusting for
-	 * max_slot_wal_keep_size.
-	 */
-	keep = XLogGetReplicationSlotMinimumLSN();
 	if (keep != InvalidXLogRecPtr)
 	{
+		/*
+		 * GPDB never uses restart_lsn as lowest cut-off point. Instead always
+		 * will use Checkpoint redo location prior to restart_lsn as cut-off
+		 * point.
+		 */
+		if (max_slot_wal_keep_size_mb > 0 && !XLogRecPtrIsInvalid(PriorRedoPtr))
+		{
+			if (PriorRedoPtr < keep)
+			{
+				keep = PriorRedoPtr;
+				CkptRedoBeforeMinLSN = PriorRedoPtr;
+			}
+			else if (!XLogRecPtrIsInvalid(CkptRedoBeforeMinLSN))
+				keep = CkptRedoBeforeMinLSN;
+		}
+
 		XLByteToSeg(keep, segno, wal_segment_size);
 
 		/* Cap by max_slot_wal_keep_size ... */
@@ -10198,54 +10204,25 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 
 			if (currSegNo - segno > slot_keep_segs)
 				segno = currSegNo - slot_keep_segs;
+
+			setvalue = true;
 		}
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	}
 
 	/* but, keep at least wal_keep_segments if that's set */
 	if (wal_keep_segments > 0 && currSegNo - segno < wal_keep_segments)
 	{
-<<<<<<< HEAD
-		XLogSegNo	slotSegNo;
-
-		/*
-		 * GPDB never uses restart_lsn as lowest cut-off point. Instead always
-		 * will use Checkpoint redo location prior to restart_lsn as cut-off
-		 * point.
-		 */
-		if (!XLogRecPtrIsInvalid(PriorRedoPtr))
-		{
-			if (PriorRedoPtr < keep)
-			{
-				keep = PriorRedoPtr;
-				CkptRedoBeforeMinLSN = PriorRedoPtr;
-			}
-			else if (!XLogRecPtrIsInvalid(CkptRedoBeforeMinLSN))
-				keep = CkptRedoBeforeMinLSN;
-		}
-
-		XLByteToSeg(keep, slotSegNo, wal_segment_size);
-
-		if (slotSegNo <= 0)
-			segno = 1;
-		else if (slotSegNo < segno)
-			segno = slotSegNo;
-		setvalue = true;
-	}
-
-	/* don't delete WAL segments newer than the calculated segment */
-	if (setvalue && segno < *logSegNo)
-=======
 		/* avoid underflow, don't go below 1 */
 		if (currSegNo <= wal_keep_segments)
 			segno = 1;
 		else
 			segno = currSegNo - wal_keep_segments;
+
+		setvalue = true;
 	}
 
 	/* don't delete WAL segments newer than the calculated segment */
-	if (XLogRecPtrIsInvalid(*logSegNo) || segno < *logSegNo)
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+	if (setvalue && (XLogRecPtrIsInvalid(*logSegNo) || segno < *logSegNo))
 		*logSegNo = segno;
 }
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10087,7 +10087,7 @@ GetWALAvailability(XLogRecPtr targetLSN)
 
 	/* calculate oldest segment currently needed by slots */
 	XLByteToSeg(targetLSN, targetSeg, wal_segment_size);
-	KeepLogSeg(currpos, &oldestSlotSeg);
+	KeepLogSeg(currpos, &oldestSlotSeg, InvalidXLogRecPtr);
 
 	/*
 	 * Find the oldest extant segment file. We get 1 until checkpoint removes
@@ -13130,7 +13130,7 @@ WaitForWALToBecomeAvailable(XLogRecPtr RecPtr, bool randAccess,
 						elogif(debug_xlog_record_read, LOG,
 							   "xlog page read -- There is enough xlog data to be "
 							   "read (receivedupto %X/%X, requestedrec %X/%X)",
-							   (uint32) (receivedUpto >> 32), (uint32) receivedUpto,
+							   (uint32) (flushedUpto >> 32), (uint32) flushedUpto,
 							   (uint32) (RecPtr >> 32), (uint32) RecPtr);
 
 						/*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -13128,7 +13128,7 @@ WaitForWALToBecomeAvailable(XLogRecPtr RecPtr, bool randAccess,
 					{
 						elogif(debug_xlog_record_read, LOG,
 							   "xlog page read -- There is enough xlog data to be "
-							   "read (receivedupto %X/%X, requestedrec %X/%X)",
+							   "read (flushedUpto %X/%X, requestedrec %X/%X)",
 							   (uint32) (flushedUpto >> 32), (uint32) flushedUpto,
 							   (uint32) (RecPtr >> 32), (uint32) RecPtr);
 


### PR DESCRIPTION
1) Commit c655077 in src/backend/access/transam/xlog.c added a call to the
InvalidateObsoleteReplicationSlots function in the CreateCheckPoint and
CreateRestartPoint functions. However, an earlier commit, 185c7d7, had already
added a new PriorRedoPtr argument to the KeepLogSeg function call before this
point.

2) Commit c655077 in src/backend/access/transam/xlog.c significantly refactored
the KeepLogSeg function. However, earlier GPDB-specific commits had already
refactored it differently.

3) Commit c655077 in src/backend/access/transam/xlog.c added a new function,
GetWALAvailability, which calls the KeepLogSeg function. However, earlier
commit 185c7d7 had already added a new argument, PriorRedoPtr, to the
KeepLogSeg function.

4) Commit d140f2f in src/backend/access/transam/xlog.c renamed receivedUpto to
flushedUpto, rename in GPDB-specific code.