### PR TITLE
Resolve conflicts in src/backend/catalog/index.c

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -3829,11 +3829,8 @@ reindex_relation(Oid relid, int flags, int options)
 	List	   *indexIds;
 	char		persistence;
 	bool		result;
-<<<<<<< HEAD
-	bool relIsAO = false;
-=======
+	bool		relIsAO = false;
 	ListCell   *indexId;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	int			i;
 
 	/*


### PR DESCRIPTION
Commit d12bdba added a new local variable indexId to the reindex_relation
function in src/backend/catalog/index.c, while the earlier commit 6b0e52b had
already added a new local variable relIsAO to the same location.