### PR TITLE
Resolve conflicts in src/backend/commands/cluster.c

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -382,18 +382,6 @@ cluster_rel(Oid tableOid, Oid indexOid, int options, bool printError)
 				pgstat_progress_end_command();
 				return false;
 			}
-<<<<<<< HEAD
-			indexForm = (Form_pg_index) GETSTRUCT(tuple);
-			if (!indexForm->indisclustered)
-			{
-				ReleaseSysCache(tuple);
-				relation_close(OldHeap, AccessExclusiveLock);
-				pgstat_progress_end_command();
-				return false;
-			}
-			ReleaseSysCache(tuple);
-=======
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 		}
 	}
 


### PR DESCRIPTION
Commit 8ef9451 in src/backend/commands/cluster.c refactored the code in the
cluster_rel function, while earlier commit e5d1779 had already replaced return
with return false in the same location.