### PR TITLE
Resolve conflicts in src/backend/utils/sort/tuplesort.c

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -774,26 +774,8 @@ tuplesort_begin_common(int workMem, SortCoordinate coordinate,
 	 * Initial size of array must be more than ALLOCSET_SEPARATE_THRESHOLD;
 	 * see comments in grow_memtuples().
 	 */
-<<<<<<< HEAD
-	state->memtupsize = Max(1024,
-							ALLOCSET_SEPARATE_THRESHOLD / sizeof(SortTuple) + 1);
-
-	state->growmemtuples = true;
-	state->totalNumTuples  = 0; /*CDB*/
-	state->slabAllocatorUsed = false;
-	state->memtuples = (SortTuple *) palloc(state->memtupsize * sizeof(SortTuple));
-
-	USEMEM(state, GetMemoryChunkSpace(state->memtuples));
-
-	/* workMem must be large enough for the minimal memtuples array */
-	if (LACKMEM(state))
-		elog(ERROR, "insufficient memory allowed for sort");
-
-	state->currentRun = 0;
-=======
 	state->memtupsize = INITIAL_MEMTUPSIZE;
 	state->memtuples = NULL;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 	/*
 	 * After all of the other non-parallel-related state, we setup all of the
@@ -869,6 +851,7 @@ tuplesort_begin_batch(Tuplesortstate *state)
 	state->tapeset = NULL;
 
 	state->memtupcount = 0;
+	state->totalNumTuples  = 0; /*CDB*/
 
 	/*
 	 * Initial size of array must be more than ALLOCSET_SEPARATE_THRESHOLD;
@@ -3431,25 +3414,13 @@ tuplesort_get_stats(Tuplesortstate *state,
 	 * GPDB: we have such accounting in memory contexts, so we store the
 	 * memory usage in 'workmemused'.
 	 */
-<<<<<<< HEAD
-	if (state->tapeset)
-	{
-		stats->spaceType = SORT_SPACE_TYPE_DISK;
-		stats->spaceUsed = LogicalTapeSetBlocks(state->tapeset) * (BLCKSZ / 1024);
-	}
-	else
-	{
-		stats->spaceType = SORT_SPACE_TYPE_MEMORY;
-		stats->spaceUsed = (state->allowedMem - state->availMem + 1023) / 1024;
-	}
 	if (state->instrument)
 	{
 		stats->workmemused = state->instrument->workmemused;
 		stats->execmemused = state->instrument->execmemused;
 	}
-=======
+
 	tuplesort_updatemax(state);
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 	if (state->isMaxSpaceDisk)
 		stats->spaceType = SORT_SPACE_TYPE_DISK;

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -4862,10 +4862,10 @@ tuplesort_finalize_stats(Tuplesortstate *state,
 	{
 		double  workmemused;
 
-		workmemused = MemoryContextGetPeakSpace(state->sortcontext);
+		workmemused = MemoryContextGetPeakSpace(state->maincontext);
 		if (state->instrument->workmemused < workmemused)
 			state->instrument->workmemused = workmemused;
-		state->instrument->execmemused += MemoryContextGetPeakSpace(state->sortcontext);
+		state->instrument->execmemused += MemoryContextGetPeakSpace(state->maincontext);
 	}
 	tuplesort_get_stats(state, stats);
 }

--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -729,7 +729,7 @@ tuplesort_begin_common(int workMem, SortCoordinate coordinate,
 	maincontext = AllocSetContextCreate(CurrentMemoryContext,
 										"TupleSort main",
 										ALLOCSET_DEFAULT_SIZES);
-	MemoryContextDeclareAccountingRoot(sortcontext);
+	MemoryContextDeclareAccountingRoot(maincontext);
 
 	/*
 	 * Create a working memory context for one sort operation.  The content of


### PR DESCRIPTION
1. Commit d2d8a229bc58a2014dce1c7a4fcdb6c5ab9fb8da has moved various state
initialization into new function tuplesort_begin_batch, which is called both
on the start of the sort and while switching to a new batch of incremental
sort. However, commit fe0a9ddbdd7eee572f7321f9680280044fd5f258 added field
totalNumTuples for calculation of wanted memory for EXPLAIN ANALYZE. Since
the sort is reset after every batch together with its memory, totalNumTuples
must be reset as well, so setting it to 0 should also be placed into
tuplesort_begin_batch.

2. Commit d2d8a229bc58a2014dce1c7a4fcdb6c5ab9fb8da moved part of resource
usage calculation into tuplesort_updatemax, while commit
fe0a9ddbdd7eee572f7321f9680280044fd5f258 added GPDB-specific code for
workmemused and execmemused.

3. Commit d164804d80305115ac392c7800f70092175335fa added a new main memory
context on top of existing sortcontext. It's the main context that has to
be declared as root. Also, GPDB-specific instrumentation code has to be
updated to use maincontext instead of sortcontext.