### PR TITLE
Resolve conflicts in src/backend/storage/smgr/smgr.c

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -39,39 +39,10 @@
  * For example, disk quota extension will use these hooks to
  * detect active tables.
  */
-<<<<<<< HEAD
 file_create_hook_type file_create_hook = NULL;
 file_extend_hook_type file_extend_hook = NULL;
 file_truncate_hook_type file_truncate_hook = NULL;
 file_unlink_hook_type file_unlink_hook = NULL;
-=======
-typedef struct f_smgr
-{
-	void		(*smgr_init) (void);	/* may be NULL */
-	void		(*smgr_shutdown) (void);	/* may be NULL */
-	void		(*smgr_open) (SMgrRelation reln);
-	void		(*smgr_close) (SMgrRelation reln, ForkNumber forknum);
-	void		(*smgr_create) (SMgrRelation reln, ForkNumber forknum,
-								bool isRedo);
-	bool		(*smgr_exists) (SMgrRelation reln, ForkNumber forknum);
-	void		(*smgr_unlink) (RelFileNodeBackend rnode, ForkNumber forknum,
-								bool isRedo);
-	void		(*smgr_extend) (SMgrRelation reln, ForkNumber forknum,
-								BlockNumber blocknum, char *buffer, bool skipFsync);
-	bool		(*smgr_prefetch) (SMgrRelation reln, ForkNumber forknum,
-								  BlockNumber blocknum);
-	void		(*smgr_read) (SMgrRelation reln, ForkNumber forknum,
-							  BlockNumber blocknum, char *buffer);
-	void		(*smgr_write) (SMgrRelation reln, ForkNumber forknum,
-							   BlockNumber blocknum, char *buffer, bool skipFsync);
-	void		(*smgr_writeback) (SMgrRelation reln, ForkNumber forknum,
-								   BlockNumber blocknum, BlockNumber nblocks);
-	BlockNumber (*smgr_nblocks) (SMgrRelation reln, ForkNumber forknum);
-	void		(*smgr_truncate) (SMgrRelation reln, ForkNumber forknum,
-								  BlockNumber nblocks);
-	void		(*smgr_immedsync) (SMgrRelation reln, ForkNumber forknum);
-} f_smgr;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 static const f_smgr smgrsw[] = {
 	/* magnetic disk */
@@ -422,7 +393,6 @@ smgrcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo)
 }
 
 /*
-<<<<<<< HEAD
  *		smgrcreate_ao() -- Create a new AO relation segment.
  *		Given a RelFileNode, cause the underlying disk file for the
  *		AO segment to be created.
@@ -436,7 +406,9 @@ smgrcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
 	mdcreate_ao(rnode, segmentFileNum, isRedo);
 	if (file_create_hook)
 		(*file_create_hook)(rnode);
-=======
+}
+
+/*
  *	smgrdosyncall() -- Immediately sync all forks of all given relations
  *
  *		All forks of all given relations are synced out to the store.
@@ -469,7 +441,6 @@ smgrdosyncall(SMgrRelation *rels, int nrels)
 				smgrsw[which].smgr_immedsync(rels[i], forknum);
 		}
 	}
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 }
 
 /*
@@ -581,11 +552,7 @@ smgrextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 bool
 smgrprefetch(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum)
 {
-<<<<<<< HEAD
-	(*reln->storageManager).smgr_prefetch(reln, forknum, blocknum);
-=======
-	return smgrsw[reln->smgr_which].smgr_prefetch(reln, forknum, blocknum);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+	return (*reln->storageManager).smgr_prefetch(reln, forknum, blocknum);
 }
 
 /*

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -106,7 +106,7 @@ typedef struct f_smgr
 								bool isRedo);
 	void		(*smgr_extend) (SMgrRelation reln, ForkNumber forknum,
 								BlockNumber blocknum, char *buffer, bool skipFsync);
-	void		(*smgr_prefetch) (SMgrRelation reln, ForkNumber forknum,
+	bool		(*smgr_prefetch) (SMgrRelation reln, ForkNumber forknum,
 								  BlockNumber blocknum);
 	void		(*smgr_read) (SMgrRelation reln, ForkNumber forknum,
 							  BlockNumber blocknum, char *buffer);


### PR DESCRIPTION
1) Commit 3985b60 in src/backend/storage/smgr/smgr.c changed the type of the
smgr_prefetch field in the f_smgr structure, while an earlier commit b354832
had already moved this structure to src/include/storage/smgr.h.

2) Commit c6b9204 in src/backend/storage/smgr/smgr.c added a new function,
smgrdosyncall, while an earlier commit 25a9039 had already added a new
function, smgrcreate_ao, in the same location.

3) Commit 3985b60 in src/backend/storage/smgr/smgr.c changed the return type
from void to bool in the smgrprefetch function, while the earlier commit
b354832 had already changed the contents of this function.