### PR TITLE
Resolve conflicts in contrib/auto_explain/auto_explain.c

### DIFF
--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -307,17 +307,14 @@ explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				queryDesc->instrument_options |= INSTRUMENT_ROWS;
 			if (auto_explain_log_buffers)
 				queryDesc->instrument_options |= INSTRUMENT_BUFFERS;
-<<<<<<< HEAD
+			if (auto_explain_log_wal)
+				queryDesc->instrument_options |= INSTRUMENT_WAL;
 
 			queryDesc->instrument_options |= INSTRUMENT_CDB;
 
 			INSTR_TIME_SET_CURRENT(starttime);
 			queryDesc->showstatctx = cdbexplain_showExecStatsBegin(queryDesc,
 																   starttime);
-=======
-			if (auto_explain_log_wal)
-				queryDesc->instrument_options |= INSTRUMENT_WAL;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 		}
 	}
 


### PR DESCRIPTION
Commit 33e05f89c53e5a1533d624046bb6fb0da7bb7141 added flag INSTRUMENT_WAL
while earlier commit 97cc24b252d20df0187889fc1ff4f77689558fa0 added option
INSTRUMENT_CDB nearby.
