### PR TITLE
Fix compilation of src/backend/access/heap/rewriteheap.c

### DIFF
--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -699,7 +699,7 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 			state->rs_blockno++;
 			state->rs_buffer_valid = false;
 
-			if (state->rs_use_wal)
+			if (RelationNeedsWAL(state->rs_new_rel))
 				wait_to_avoid_large_repl_lag();
 		}
 	}


### PR DESCRIPTION
Commit c6b9204 in src/backend/access/heap/rewriteheap.c in the RewriteStateData
structure removed the rs_use_wal field, replacing its usage with
RelationNeedsWAL. Replace this in GPDB-specific code.