### PR TITLE
Resolve conflicts in src/backend/optimizer/plan/createplan.c

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -127,8 +127,12 @@ static Plan *create_projection_plan(PlannerInfo *root,
 									int flags);
 static Plan *inject_projection_plan(Plan *subplan, List *tlist, bool parallel_safe);
 static Sort *create_sort_plan(PlannerInfo *root, SortPath *best_path, int flags);
+<<<<<<< HEAD
+=======
 static IncrementalSort *create_incrementalsort_plan(PlannerInfo *root,
 													IncrementalSortPath *best_path, int flags);
+static Group *create_group_plan(PlannerInfo *root, GroupPath *best_path);
+>>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 static Unique *create_upper_unique_plan(PlannerInfo *root, UpperUniquePath *best_path,
 										int flags);
 static Agg *create_agg_plan(PlannerInfo *root, AggPath *best_path);
@@ -2255,6 +2259,8 @@ create_sort_plan(PlannerInfo *root, SortPath *best_path, int flags)
 }
 
 /*
+<<<<<<< HEAD
+=======
  * create_incrementalsort_plan
  *
  *	  Do the same as create_sort_plan, but create IncrementalSort plan.
@@ -2281,6 +2287,46 @@ create_incrementalsort_plan(PlannerInfo *root, IncrementalSortPath *best_path,
 }
 
 /*
+ * create_group_plan
+ *
+ *	  Create a Group plan for 'best_path' and (recursively) plans
+ *	  for its subpaths.
+ */
+static Group *
+create_group_plan(PlannerInfo *root, GroupPath *best_path)
+{
+	Group	   *plan;
+	Plan	   *subplan;
+	List	   *tlist;
+	List	   *quals;
+
+	/*
+	 * Group can project, so no need to be terribly picky about child tlist,
+	 * but we do need grouping columns to be available
+	 */
+	subplan = create_plan_recurse(root, best_path->subpath, CP_LABEL_TLIST);
+
+	tlist = build_path_tlist(root, &best_path->path);
+
+	quals = order_qual_clauses(root, best_path->qual);
+
+	plan = make_group(tlist,
+					  quals,
+					  list_length(best_path->groupClause),
+					  extract_grouping_cols(best_path->groupClause,
+											subplan->targetlist),
+					  extract_grouping_ops(best_path->groupClause),
+					  extract_grouping_collations(best_path->groupClause,
+												  subplan->targetlist),
+					  subplan);
+
+	copy_generic_path_info(&plan->plan, (Path *) best_path);
+
+	return plan;
+}
+
+/*
+>>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
  * create_upper_unique_plan
  *
  *	  Create a Unique plan for 'best_path' and (recursively) plans

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -127,12 +127,11 @@ static Plan *create_projection_plan(PlannerInfo *root,
 									int flags);
 static Plan *inject_projection_plan(Plan *subplan, List *tlist, bool parallel_safe);
 static Sort *create_sort_plan(PlannerInfo *root, SortPath *best_path, int flags);
-<<<<<<< HEAD
-=======
 static IncrementalSort *create_incrementalsort_plan(PlannerInfo *root,
 													IncrementalSortPath *best_path, int flags);
+#ifdef NOT_USED /* Group nodes are not used in GPDB */
 static Group *create_group_plan(PlannerInfo *root, GroupPath *best_path);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#endif
 static Unique *create_upper_unique_plan(PlannerInfo *root, UpperUniquePath *best_path,
 										int flags);
 static Agg *create_agg_plan(PlannerInfo *root, AggPath *best_path);
@@ -532,7 +531,7 @@ create_plan_recurse(PlannerInfo *root, Path *best_path, int flags)
 														(IncrementalSortPath *) best_path,
 														flags);
 			break;
-#ifdef NOT_USED
+#ifdef NOT_USED /* Group nodes are not used in GPDB */
 		case T_Group:
 			plan = (Plan *) create_group_plan(root,
 											  (GroupPath *) best_path);
@@ -2259,8 +2258,6 @@ create_sort_plan(PlannerInfo *root, SortPath *best_path, int flags)
 }
 
 /*
-<<<<<<< HEAD
-=======
  * create_incrementalsort_plan
  *
  *	  Do the same as create_sort_plan, but create IncrementalSort plan.
@@ -2286,6 +2283,7 @@ create_incrementalsort_plan(PlannerInfo *root, IncrementalSortPath *best_path,
 	return plan;
 }
 
+#ifdef NOT_USED /* Group nodes are not used in GPDB */
 /*
  * create_group_plan
  *
@@ -2324,9 +2322,9 @@ create_group_plan(PlannerInfo *root, GroupPath *best_path)
 
 	return plan;
 }
+#endif
 
 /*
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
  * create_upper_unique_plan
  *
  *	  Create a Unique plan for 'best_path' and (recursively) plans

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -127,12 +127,8 @@ static Plan *create_projection_plan(PlannerInfo *root,
 									int flags);
 static Plan *inject_projection_plan(Plan *subplan, List *tlist, bool parallel_safe);
 static Sort *create_sort_plan(PlannerInfo *root, SortPath *best_path, int flags);
-<<<<<<< HEAD
-=======
 static IncrementalSort *create_incrementalsort_plan(PlannerInfo *root,
 													IncrementalSortPath *best_path, int flags);
-static Group *create_group_plan(PlannerInfo *root, GroupPath *best_path);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 static Unique *create_upper_unique_plan(PlannerInfo *root, UpperUniquePath *best_path,
 										int flags);
 static Agg *create_agg_plan(PlannerInfo *root, AggPath *best_path);
@@ -301,13 +297,8 @@ static Plan *prepare_sort_from_pathkeys(Plan *lefttree, List *pathkeys,
 static EquivalenceMember *find_ec_member_for_tle(EquivalenceClass *ec,
 												 TargetEntry *tle,
 												 Relids relids);
-<<<<<<< HEAD
-=======
-static Sort *make_sort_from_pathkeys(Plan *lefttree, List *pathkeys,
-									 Relids relids);
 static IncrementalSort *make_incrementalsort_from_pathkeys(Plan *lefttree,
 														   List *pathkeys, Relids relids, int nPresortedCols);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 static Sort *make_sort_from_groupcols(List *groupcls,
 									  AttrNumber *grpColIdx,
 									  Plan *lefttree);
@@ -532,18 +523,17 @@ create_plan_recurse(PlannerInfo *root, Path *best_path, int flags)
 											 (SortPath *) best_path,
 											 flags);
 			break;
-<<<<<<< HEAD
-=======
 		case T_IncrementalSort:
 			plan = (Plan *) create_incrementalsort_plan(root,
 														(IncrementalSortPath *) best_path,
 														flags);
 			break;
+#ifdef NOT_USED
 		case T_Group:
 			plan = (Plan *) create_group_plan(root,
 											  (GroupPath *) best_path);
 			break;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+#endif
 		case T_Agg:
 			if (IsA(best_path, GroupingSetsPath))
 				plan = create_groupingsets_plan(root,
@@ -2265,8 +2255,6 @@ create_sort_plan(PlannerInfo *root, SortPath *best_path, int flags)
 }
 
 /*
-<<<<<<< HEAD
-=======
  * create_incrementalsort_plan
  *
  *	  Do the same as create_sort_plan, but create IncrementalSort plan.
@@ -2293,46 +2281,6 @@ create_incrementalsort_plan(PlannerInfo *root, IncrementalSortPath *best_path,
 }
 
 /*
- * create_group_plan
- *
- *	  Create a Group plan for 'best_path' and (recursively) plans
- *	  for its subpaths.
- */
-static Group *
-create_group_plan(PlannerInfo *root, GroupPath *best_path)
-{
-	Group	   *plan;
-	Plan	   *subplan;
-	List	   *tlist;
-	List	   *quals;
-
-	/*
-	 * Group can project, so no need to be terribly picky about child tlist,
-	 * but we do need grouping columns to be available
-	 */
-	subplan = create_plan_recurse(root, best_path->subpath, CP_LABEL_TLIST);
-
-	tlist = build_path_tlist(root, &best_path->path);
-
-	quals = order_qual_clauses(root, best_path->qual);
-
-	plan = make_group(tlist,
-					  quals,
-					  list_length(best_path->groupClause),
-					  extract_grouping_cols(best_path->groupClause,
-											subplan->targetlist),
-					  extract_grouping_ops(best_path->groupClause),
-					  extract_grouping_collations(best_path->groupClause,
-												  subplan->targetlist),
-					  subplan);
-
-	copy_generic_path_info(&plan->plan, (Path *) best_path);
-
-	return plan;
-}
-
-/*
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
  * create_upper_unique_plan
  *
  *	  Create a Unique plan for 'best_path' and (recursively) plans
@@ -2691,14 +2639,10 @@ create_minmaxagg_plan(PlannerInfo *root, MinMaxAggPath *best_path)
 
 		plan = (Plan *) make_limit(plan,
 								   subparse->limitOffset,
-<<<<<<< HEAD
-								   subparse->limitCount);
-		plan->flow = plan->lefttree->flow;
-=======
 								   subparse->limitCount,
 								   subparse->limitOption,
 								   0, NULL, NULL, NULL);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+		plan->flow = plan->lefttree->flow;
 
 		/* Must apply correct cost/width data to Limit node */
 		plan->startup_cost = mminfo->path->startup_cost;
@@ -6972,7 +6916,6 @@ make_sort(Plan *lefttree, int numCols,
 }
 
 /*
-<<<<<<< HEAD
  * add_sort_cost --- basic routine to accumulate Sort cost into a
  * plan node representing the input cost.
  *
@@ -6996,7 +6939,9 @@ add_sort_cost(PlannerInfo *root, Plan *input, double limit_tuples)
 	input->total_cost = sort_path.total_cost;
 
 	return input;
-=======
+}
+
+/*
  * make_incrementalsort --- basic routine to build an IncrementalSort plan node
  *
  * Caller must have built the sortColIdx, sortOperators, collations, and
@@ -7025,7 +6970,6 @@ make_incrementalsort(Plan *lefttree, int numCols, int nPresortedCols,
 	node->sort.nullsFirst = nullsFirst;
 
 	return node;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 }
 
 /*


### PR DESCRIPTION
1. Commit d2d8a229bc58a2014dce1c7a4fcdb6c5ab9fb8da added IncrementalSort node
type, but an earlier commit 38d88155520790b268b1a380caa9a2d9508edc66 had
already removed node type Group as unsupported in the GPDB. Also,
add_sort_cost function is present in initial GPDB code.

2. Commit 357889eb17bb9c9336c4f324ceb1651da616fe57 added new arguments to
make_limit, but commit 93abe741cd67f04958e2951edff02b45ab6e280f added a
statement setting flow nearby.