### PR TITLE
Resolve conflicts in src/backend/optimizer/plan/subselect.c

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -3181,11 +3181,8 @@ finalize_plan(PlannerInfo *root, Plan *plan,
 		case T_Hash:
 		case T_Material:
 		case T_Sort:
-<<<<<<< HEAD
 		case T_ShareInputScan:
-=======
 		case T_IncrementalSort:
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 		case T_Unique:
 		case T_SetOp:
 		case T_SplitUpdate:


### PR DESCRIPTION
Commit d2d8a22 added the T_IncrementalSort option to the finalize_plan function
in src/backend/optimizer/plan/subselect.c, while an earlier commit, 6b0e52b,
had already added the T_ShareInputScan option to the same location.