### PR TITLE
Resolve conflicts in src/test/regress/expected/update.out

### DIFF
--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -229,33 +229,14 @@ ERROR:  modification of distribution columns in OnConflictUpdate is not supporte
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
 INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-<<<<<<< HEAD
-  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
-=======
   RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = 0 AS xmax_correct;
-  tableoid   | xmin_correct | xmax_correct 
--------------+--------------+--------------
- upsert_test | t            | t
-(1 row)
-
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
 INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-<<<<<<< HEAD
-  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
-DROP FUNCTION xid_current();
-=======
   RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = pg_current_xact_id()::xid AS xmax_correct;
-  tableoid   | xmin_correct | xmax_correct 
--------------+--------------+--------------
- upsert_test | t            | t
-(1 row)
-
->>>>>>> 3e9744465dbe51822c7d76baca1f934d54ba9452
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 ---------------------------

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -9,7 +9,7 @@ CREATE TABLE update_test (
 CREATE TABLE upsert_test (
     a   INT,
     b   TEXT,
-    id  INT,
+    id  INT DEFAULT 0,
     PRIMARY KEY (id, a)
 ) DISTRIBUTED BY (id);
 INSERT INTO update_test VALUES (5, 10, 'foo');
@@ -210,10 +210,10 @@ SELECT a, b, char_length(c) FROM update_test;
 (4 rows)
 
 -- Test ON CONFLICT DO UPDATE
-INSERT INTO upsert_test VALUES(1, 'Boo', 0);
+INSERT INTO upsert_test VALUES(1, 'Boo');
 -- uncorrelated  sub-select:
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
-  VALUES (1, 'Bar', 0) ON CONFLICT(id, a)
+  VALUES (1, 'Bar') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING a, b;
  a |  b  
 ---+-----
@@ -221,7 +221,7 @@ WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
 (1 row)
 
 -- correlated sub-select:
-INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
   RETURNING a, b;
  a |        b        
@@ -230,7 +230,7 @@ INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
 (1 row)
 
 -- correlated sub-select (EXCLUDED.* alias):
-INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING a, b;
  a |             b             
@@ -242,7 +242,7 @@ INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
 CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT pg_current_xact_id()::xid;$$ SECURITY DEFINER;
-INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
   tableoid   | xmin_correct | xmax_correct 
@@ -252,7 +252,7 @@ INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
 
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
-INSERT INTO upsert_test VALUES (2, 'Brox', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
   tableoid   | xmin_correct | xmax_correct 

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -7,9 +7,11 @@ CREATE TABLE update_test (
     c   TEXT
 );
 CREATE TABLE upsert_test (
-    a   INT PRIMARY KEY,
-    b   TEXT
-);
+    a   INT,
+    b   TEXT,
+    id  INT,
+    PRIMARY KEY (id, a)
+) DISTRIBUTED BY (id);
 INSERT INTO update_test VALUES (5, 10, 'foo');
 INSERT INTO update_test(b, a) VALUES (15, 10);
 SELECT a,b,c FROM update_test ORDER BY a,b,c;
@@ -208,35 +210,57 @@ SELECT a, b, char_length(c) FROM update_test;
 (4 rows)
 
 -- Test ON CONFLICT DO UPDATE
-INSERT INTO upsert_test VALUES(1, 'Boo');
+INSERT INTO upsert_test VALUES(1, 'Boo', 0);
 -- uncorrelated  sub-select:
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
-  VALUES (1, 'Bar') ON CONFLICT(a)
-  DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING *;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  VALUES (1, 'Bar', 0) ON CONFLICT(id, a)
+  DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING a, b;
+ a |  b  
+---+-----
+ 1 | Foo
+(1 row)
+
 -- correlated sub-select:
-INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
-  RETURNING *;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING a, b;
+ a |        b        
+---+-----------------
+ 1 | Foo, Correlated
+(1 row)
+
 -- correlated sub-select (EXCLUDED.* alias):
-INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING *;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING a, b;
+ a |             b             
+---+---------------------------
+ 1 | Foo, Correlated, Excluded
+(1 row)
+
 -- ON CONFLICT using system attributes in RETURNING, testing both the
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
-INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
+CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT pg_current_xact_id()::xid;$$ SECURITY DEFINER;
+INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = 0 AS xmax_correct;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
+  tableoid   | xmin_correct | xmax_correct 
+-------------+--------------+--------------
+ upsert_test | t            | t
+(1 row)
+
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
-INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (2, 'Brox', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = pg_current_xact_id()::xid AS xmax_correct;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
+  tableoid   | xmin_correct | xmax_correct 
+-------------+--------------+--------------
+ upsert_test | t            | t
+(1 row)
+
+DROP FUNCTION xid_current();
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 ---------------------------

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -9,7 +9,7 @@ CREATE TABLE update_test (
 CREATE TABLE upsert_test (
     a   INT,
     b   TEXT,
-    id  INT,
+    id  INT DEFAULT 0,
     PRIMARY KEY (id, a)
 ) DISTRIBUTED BY (id);
 INSERT INTO update_test VALUES (5, 10, 'foo');
@@ -210,10 +210,10 @@ SELECT a, b, char_length(c) FROM update_test;
 (4 rows)
 
 -- Test ON CONFLICT DO UPDATE
-INSERT INTO upsert_test VALUES(1, 'Boo', 0);
+INSERT INTO upsert_test VALUES(1, 'Boo');
 -- uncorrelated  sub-select:
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
-  VALUES (1, 'Bar', 0) ON CONFLICT(id, a)
+  VALUES (1, 'Bar') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING a, b;
  a |  b  
 ---+-----
@@ -221,7 +221,7 @@ WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
 (1 row)
 
 -- correlated sub-select:
-INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
   RETURNING a, b;
  a |        b        
@@ -230,7 +230,7 @@ INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
 (1 row)
 
 -- correlated sub-select (EXCLUDED.* alias):
-INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING a, b;
  a |             b             
@@ -242,7 +242,7 @@ INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
 CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT pg_current_xact_id()::xid;$$ SECURITY DEFINER;
-INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
   tableoid   | xmin_correct | xmax_correct 
@@ -252,7 +252,7 @@ INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
 
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
-INSERT INTO upsert_test VALUES (2, 'Brox', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
   tableoid   | xmin_correct | xmax_correct 

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -7,9 +7,11 @@ CREATE TABLE update_test (
     c   TEXT
 );
 CREATE TABLE upsert_test (
-    a   INT PRIMARY KEY,
-    b   TEXT
-);
+    a   INT,
+    b   TEXT,
+    id  INT,
+    PRIMARY KEY (id, a)
+) DISTRIBUTED BY (id);
 INSERT INTO update_test VALUES (5, 10, 'foo');
 INSERT INTO update_test(b, a) VALUES (15, 10);
 SELECT a,b,c FROM update_test ORDER BY a,b,c;
@@ -208,35 +210,57 @@ SELECT a, b, char_length(c) FROM update_test;
 (4 rows)
 
 -- Test ON CONFLICT DO UPDATE
-INSERT INTO upsert_test VALUES(1, 'Boo');
+INSERT INTO upsert_test VALUES(1, 'Boo', 0);
 -- uncorrelated  sub-select:
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
-  VALUES (1, 'Bar') ON CONFLICT(a)
-  DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING *;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  VALUES (1, 'Bar', 0) ON CONFLICT(id, a)
+  DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING a, b;
+ a |  b  
+---+-----
+ 1 | Foo
+(1 row)
+
 -- correlated sub-select:
-INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
-  RETURNING *;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING a, b;
+ a |        b        
+---+-----------------
+ 1 | Foo, Correlated
+(1 row)
+
 -- correlated sub-select (EXCLUDED.* alias):
-INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING *;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING a, b;
+ a |             b             
+---+---------------------------
+ 1 | Foo, Correlated, Excluded
+(1 row)
+
 -- ON CONFLICT using system attributes in RETURNING, testing both the
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
-INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
+CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT pg_current_xact_id()::xid;$$ SECURITY DEFINER;
+INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = 0 AS xmax_correct;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
+  tableoid   | xmin_correct | xmax_correct 
+-------------+--------------+--------------
+ upsert_test | t            | t
+(1 row)
+
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
-INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (2, 'Brox', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = pg_current_xact_id()::xid AS xmax_correct;
-ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
+  tableoid   | xmin_correct | xmax_correct 
+-------------+--------------+--------------
+ upsert_test | t            | t
+(1 row)
+
+DROP FUNCTION xid_current();
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 ---------------------------

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -227,18 +227,16 @@ ERROR:  modification of distribution columns in OnConflictUpdate is not supporte
 -- ON CONFLICT using system attributes in RETURNING, testing both the
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
-CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT (txid_current() % ((1::int8<<32)))::text::xid;$$;
 INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
+  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = 0 AS xmax_correct;
 ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
 INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
+  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = pg_current_xact_id()::xid AS xmax_correct;
 ERROR:  modification of distribution columns in OnConflictUpdate is not supported
-DROP FUNCTION xid_current();
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 ---------------------------

--- a/src/test/regress/sql/update.sql
+++ b/src/test/regress/sql/update.sql
@@ -11,7 +11,7 @@ CREATE TABLE update_test (
 CREATE TABLE upsert_test (
     a   INT,
     b   TEXT,
-    id  INT,
+    id  INT DEFAULT 0,
     PRIMARY KEY (id, a)
 ) DISTRIBUTED BY (id);
 
@@ -102,17 +102,17 @@ UPDATE update_test t
 SELECT a, b, char_length(c) FROM update_test;
 
 -- Test ON CONFLICT DO UPDATE
-INSERT INTO upsert_test VALUES(1, 'Boo', 0);
+INSERT INTO upsert_test VALUES(1, 'Boo');
 -- uncorrelated  sub-select:
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
-  VALUES (1, 'Bar', 0) ON CONFLICT(id, a)
+  VALUES (1, 'Bar') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING a, b;
 -- correlated sub-select:
-INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
   RETURNING a, b;
 -- correlated sub-select (EXCLUDED.* alias):
-INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING a, b;
 
@@ -120,12 +120,12 @@ INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
 CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT pg_current_xact_id()::xid;$$ SECURITY DEFINER;
-INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
-INSERT INTO upsert_test VALUES (2, 'Brox', 0) ON CONFLICT(id, a)
+INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
 

--- a/src/test/regress/sql/update.sql
+++ b/src/test/regress/sql/update.sql
@@ -9,9 +9,11 @@ CREATE TABLE update_test (
 );
 
 CREATE TABLE upsert_test (
-    a   INT PRIMARY KEY,
-    b   TEXT
-);
+    a   INT,
+    b   TEXT,
+    id  INT,
+    PRIMARY KEY (id, a)
+) DISTRIBUTED BY (id);
 
 INSERT INTO update_test VALUES (5, 10, 'foo');
 INSERT INTO update_test(b, a) VALUES (15, 10);
@@ -100,33 +102,34 @@ UPDATE update_test t
 SELECT a, b, char_length(c) FROM update_test;
 
 -- Test ON CONFLICT DO UPDATE
-INSERT INTO upsert_test VALUES(1, 'Boo');
+INSERT INTO upsert_test VALUES(1, 'Boo', 0);
 -- uncorrelated  sub-select:
 WITH aaa AS (SELECT 1 AS a, 'Foo' AS b) INSERT INTO upsert_test
-  VALUES (1, 'Bar') ON CONFLICT(a)
-  DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING *;
+  VALUES (1, 'Bar', 0) ON CONFLICT(id, a)
+  DO UPDATE SET (b, a) = (SELECT b, a FROM aaa) RETURNING a, b;
 -- correlated sub-select:
-INSERT INTO upsert_test VALUES (1, 'Baz') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (1, 'Baz', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Correlated', a from upsert_test i WHERE i.a = upsert_test.a)
-  RETURNING *;
+  RETURNING a, b;
 -- correlated sub-select (EXCLUDED.* alias):
-INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (1, 'Bat', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING *;
+  RETURNING a, b;
 
 -- ON CONFLICT using system attributes in RETURNING, testing both the
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
-INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
+CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT pg_current_xact_id()::xid;$$ SECURITY DEFINER;
+INSERT INTO upsert_test VALUES (2, 'Beeble', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = 0 AS xmax_correct;
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
-INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
+INSERT INTO upsert_test VALUES (2, 'Brox', 0) ON CONFLICT(id, a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
-  RETURNING tableoid::regclass, xmin = pg_current_xact_id()::xid AS xmin_correct, xmax = pg_current_xact_id()::xid AS xmax_correct;
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
 
-
+DROP FUNCTION xid_current();
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 


### PR DESCRIPTION
Commit 4c04be9b05ad2ec5acd27c3417bf075c13cab134 replaced custom function
xid_current() with new standard pg_current_xact_id() in tests. The tests using
upsert_test table have also been updated to run properly in GPDB. However, we
still need xid_current() function to force pg_current_xact_id() to execute on
segments. Also update update_optimizer.out.
