### PR TITLE
Fix compilation of src/backend/catalog/storage.c

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -715,7 +715,8 @@ smgrDoPendingSyncs(bool isCommit, bool isParallelWorker)
 		BlockNumber total_blocks = 0;
 		SMgrRelation srel;
 
-		srel = smgropen(pendingsync->rnode, InvalidBackendId);
+		srel = smgropen(pendingsync->rnode, InvalidBackendId,
+						pending->relnode.smgr_which);
 
 		/*
 		 * We emit newpage WAL records for smaller relations.


### PR DESCRIPTION
Commit c6b9204 added a new function, smgrDoPendingSyncs, to
src/backend/catalog/storage.c, which calls the smgropen function with two
arguments. However, the earlier commit 19cd1cf had already added a new
argument, which, to the smgropen function.