### PR TITLE
Fix compilation of src/backend/cdb/cdbtm.c

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1491,7 +1491,7 @@ insertedDistributedCommitted(void)
 	 * We don't have to hold ProcArrayLock here because needIncludedInCkpt is used
 	 * during creating checkpoint and we already set delayChkpt before we got here.
 	 */
-	Assert(MyPgXact->delayChkpt);
+	Assert(MyProc->delayChkpt);
 	if (IS_QUERY_DISPATCHER())
 		MyTmGxact->includeInCkpt = true;
 }


### PR DESCRIPTION
Commit 75848bc moved the delayChkpt field from the PGXACT structure to the
PGPROC structure. Move in GPDB-specific code.