### PR TITLE
Resolve conflicts in src/backend/storage/buffer/bufmgr.c

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -3781,12 +3781,9 @@ MarkBufferDirtyHint(Buffer buffer, bool buffer_std)
 			 *
 			 * See src/backend/storage/page/README for longer discussion.
 			 */
-<<<<<<< HEAD
-			if (RecoveryInProgress() || IsInitProcessingMode())
-=======
 			if (RecoveryInProgress() ||
+				IsInitProcessingMode() ||
 				RelFileNodeSkippingWAL(bufHdr->tag.rnode))
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 				return;
 
 			/*


### PR DESCRIPTION
Commit c6b92041d38512a4176ed76ad06f713d2e6c01a8 added condition with
RelFileNodeSkippingWAL(bufHdr->tag.rnode) while earlier commit
e2c4f61ff7d325f0f169ed544951565260b0808b added condition with
IsInitProcessingMode().