### PR TITLE
Resolve conflicts in src/backend/commands/explain.c

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -3009,13 +3009,13 @@ show_windowagg_keys(WindowAggState *waggstate, List *ancestors, ExplainState *es
 	if ( window->partNumCols > 0 )
 	{
 		show_sort_group_keys((PlanState *) outerPlanState(waggstate), "Partition By",
-							 window->partNumCols, window->partColIdx,
+							 window->partNumCols, 0, window->partColIdx,
 							 NULL, NULL, NULL,
 							 ancestors, es);
 	}
 
 	show_sort_group_keys((PlanState *) outerPlanState(waggstate), "Order By",
-						 window->ordNumCols, window->ordColIdx,
+						 window->ordNumCols, 0, window->ordColIdx,
 						 NULL, NULL, NULL,
 						 ancestors, es);
 	ancestors = list_delete_first(ancestors);
@@ -3093,7 +3093,7 @@ show_tuple_split_keys(TupleSplitState *tstate, List *ancestors,
 
 	if (plan->numCols > 0)
 		show_sort_group_keys(outerPlanState(tstate), "Group Key",
-							 plan->numCols, plan->grpColIdx,
+							 plan->numCols, 0, plan->grpColIdx,
 							 NULL, NULL, NULL,
 							 ancestors, es);
 

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -128,12 +128,9 @@ static void show_sortorder_options(StringInfo buf, Node *sortexpr,
 static void show_tablesample(TableSampleClause *tsc, PlanState *planstate,
 							 List *ancestors, ExplainState *es);
 static void show_sort_info(SortState *sortstate, ExplainState *es);
-<<<<<<< HEAD
 static void show_windowagg_keys(WindowAggState *waggstate, List *ancestors, ExplainState *es);
-=======
 static void show_incremental_sort_info(IncrementalSortState *incrsortstate,
 									   ExplainState *es);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 static void show_hash_info(HashState *hashstate, ExplainState *es);
 static void show_hashagg_info(AggState *hashstate, ExplainState *es);
 static void show_tidbitmap_info(BitmapHeapScanState *planstate,
@@ -1708,17 +1705,17 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		case T_Sort:
 			pname = sname = "Sort";
 			break;
-<<<<<<< HEAD
 		case T_TupleSplit:
 			pname = "TupleSplit";
-=======
+			break;
 		case T_IncrementalSort:
 			pname = sname = "Incremental Sort";
 			break;
+#ifdef NOT_USED /* Group nodes are not used in GPDB */
 		case T_Group:
 			pname = sname = "Group";
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 			break;
+#endif
 		case T_Agg:
 			{
 				Agg		   *agg = (Agg *) plan;
@@ -2685,15 +2682,11 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		}
 	}
 
-<<<<<<< HEAD
 	/* Show executor statistics */
 	if (planstate->instrument && planstate->instrument->need_cdb)
 		cdbexplain_showExecStats(planstate, es);
 
-	/* Show buffer usage */
-=======
 	/* Show buffer/WAL usage */
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	if (es->buffers && planstate->instrument)
 		show_buffer_usage(es, &planstate->instrument->bufusage);
 	if (es->wal && planstate->instrument)
@@ -2998,17 +2991,9 @@ static void
 show_sort_keys(SortState *sortstate, List *ancestors, ExplainState *es)
 {
 	Sort	   *plan = (Sort *) sortstate->ss.ps.plan;
-	const char *SortKeystr;
 
-<<<<<<< HEAD
-	SortKeystr = "Sort Key";
-
-	show_sort_group_keys((PlanState *) sortstate, SortKeystr,
-						 plan->numCols, plan->sortColIdx,
-=======
 	show_sort_group_keys((PlanState *) sortstate, "Sort Key",
 						 plan->numCols, 0, plan->sortColIdx,
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 						 plan->sortOperators, plan->collations,
 						 plan->nullsFirst,
 						 ancestors, es);
@@ -3326,17 +3311,8 @@ show_sort_group_keys(PlanState *planstate, const char *qlabel,
 	}
 
 	ExplainPropertyList(qlabel, result, es);
-<<<<<<< HEAD
-
-	/*
-	 * GPDB_90_MERGE_FIXME: handle rollup times printing
-	 * if (rollup_gs_times > 1)
-	 *	appendStringInfo(es->str, " (%d times)", rollup_gs_times);
-	 */
-=======
 	if (nPresortedKeys > 0)
 		ExplainPropertyList("Presorted Key", resultPresorted, es);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 }
 
 /*


### PR DESCRIPTION
1) Commit d2d8a22 added the definition of a new function,
show_incremental_sort_info, to src/backend/commands/explain.c. An earlier
commit, 25a9039, had already added the definition of another new function,
show_windowagg_keys, to the same location.

2) Commit d2d8a22 added the new option T_IncrementalSort to the ExplainNode
function in src/backend/commands/explain.c. However, an earlier commit,
38d8815, had already removed the option T_Group as unsupported in the GPDB, and
commit 0138eed had already added the option T_TupleSplit to the same location.

3) Commit 33e05f8 in src/backend/commands/explain.c changed the comment in the
ExplainNode function from "Show buffer usage" to "Show buffer/WAL usage," while
earlier commit 5ec5c30 had already added GPDB-specific code before this point.

4) Commit d2d8a22 in src/backend/commands/explain.c added a new argument, 0, to
the show_sort_group_keys function call, while earlier commit 5ec5c30 had, for
some reason, separated the string argument into a separate variable.

5) Commit d2d8a22 in src/backend/commands/explain.c in the show_sort_group_keys
function added the use of the new argument nPresortedKeys, while the earlier
commit 1617960 had already added dead code in the same place.

6) Commit d2d8a22 in src/backend/commands/explain.c in show_sort_group_keys
function added a new argument nPresortedKeys, add it in GPDB-specific code.