### PR TITLE
Fix unit tests

### DIFF
--- a/src/backend/cdb/test/cdbappendonlyxlog_test.c
+++ b/src/backend/cdb/test/cdbappendonlyxlog_test.c
@@ -45,7 +45,7 @@ ao_invalid_segment_file_test(uint8 xl_info)
 	record.xl_info = xl_info;
 	record.xl_rmid = RM_APPEND_ONLY_ID;
 
-	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, XL_ROUTINE(), NULL);
+	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, XL_ROUTINE(.page_read = &read_local_xlog_page), NULL);
 
 	if (xl_info == XLOG_APPENDONLY_INSERT)
 	{

--- a/src/backend/cdb/test/cdbappendonlyxlog_test.c
+++ b/src/backend/cdb/test/cdbappendonlyxlog_test.c
@@ -45,7 +45,11 @@ ao_invalid_segment_file_test(uint8 xl_info)
 	record.xl_info = xl_info;
 	record.xl_rmid = RM_APPEND_ONLY_ID;
 
-	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, XL_ROUTINE(.page_read = &read_local_xlog_page), NULL);
+	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL,
+									XL_ROUTINE(.page_read = read_local_xlog_page,
+											   .segment_open = wal_segment_open,
+											   .segment_close = wal_segment_close),
+									NULL);
 
 	if (xl_info == XLOG_APPENDONLY_INSERT)
 	{

--- a/src/backend/cdb/test/cdbappendonlyxlog_test.c
+++ b/src/backend/cdb/test/cdbappendonlyxlog_test.c
@@ -45,7 +45,7 @@ ao_invalid_segment_file_test(uint8 xl_info)
 	record.xl_info = xl_info;
 	record.xl_rmid = RM_APPEND_ONLY_ID;
 
-	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, NULL, NULL);
+	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, XL_ROUTINE(), NULL);
 
 	if (xl_info == XLOG_APPENDONLY_INSERT)
 	{

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -458,7 +458,7 @@ check_ao_record_present(unsigned char type, char *buf, Size len,
 	test_PrintLog("wal start record", dataStart, sendTime);
 	test_PrintLog("wal end record", walEnd, sendTime);
 
-	xlogreader = XLogReaderAllocate(wal_segment_size, NULL, &read_local_xlog_page, NULL);
+	xlogreader = XLogReaderAllocate(wal_segment_size, NULL, XL_ROUTINE(.page_read = &read_local_xlog_page), NULL);
 
 	/*
 	 * Find the first valid record at or after the given starting point.

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -458,7 +458,11 @@ check_ao_record_present(unsigned char type, char *buf, Size len,
 	test_PrintLog("wal start record", dataStart, sendTime);
 	test_PrintLog("wal end record", walEnd, sendTime);
 
-	xlogreader = XLogReaderAllocate(wal_segment_size, NULL, XL_ROUTINE(.page_read = &read_local_xlog_page), NULL);
+	xlogreader = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL,
+									XL_ROUTINE(.page_read = read_local_xlog_page,
+											   .segment_open = wal_segment_open,
+											   .segment_close = wal_segment_close),
+									NULL);
 
 	/*
 	 * Find the first valid record at or after the given starting point.


### PR DESCRIPTION
Commit b060dbe changed the pagereadfunc argument in the XLogReaderAllocate
function to routine. Change it in the GPDB-specific unit tests.