### PR TITLE
Fix compilation of src/backend/optimizer/path/costsize.c

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -1887,7 +1887,7 @@ cost_tuplesort(Cost *startup_cost, Cost *run_cost,
 	double		input_bytes = relation_byte_size(tuples, width);
 	double		output_bytes;
 	double		output_tuples;
-	long		sort_mem_bytes = (long) global_work_mem(root);
+	long		sort_mem_bytes = (long) global_work_mem(NULL);
 
 	/*
 	 * We want to be sure the cost of a sort is never estimated as zero, even


### PR DESCRIPTION
Commit d2d8a22 in src/backend/optimizer/path/costsize.c renamed the function
cost_sort to cost_tuplesort and removed its "root" argument. However, the
earlier commit 6b0e52b had already added a call to the GPDB-specific function
global_work_mem using this argument. However, this function doesn't use its
argument internally. Call it with NULL as an argument.