### PR TITLE
Resolve conflicts in src/backend/catalog/pg_publication.c

### DIFF
--- a/src/backend/catalog/pg_publication.c
+++ b/src/backend/catalog/pg_publication.c
@@ -42,13 +42,8 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "catalog/oid_dispatch.h"
 
-static List *get_rel_publications(Oid relid);
-
-=======
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 /*
  * Check if relation can be in given publication and throws appropriate
  * error if not.


### PR DESCRIPTION
Commit 83fd453 removed the definition of the get_rel_publications function in
src/backend/catalog/pg_publication.c, although an earlier commit, 19cd1cf, had
already added a new include, catalog/oid_dispatch.h, before that point.