### PR TITLE
Resolve conflicts in src/backend/executor/execSRF.c

### DIFF
--- a/src/backend/executor/execSRF.c
+++ b/src/backend/executor/execSRF.c
@@ -262,15 +262,10 @@ ExecMakeTableFunctionResult(SetExprState *setexpr,
 			 */
 			if (first_time)
 			{
-<<<<<<< HEAD
-				oldcontext = MemoryContextSwitchTo(econtext->ecxt_per_query_memory);
-				tupstore = tuplestore_begin_heap(randomAccess, false, operatorMemKB);
-=======
 				MemoryContext oldcontext =
 					MemoryContextSwitchTo(econtext->ecxt_per_query_memory);
 
-				tupstore = tuplestore_begin_heap(randomAccess, false, work_mem);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+				tupstore = tuplestore_begin_heap(randomAccess, false, operatorMemKB);
 				rsinfo.setResult = tupstore;
 				if (!returnsTuple)
 				{


### PR DESCRIPTION
Commit 299298b in src/backend/executor/execSRF.c moved the local variable
oldcontext in the ExecMakeTableFunctionResult function. However, an earlier
commit, 19cd1cf, had already changed the work_mem argument to operatorMemKB
when calling the tuplestore_begin_heap function after this point.