### PR TITLE
Fix compilation of src/backend/commands/explain_gp.c

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -857,7 +857,7 @@ cdbexplain_collectStatsFromNode(PlanState *planstate, CdbExplain_SendStatCtx *ct
 		HashState *hashstate = (HashState *) planstate;
 
 		if (hashstate->hashtable)
-			ExecHashGetInstrumentation(&si->hashstats, hashstate->hashtable);
+			ExecHashAccumInstrumentation(&si->hashstats, hashstate->hashtable);
 	}
 }								/* cdbexplain_collectStatsFromNode */
 


### PR DESCRIPTION
Commit 969f9d0b renamed the ExecHashGetInstrumentation function to
ExecHashAccumInstrumentation. Rename it in the GPDB-specific code.