### PR TITLE
Resolve conflicts in src/backend/replication/syncrep.c

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -654,7 +654,7 @@ SyncRepGetSyncRecPtr(XLogRecPtr *writePtr, XLogRecPtr *flushPtr,
 	*am_sync = false;
 
 	/* Quick out if not even configured to be synchronous */
-	if (SyncRepConfig == NULL)
+	if (!IS_QUERY_DISPATCHER() && SyncRepConfig == NULL)
 		return false;
 
 	/* Get standbys that are considered as synchronous at this moment */

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -879,11 +879,11 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 			if (state != WALSNDSTATE_STREAMING &&
 				state != WALSNDSTATE_STOPPING)
 				continue;
-
-			/* Must be synchronous */
-			if (stby->sync_standby_priority == 0)
-				continue;
 		}
+
+		/* Must be synchronous */
+		if (stby->sync_standby_priority == 0)
+			continue;
 
 		/* Must have a valid flush position */
 		if (XLogRecPtrIsInvalid(stby->flush))

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -674,19 +674,16 @@ SyncRepGetSyncRecPtr(XLogRecPtr *writePtr, XLogRecPtr *flushPtr,
 	 * Nothing more to do if we are not managing a sync standby or there are
 	 * not enough synchronous standbys.
 	 */
-<<<<<<< HEAD
 	if (IS_QUERY_DISPATCHER())
 	{
-		if (list_length(sync_standbys) == 0)
+		if (num_standbys == 0)
+		{
+			pfree(sync_standbys);
 			return false;
+		}
 	}
 	else if (!(*am_sync) ||
-		SyncRepConfig == NULL ||
-		list_length(sync_standbys) < SyncRepConfig->num_sync)
-=======
-	if (!(*am_sync) ||
 		num_standbys < SyncRepConfig->num_sync)
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 	{
 		pfree(sync_standbys);
 		return false;
@@ -827,26 +824,20 @@ cmp_lsn(const void *a, const void *b)
 int
 SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 {
-<<<<<<< HEAD
-	List	   *result = NIL;
-	bool		syncStandbyPresent;
-	int			i;
-	volatile WalSnd *walsnd;	/* Use volatile pointer to prevent code
-								 * rearrangement */
-	Assert(LWLockHeldByMe(SyncRepLock));
-=======
 	int			i;
 	int			n;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 	/* Create result array */
 	*standbys = (SyncRepStandbyData *)
 		palloc(max_wal_senders * sizeof(SyncRepStandbyData));
 
-	/* GPDB_12_MERGE_FIXME: Should this be in SyncRepGetSyncStandbysQuorum()
-	 * instead? */
 	if (IS_QUERY_DISPATCHER())
 	{
+		bool		syncStandbyPresent;
+		int			i;
+		volatile WalSnd *walsnd;	/* Use volatile pointer to prevent code
+									 * rearrangement */
+
 		for (i = 0; i < max_wal_senders; i++)
 		{
 			walsnd = &WalSndCtl->walsnds[i];
@@ -859,10 +850,14 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 
 			if (syncStandbyPresent)
 			{
-				result = lappend_int(result, i);
-				if (am_sync)
-					*am_sync = true;
-				return result;
+				SpinLockAcquire(&walsnd->mutex);
+				standbys[0]->pid = walsnd->pid;
+				standbys[0]->write = walsnd->write;
+				standbys[0]->flush = walsnd->flush;
+				standbys[0]->apply = walsnd->apply;
+				standbys[0]->sync_standby_priority = walsnd->sync_standby_priority;
+				SpinLockRelease(&walsnd->mutex);
+				return 1;
 			}
 		}
 	}

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -663,13 +663,16 @@ SyncRepGetSyncRecPtr(XLogRecPtr *writePtr, XLogRecPtr *flushPtr,
 	/* Get standbys that are considered as synchronous at this moment */
 	num_standbys = SyncRepGetCandidateStandbys(&sync_standbys);
 
-	/* Am I among the candidate sync standbys? */
-	for (i = 0; i < num_standbys; i++)
+	if (!IS_QUERY_DISPATCHER())
 	{
-		if (sync_standbys[i].is_me)
+		/* Am I among the candidate sync standbys? */
+		for (i = 0; i < num_standbys; i++)
 		{
-			*am_sync = true;
-			break;
+			if (sync_standbys[i].is_me)
+			{
+				*am_sync = true;
+				break;
+			}
 		}
 	}
 

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -831,9 +831,12 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 	*standbys = (SyncRepStandbyData *)
 		palloc(max_wal_senders * sizeof(SyncRepStandbyData));
 
-	/* Quick exit if sync replication is not requested */
-	if (SyncRepConfig == NULL)
-		return 0;
+	if (!IS_QUERY_DISPATCHER())
+	{
+		/* Quick exit if sync replication is not requested */
+		if (SyncRepConfig == NULL)
+			return 0;
+	}
 
 	/* Collect raw data from shared memory */
 	n = 0;
@@ -841,9 +844,9 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 	{
 		volatile WalSnd *walsnd;	/* Use volatile pointer to prevent code
 									 * rearrangement */
-		volatile bool caughtup_within_range;
 		SyncRepStandbyData *stby;
 		WalSndState state;		/* not included in SyncRepStandbyData */
+		bool		caughtup_within_range;
 
 		walsnd = &WalSndCtl->walsnds[i];
 		stby = *standbys + n;
@@ -865,13 +868,9 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 
 		if (IS_QUERY_DISPATCHER())
 		{
-			/* Must be streaming or catchup */
+			/* Must be streaming or catchup in range */
 			if (state != WALSNDSTATE_STREAMING &&
-				state != WALSNDSTATE_CATCHUP)
-				continue;
-
-			/* Must be in range */
-			if (!walsnd->caughtup_within_range)
+				(state != WALSNDSTATE_CATCHUP || !caughtup_within_range))
 				continue;
 		}
 		else
@@ -884,11 +883,11 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 			/* Must be synchronous */
 			if (stby->sync_standby_priority == 0)
 				continue;
-
-			/* Must have a valid flush position */
-			if (XLogRecPtrIsInvalid(stby->flush))
-				continue;
 		}
+
+		/* Must have a valid flush position */
+		if (XLogRecPtrIsInvalid(stby->flush))
+			continue;
 
 		/* OK, it's a candidate */
 		stby->walsnd_index = i;

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -849,7 +849,7 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 									 * rearrangement */
 		SyncRepStandbyData *stby;
 		WalSndState state;		/* not included in SyncRepStandbyData */
-		bool		caughtup_within_range;
+		bool		caughtup_within_range = false;
 
 		walsnd = &WalSndCtl->walsnds[i];
 		stby = *standbys + n;

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -721,6 +721,9 @@ SyncRepGetSyncRecPtr(XLogRecPtr *writePtr, XLogRecPtr *flushPtr,
 									  SyncRepConfig->num_sync);
 	}
 
+	if (IS_QUERY_DISPATCHER())
+		*am_sync = true;
+
 	pfree(sync_standbys);
 	return true;
 }

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -907,6 +907,9 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 			return n;
 	}
 
+	if (IS_QUERY_DISPATCHER())
+		return n;
+
 	/*
 	 * In quorum mode, we return all the candidates.  In priority mode, if we
 	 * have too many candidates then return only the num_sync ones of highest

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -896,10 +896,10 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 		stby->walsnd_index = i;
 		stby->is_me = (walsnd == MyWalSnd);
 		n++;
-	}
 
-	if (IS_QUERY_DISPATCHER())
-		return n;
+		if (IS_QUERY_DISPATCHER())
+			return n;
+	}
 
 	/*
 	 * In quorum mode, we return all the candidates.  In priority mode, if we

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -831,37 +831,6 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 	*standbys = (SyncRepStandbyData *)
 		palloc(max_wal_senders * sizeof(SyncRepStandbyData));
 
-	if (IS_QUERY_DISPATCHER())
-	{
-		bool		syncStandbyPresent;
-		int			i;
-		volatile WalSnd *walsnd;	/* Use volatile pointer to prevent code
-									 * rearrangement */
-
-		for (i = 0; i < max_wal_senders; i++)
-		{
-			walsnd = &WalSndCtl->walsnds[i];
-			SpinLockAcquire(&walsnd->mutex);
-			syncStandbyPresent = (walsnd->pid != 0)
-				&& ((walsnd->state == WALSNDSTATE_STREAMING)
-				|| (walsnd->state == WALSNDSTATE_CATCHUP &&
-				walsnd->caughtup_within_range));
-			SpinLockRelease(&walsnd->mutex);
-
-			if (syncStandbyPresent)
-			{
-				SpinLockAcquire(&walsnd->mutex);
-				standbys[0]->pid = walsnd->pid;
-				standbys[0]->write = walsnd->write;
-				standbys[0]->flush = walsnd->flush;
-				standbys[0]->apply = walsnd->apply;
-				standbys[0]->sync_standby_priority = walsnd->sync_standby_priority;
-				SpinLockRelease(&walsnd->mutex);
-				return 1;
-			}
-		}
-	}
-
 	/* Quick exit if sync replication is not requested */
 	if (SyncRepConfig == NULL)
 		return 0;
@@ -872,6 +841,7 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 	{
 		volatile WalSnd *walsnd;	/* Use volatile pointer to prevent code
 									 * rearrangement */
+		volatile bool caughtup_within_range;
 		SyncRepStandbyData *stby;
 		WalSndState state;		/* not included in SyncRepStandbyData */
 
@@ -885,24 +855,40 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 		stby->flush = walsnd->flush;
 		stby->apply = walsnd->apply;
 		stby->sync_standby_priority = walsnd->sync_standby_priority;
+		if (IS_QUERY_DISPATCHER())
+			caughtup_within_range = walsnd->caughtup_within_range;
 		SpinLockRelease(&walsnd->mutex);
 
 		/* Must be active */
 		if (stby->pid == 0)
 			continue;
 
-		/* Must be streaming or stopping */
-		if (state != WALSNDSTATE_STREAMING &&
-			state != WALSNDSTATE_STOPPING)
-			continue;
+		if (IS_QUERY_DISPATCHER())
+		{
+			/* Must be streaming or catchup */
+			if (state != WALSNDSTATE_STREAMING &&
+				state != WALSNDSTATE_CATCHUP)
+				continue;
 
-		/* Must be synchronous */
-		if (stby->sync_standby_priority == 0)
-			continue;
+			/* Must be in range */
+			if (!walsnd->caughtup_within_range)
+				continue;
+		}
+		else
+		{
+			/* Must be streaming or stopping */
+			if (state != WALSNDSTATE_STREAMING &&
+				state != WALSNDSTATE_STOPPING)
+				continue;
 
-		/* Must have a valid flush position */
-		if (XLogRecPtrIsInvalid(stby->flush))
-			continue;
+			/* Must be synchronous */
+			if (stby->sync_standby_priority == 0)
+				continue;
+
+			/* Must have a valid flush position */
+			if (XLogRecPtrIsInvalid(stby->flush))
+				continue;
+		}
 
 		/* OK, it's a candidate */
 		stby->walsnd_index = i;

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -898,6 +898,9 @@ SyncRepGetCandidateStandbys(SyncRepStandbyData **standbys)
 		n++;
 	}
 
+	if (IS_QUERY_DISPATCHER())
+		return n;
+
 	/*
 	 * In quorum mode, we return all the candidates.  In priority mode, if we
 	 * have too many candidates then return only the num_sync ones of highest

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -653,9 +653,12 @@ SyncRepGetSyncRecPtr(XLogRecPtr *writePtr, XLogRecPtr *flushPtr,
 	*applyPtr = InvalidXLogRecPtr;
 	*am_sync = false;
 
-	/* Quick out if not even configured to be synchronous */
-	if (!IS_QUERY_DISPATCHER() && SyncRepConfig == NULL)
-		return false;
+	if (!IS_QUERY_DISPATCHER())
+	{
+		/* Quick out if not even configured to be synchronous */
+		if (SyncRepConfig == NULL)
+			return false;
+	}
 
 	/* Get standbys that are considered as synchronous at this moment */
 	num_standbys = SyncRepGetCandidateStandbys(&sync_standbys);


### PR DESCRIPTION
1) Commit f332241 in src/backend/replication/syncrep.c changed the early exit
condition in the SyncRepGetSyncRecPtr function, while earlier commit 38d8815
had already added a GPDB-specific condition before the same location.

2) Commit f332241 in src/backend/replication/syncrep.c refactored the code in
the SyncRepGetCandidateStandbys function and removed the
SyncRepGetSyncStandbysPriority and SyncRepGetSyncStandbysQuorum functions,
while earlier commit 38d8815 had already added GPDB-specific code to the same
location.

3) Commit f332241 in the src/backend/replication/syncrep.c file in the
SyncRepGetSyncRecPtr function added a conditional return, while in the GPDB
this does not need to be done on the coordinator.