### PR TITLE
Resolve conflicts in src/test/regress/expected/explain.out

### DIFF
--- a/src/test/regress/expected/explain.out
+++ b/src/test/regress/expected/explain.out
@@ -83,27 +83,17 @@ select explain_filter('explain (analyze, verbose) select * from int8_tbl i8');
 (11 rows)
 
 select explain_filter('explain (analyze, buffers, format text) select * from int8_tbl i8');
-<<<<<<< HEAD
                                                  explain_filter                                                 
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion N:N  (slice1; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
    ->  Seq Scan on int8_tbl i8  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
  Optimizer: Postgres query optimizer
-=======
-                                        explain_filter                                         
------------------------------------------------------------------------------------------------
- Seq Scan on int8_tbl i8  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
  Planning Time: N.N ms
    (slice0)    Executor memory: 36K bytes.
    (slice1)    Executor memory: 36K bytes avg x N workers, 36K bytes max (seg0).
  Memory used:  NkB
  Execution Time: N.N ms
-<<<<<<< HEAD
 (8 rows)
-=======
-(3 rows)
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
 
 select explain_filter('explain (analyze, buffers, format json) select * from int8_tbl i8');
                 explain_filter                

--- a/src/test/regress/expected/explain_optimizer.out
+++ b/src/test/regress/expected/explain_optimizer.out
@@ -20,8 +20,9 @@ begin
         ln := regexp_replace(ln, '\m\d+\M', 'N', 'g');
         -- In sort output, the above won't match units-suffixed numbers
         ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
-        -- Text-mode buffers output varies depending on the system state
-        ln := regexp_replace(ln, '^( +Buffers: shared)( hit=N)?( read=N)?', '\1 [read]');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
         return next ln;
     end loop;
 end;


### PR DESCRIPTION
Commit c0885c4 in src/test/regress/sql/explain.sql added ignoring of the
"Buffers" line, reducing the number of lines in
src/test/regress/expected/explain.out from 4 to 3. However, the earlier commit
db2a798(d8a9c0f) had already added GPDB-specific output in the same location.
Adapt this change for ORCA.