### PR TITLE
Resolve conflicts in src/test/regress/sql/errors.sql

### DIFF
--- a/src/test/regress/expected/errors.out
+++ b/src/test/regress/expected/errors.out
@@ -456,9 +456,8 @@ LINE 16: ...L, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 I...
 -- max_stack_depth is not set too high.  The full error report is not
 -- very stable, so show only SQLSTATE and primary error message.
 create function infinite_recurse() returns int as
-<<<<<<< HEAD
 'select infinite_recurse()' language sql CONTAINS SQL;
-\set VERBOSITY terse
+\set VERBOSITY sqlstate
 -- start_matchsubs
 -- # mpp-2756
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
@@ -468,19 +467,13 @@ create function infinite_recurse() returns int as
 -- end_matchsubs
 -- start_ignore
 select infinite_recurse();
-ERROR:  stack depth limit exceeded
+ERROR:  54001
 -- end_ignore
+\echo :LAST_ERROR_MESSAGE
+stack depth limit exceeded
 select 1; -- test that this works
  ?column? 
 ----------
         1
 (1 row)
 
-=======
-'select infinite_recurse()' language sql;
-\set VERBOSITY sqlstate
-select infinite_recurse();
-ERROR:  54001
-\echo :LAST_ERROR_MESSAGE
-stack depth limit exceeded
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452

--- a/src/test/regress/sql/errors.sql
+++ b/src/test/regress/sql/errors.sql
@@ -383,9 +383,8 @@ NULL);
 -- max_stack_depth is not set too high.  The full error report is not
 -- very stable, so show only SQLSTATE and primary error message.
 create function infinite_recurse() returns int as
-<<<<<<< HEAD
 'select infinite_recurse()' language sql CONTAINS SQL;
-\set VERBOSITY terse
+\set VERBOSITY sqlstate
 -- start_matchsubs
 -- # mpp-2756
 -- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
@@ -396,10 +395,5 @@ create function infinite_recurse() returns int as
 -- start_ignore
 select infinite_recurse();
 -- end_ignore
-select 1; -- test that this works
-=======
-'select infinite_recurse()' language sql;
-\set VERBOSITY sqlstate
-select infinite_recurse();
 \echo :LAST_ERROR_MESSAGE
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+select 1; -- test that this works


### PR DESCRIPTION
Commit 3c8553547b1493c4afdb80393f4a47dbfa019a79 has changed verbosity
in the test, however in GPDB there were matchsubs in the test since
initial commit.
