### PR TITLE
Resolve conflicts in src/backend/parser/gram.y

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -263,11 +263,8 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 	PartitionSpec		*partspec;
 	PartitionBoundSpec	*partboundspec;
 	RoleSpec			*rolespec;
-<<<<<<< HEAD
 	DistributionKeyElem *dkelem;
-=======
 	struct SelectLimit	*selectlimit;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 }
 
 %type <node>	stmt schema_stmt


### PR DESCRIPTION
Commit 357889e in src/backend/parser/gram.y added a new local variable,
selectlimit, in the makeRecursiveViewSelect function. However, an earlier
commit, 506ebad, had already added another new local variable, dkelem, in the
same location.