### PR TITLE
Fix compilation of src/backend/replication/backup_manifest.c

### DIFF
--- a/src/backend/replication/backup_manifest.c
+++ b/src/backend/replication/backup_manifest.c
@@ -60,7 +60,7 @@ InitializeBackupManifest(backup_manifest_info *manifest,
 	if (want_manifest == MANIFEST_OPTION_NO)
 		manifest->buffile = NULL;
 	else
-		manifest->buffile = BufFileCreateTemp(false);
+		manifest->buffile = BufFileCreateTemp("InitializeBackupManifest", false);
 	manifest->checksum_type = manifest_checksum_type;
 	pg_sha256_init(&manifest->manifest_ctx);
 	manifest->manifest_size = UINT64CONST(0);


### PR DESCRIPTION
Commit 079ac29 added a new file, src/backend/replication/backup_manifest.c,
containing the InitializeBackupManifest function, which calls the
BufFileCreateTemp function with one argument. However, the earlier commit
f1ef366 had already added an additional argument, operation_name, to this
BufFileCreateTemp function.