### PR TITLE
Resolve conflicts in src/backend/commands/copy.c

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3813,19 +3813,6 @@ CopyFrom(CopyState cstate)
 		(cstate->rel->rd_createSubid != InvalidSubTransactionId ||
 		 cstate->rel->rd_firstRelfilenodeSubid != InvalidSubTransactionId))
 		ti_options |= TABLE_INSERT_SKIP_FSM;
-<<<<<<< HEAD
-		/*
-		 * The optimization to skip WAL has been disabled in GPDB. wal_level
-		 * is hardcoded to 'archive' in GPDB, so it wouldn't have any effect
-		 * anyway.
-		 */
-#if 0
-		if (!XLogIsNeeded())
-			ti_options |= TABLE_INSERT_SKIP_WAL;
-#endif
-	}
-=======
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 	/*
 	 * Optimize if new relfilenode was created in this subxact or one of its


### PR DESCRIPTION
Commit c6b9204 in src/backend/commands/copy.c in the CopyFrom function removed
the conditional setting of the TABLE_INSERT_SKIP_WAL option, although earlier
commit 25a9039 had already disabled the same location.