### PR TITLE
Add fallbacks for Orca unsupported features

### DIFF
--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -1651,9 +1651,11 @@ CQueryMutators::ReassignSortClause(Query *top_level_query,
 	top_level_query->sortClause = derived_table_query->sortClause;
 	top_level_query->limitOffset = derived_table_query->limitOffset;
 	top_level_query->limitCount = derived_table_query->limitCount;
+	top_level_query->limitOption = derived_table_query->limitOption;
 	derived_table_query->sortClause = nullptr;
 	derived_table_query->limitOffset = nullptr;
 	derived_table_query->limitCount = nullptr;
+	derived_table_query->limitOption = LIMIT_OPTION_DEFAULT;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -604,8 +604,8 @@ CTranslatorQueryToDXL::TranslateSelectQueryToDXL()
 
 	// translate limit clause
 	CDXLNode *limit_dxlnode = TranslateLimitToDXLGroupBy(
-		m_query->sortClause, m_query->limitCount, m_query->limitOffset, m_query->limitOption,
-		child_dxlnode, sort_group_attno_to_colid_mapping);
+		m_query->sortClause, m_query->limitCount, m_query->limitOffset,
+		m_query->limitOption, child_dxlnode, sort_group_attno_to_colid_mapping);
 
 
 	if (nullptr == m_query->targetList)
@@ -1932,8 +1932,9 @@ CTranslatorQueryToDXL::TranslateSortColumsToDXL(
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorQueryToDXL::TranslateLimitToDXLGroupBy(
-	List *sort_clause, Node *limit_count, Node *limit_offset_node, LimitOption limit_option,
-	CDXLNode *child_dxlnode, IntToUlongMap *grpcols_to_colid_mapping)
+	List *sort_clause, Node *limit_count, Node *limit_offset_node,
+	LimitOption limit_option, CDXLNode *child_dxlnode,
+	IntToUlongMap *grpcols_to_colid_mapping)
 {
 	if (0 == gpdb::ListLength(sort_clause) && nullptr == limit_count &&
 		nullptr == limit_offset_node)
@@ -1943,9 +1944,8 @@ CTranslatorQueryToDXL::TranslateLimitToDXLGroupBy(
 
 	if (LIMIT_OPTION_WITH_TIES == limit_option)
 	{
-		GPOS_RAISE(
-			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-			GPOS_WSZ_LIT("FETCH FIRST WITH TIES"));
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+				   GPOS_WSZ_LIT("FETCH FIRST WITH TIES"));
 	}
 
 	// do not remove limit if it is immediately under a DML (JIRA: GPSQL-2669)

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -604,7 +604,7 @@ CTranslatorQueryToDXL::TranslateSelectQueryToDXL()
 
 	// translate limit clause
 	CDXLNode *limit_dxlnode = TranslateLimitToDXLGroupBy(
-		m_query->sortClause, m_query->limitCount, m_query->limitOffset,
+		m_query->sortClause, m_query->limitCount, m_query->limitOffset, m_query->limitOption,
 		child_dxlnode, sort_group_attno_to_colid_mapping);
 
 
@@ -1932,13 +1932,20 @@ CTranslatorQueryToDXL::TranslateSortColumsToDXL(
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorQueryToDXL::TranslateLimitToDXLGroupBy(
-	List *sort_clause, Node *limit_count, Node *limit_offset_node,
+	List *sort_clause, Node *limit_count, Node *limit_offset_node, LimitOption limit_option,
 	CDXLNode *child_dxlnode, IntToUlongMap *grpcols_to_colid_mapping)
 {
 	if (0 == gpdb::ListLength(sort_clause) && nullptr == limit_count &&
 		nullptr == limit_offset_node)
 	{
 		return child_dxlnode;
+	}
+
+	if (LIMIT_OPTION_WITH_TIES == limit_option)
+	{
+		GPOS_RAISE(
+			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+			GPOS_WSZ_LIT("FETCH FIRST WITH TIES"));
 	}
 
 	// do not remove limit if it is immediately under a DML (JIRA: GPSQL-2669)

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -266,11 +266,11 @@ private:
 		List *sort_clause, IntToUlongMap *col_attno_colid_mapping) const;
 
 	CDXLNode *TranslateLimitToDXLGroupBy(
-		List *plsortcl,			  // list of sort clauses
-		Node *limit_count,		  // query node representing the limit count
-		Node *limit_offset_node,  // query node representing the limit offset
-		LimitOption limit_option, // enum representing the limit option
-		CDXLNode *dxlnode,		  // the dxl node representing the subtree
+		List *plsortcl,			   // list of sort clauses
+		Node *limit_count,		   // query node representing the limit count
+		Node *limit_offset_node,   // query node representing the limit offset
+		LimitOption limit_option,  // enum representing the limit option
+		CDXLNode *dxlnode,		   // the dxl node representing the subtree
 		IntToUlongMap *
 			grpcols_to_colid_mapping  // the mapping between the position in the TargetList to the ColId
 	);

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -269,6 +269,7 @@ private:
 		List *plsortcl,			  // list of sort clauses
 		Node *limit_count,		  // query node representing the limit count
 		Node *limit_offset_node,  // query node representing the limit offset
+		LimitOption limit_option, // enum representing the limit option
 		CDXLNode *dxlnode,		  // the dxl node representing the subtree
 		IntToUlongMap *
 			grpcols_to_colid_mapping  // the mapping between the position in the TargetList to the ColId


### PR DESCRIPTION
Orca does not support FETCH FIRST WITH TIES, newly added by
357889eb17bb9c9336c4f324ceb1651da616fe57, so disable it to avoid giving
incorrect output.