### PR TITLE
Resolve conflicts in src/backend/replication/repl_gram.y

### DIFF
--- a/src/backend/replication/repl_gram.y
+++ b/src/backend/replication/repl_gram.y
@@ -218,12 +218,11 @@ base_backup_opt:
 				  $$ = makeDefElem("noverify_checksums",
 								   (Node *)makeInteger(true), -1);
 				}
-<<<<<<< HEAD
 			| K_EXCLUDE SCONST
 				{
 				  $$ = makeDefElem("exclude",
 						  (Node *) makeString($2), -1);
-=======
+				}
 			| K_MANIFEST SCONST
 				{
 				  $$ = makeDefElem("manifest",
@@ -233,7 +232,6 @@ base_backup_opt:
 				{
 				  $$ = makeDefElem("manifest_checksums",
 								   (Node *)makeString($2), -1);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 				}
 			;
 


### PR DESCRIPTION
Commit 0d8c9c1 in src/backend/replication/repl_gram.y in base_backup_opt added
new options, manifest and manifest_checksums, while an earlier commit, 6b0e52b,
had already added another new option, exclude, in the same location.