### PR TITLE
Resolve conflicts in src/test/regress/sql/vacuum.sql

### DIFF
--- a/src/test/regress/expected/vacuum.out
+++ b/src/test/regress/expected/vacuum.out
@@ -128,13 +128,9 @@ ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 2, INDEX_CLEANUP FALSE) pvactst;
                 ^
 VACUUM (PARALLEL 2, FULL TRUE) pvactst; -- error, cannot use both PARALLEL and FULL
-<<<<<<< HEAD
 ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL 2, FULL TRUE) pvactst;
                 ^
-=======
-ERROR:  VACUUM FULL cannot be performed in parallel
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 VACUUM (PARALLEL) pvactst; -- error, cannot use PARALLEL option without parallel degree
 ERROR:  VACUUM option "parallel" not supported in GPDB
 LINE 1: VACUUM (PARALLEL) pvactst;
@@ -142,16 +138,14 @@ LINE 1: VACUUM (PARALLEL) pvactst;
 -- Test different combinations of parallel and full options for temporary tables
 CREATE TEMPORARY TABLE tmp (a int PRIMARY KEY);
 CREATE INDEX tmp_idx1 ON tmp (a);
-<<<<<<< HEAD
-VACUUM (PARALLEL 1) tmp; -- disables parallel vacuum option
-ERROR:  VACUUM option "parallel" not supported in GPDB
-LINE 1: VACUUM (PARALLEL 1) tmp;
-                ^
-=======
 VACUUM (PARALLEL 1, FULL FALSE) tmp; -- parallel vacuum disabled for temp tables
-WARNING:  disabling parallel option of vacuum on "tmp" --- cannot vacuum temporary tables in parallel
+ERROR:  VACUUM option "parallel" not supported in GPDB
+LINE 1: VACUUM (PARALLEL 1, FULL FALSE) tmp;
+                ^
 VACUUM (PARALLEL 0, FULL TRUE) tmp; -- can specify parallel disabled (even though that's implied by FULL)
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+ERROR:  VACUUM option "parallel" not supported in GPDB
+LINE 1: VACUUM (PARALLEL 0, FULL TRUE) tmp;
+                ^
 RESET min_parallel_index_scan_size;
 DROP TABLE pvactst;
 -- INDEX_CLEANUP option
@@ -160,12 +154,8 @@ CREATE TABLE no_index_cleanup (i INT PRIMARY KEY, t TEXT);
 CREATE INDEX no_index_cleanup_idx ON no_index_cleanup(t);
 ALTER TABLE no_index_cleanup ALTER COLUMN t SET STORAGE EXTERNAL;
 INSERT INTO no_index_cleanup(i, t) VALUES (generate_series(1,30),
-<<<<<<< HEAD
-    repeat('1234567890',300));
-ANALYZE no_index_cleanup;
-=======
     repeat('1234567890',269));
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+ANALYZE no_index_cleanup;
 -- index cleanup option is ignored if VACUUM FULL
 VACUUM (INDEX_CLEANUP TRUE, FULL TRUE) no_index_cleanup;
 VACUUM (FULL TRUE) no_index_cleanup;

--- a/src/test/regress/sql/vacuum.sql
+++ b/src/test/regress/sql/vacuum.sql
@@ -119,12 +119,8 @@ CREATE TABLE no_index_cleanup (i INT PRIMARY KEY, t TEXT);
 CREATE INDEX no_index_cleanup_idx ON no_index_cleanup(t);
 ALTER TABLE no_index_cleanup ALTER COLUMN t SET STORAGE EXTERNAL;
 INSERT INTO no_index_cleanup(i, t) VALUES (generate_series(1,30),
-<<<<<<< HEAD
-    repeat('1234567890',300));
-ANALYZE no_index_cleanup;
-=======
     repeat('1234567890',269));
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+ANALYZE no_index_cleanup;
 -- index cleanup option is ignored if VACUUM FULL
 VACUUM (INDEX_CLEANUP TRUE, FULL TRUE) no_index_cleanup;
 VACUUM (FULL TRUE) no_index_cleanup;


### PR DESCRIPTION
Commit 24d2d38b1eb86c0b410ad0f07f66566a83c6f05c added new testcases for
parallel vacuum, however parallel vacuum is not supported in GPDB.
