### PR TITLE
Fix src/backend/optimizer/util/pathnode.c startup

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -4350,6 +4350,7 @@ create_incremental_sort_path(PlannerInfo *root,
 		subpath->parallel_safe;
 	pathnode->path.parallel_workers = subpath->parallel_workers;
 	pathnode->path.pathkeys = pathkeys;
+	pathnode->path.locus = subpath->locus;
 
 	pathnode->subpath = subpath;
 


### PR DESCRIPTION
Commit d2d8a22 added a new function, create_incremental_sort_path, to
src/backend/optimizer/util/pathnode.c for creating paths. The locus must be
saved in the GPDB, as is done, for example, in the similar function
create_sort_path.