### PR TITLE
Resolve conflicts in src/bin/pg_basebackup/t/010_pg_basebackup.pl

### DIFF
--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -6,11 +6,7 @@ use File::Basename qw(basename dirname);
 use File::Path qw(rmtree);
 use PostgresNode;
 use TestLib;
-<<<<<<< HEAD
-use Test::More tests => 107 + 15;
-=======
-use Test::More tests => 109;
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+use Test::More tests => 109 + 15;
 
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');
@@ -168,13 +164,8 @@ rmtree("$tempdir/backup");
 
 $node->command_ok(
 	[
-<<<<<<< HEAD
-		'pg_basebackup', '-D', "$tempdir/backup2", '--waldir',
-		"$tempdir/xlog2", '--target-gp-dbid', '123'
-=======
 		'pg_basebackup', '-D', "$tempdir/backup2", '--no-manifest',
-		'--waldir', "$tempdir/xlog2"
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+		'--waldir', "$tempdir/xlog2", '--target-gp-dbid', '123'
 	],
 	'separate xlog directory');
 ok(-f "$tempdir/backup2/PG_VERSION", 'backup was created');


### PR DESCRIPTION
Commit 0d8c9c1 added a couple of tests and the --no-manifest option to
src/bin/pg_basebackup/t/010_pg_basebackup.pl. However, the earlier commit
db2a798(d921a2c) had already increased the number of tests by 15, and commit
19cd1cf had already added the --target-gp-dbid option in the same location.