### PR TITLE
Resolve conflicts in src/backend/storage/ipc/procarray.c

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -489,7 +489,6 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 			ProcArrayGroupClearXid(proc, latestXid);
 	}
 
-<<<<<<< HEAD
 	/*
 	 * If we have no XID, we don't need to lock, since we won't affect
 	 * anyone else's calculation of a snapshot.  We might change their
@@ -501,20 +500,12 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 	 */
 	Assert(!TransactionIdIsValid(allPgXact[proc->pgprocno].xid));
 	Assert(!TransactionIdIsValid(allTmGxact[proc->pgprocno].gxid));
-=======
-		proc->lxid = InvalidLocalTransactionId;
-		pgxact->xmin = InvalidTransactionId;
-		/* must be cleared with xid/xmin: */
-		pgxact->vacuumFlags &= ~PROC_VACUUM_STATE_MASK;
-		proc->delayChkpt = false; /* be sure this is cleared in abort */
-		proc->recoveryConflictPending = false;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 	proc->lxid = InvalidLocalTransactionId;
 	pgxact->xmin = InvalidTransactionId;
 	/* must be cleared with xid/xmin: */
 	pgxact->vacuumFlags &= ~PROC_VACUUM_STATE_MASK;
-	pgxact->delayChkpt = false;		/* be sure this is cleared in abort */
+	proc->delayChkpt = false;		/* be sure this is cleared in abort */
 	proc->recoveryConflictPending = false;
 
 	Assert(pgxact->nxids == 0);


### PR DESCRIPTION
Commit 75848bc in src/backend/storage/ipc/procarray.c in the
ProcArrayEndTransaction function changed the setting of the delayChkpt field in
pgxact to the same field in proc, while the earlier commit 2225945 had already
added GPDB-specific code near the same location.