### PR TITLE
Fix tests gp_create_table and expand_table_ao

### DIFF
--- a/src/test/regress/expected/expand_table_ao.out
+++ b/src/test/regress/expected/expand_table_ao.out
@@ -739,7 +739,7 @@ select localoid::regclass::name, policytype, numsegments, distkey, distclass
 from gp_distribution_policy where localoid = 't_9526'::regclass::oid;
  localoid | policytype | numsegments | distkey | distclass 
 ----------+------------+-------------+---------+-----------
- t_9526   | p          |           3 | 1       | 10054
+ t_9526   | p          |           3 | 1       | 10055
 (1 row)
 
 -- storage paramter should be same with before
@@ -779,7 +779,7 @@ select localoid::regclass::name, policytype, numsegments, distkey, distclass
     from gp_distribution_policy where localoid = 't_9527'::regclass::oid;
  localoid | policytype | numsegments | distkey | distclass 
 ----------+------------+-------------+---------+-----------
- t_9527   | p          |           3 | 1       | 10054
+ t_9527   | p          |           3 | 1       | 10055
 (1 row)
 
 -- storage paramter should be same with before
@@ -818,7 +818,7 @@ select localoid::regclass::name, policytype, numsegments, distkey, distclass
     from gp_distribution_policy where localoid = 't_9528'::regclass::oid;
  localoid | policytype | numsegments | distkey | distclass 
 ----------+------------+-------------+---------+-----------
- t_9528   | p          |           2 | 2       | 10072
+ t_9528   | p          |           2 | 2       | 10073
 (1 row)
 
 -- storage paramter should be same with before

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -34,7 +34,7 @@ create table distpol as select random(), 1 as a, 2 as b distributed by (random);
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol'::regclass;
  distkey | distclass 
 ---------+-----------
- 1       | 10048
+ 1       | 10049
 (1 row)
 
 drop table distpol;
@@ -42,7 +42,7 @@ create table distpol as select random(), 2 as foo distributed by (foo);
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol'::regclass;
  distkey | distclass 
 ---------+-----------
- 2       | 10054
+ 2       | 10055
 (1 row)
 
 drop table distpol;
@@ -68,8 +68,8 @@ select localoid::regclass, distkey, distclass from gp_distribution_policy where
       localoid       | distkey |  distclass  
 ---------------------+---------+-------------
  distpol_no_pk       |         | 
- distpol_with_pk     | 1       | 10054
- distpol_with_unique | 1 2     | 10054 10054
+ distpol_with_pk     | 1       | 10055
+ distpol_with_unique | 1 2     | 10055 10055
 (3 rows)
 
 -- If a table is previously DISTRIBUTED RANDOMLY, you cannot add a primary key
@@ -91,7 +91,7 @@ create table distpol3 as select i, j from distpol1 union
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol3'::regclass;
  distkey | distclass 
 ---------+-----------
- 2       | 10054
+ 2       | 10055
 (1 row)
 
 drop table distpol3;
@@ -100,7 +100,7 @@ create table distpol3 as (select i, j from distpol1 union
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol3'::regclass;
  distkey | distclass 
 ---------+-----------
- 2       | 10054
+ 2       | 10055
 (1 row)
 
 -- MPP-7268: CTAS produces incorrect distribution.
@@ -113,7 +113,7 @@ create table bar as select * from foo distributed by (b);
 select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
  distkey | distclass 
 ---------+-----------
- 2       | 10054
+ 2       | 10055
 (1 row)
 
 drop table if exists foo;
@@ -123,7 +123,7 @@ create table bar as select * from foo distributed by (b);
 select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
  distkey | distclass 
 ---------+-----------
- 2       | 10072
+ 2       | 10073
 (1 row)
 
 drop table if exists foo;
@@ -137,7 +137,7 @@ CREATE TABLE bar AS SELECT * FROM foo distributed by (col_with_constraint);
 select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
  distkey | distclass 
 ---------+-----------
- 3       | 10064
+ 3       | 10065
 (1 row)
 
 drop table if exists foo;
@@ -175,7 +175,7 @@ create table foo ("I" int, i int) distributed by ("I",I);
 select distkey, distclass from gp_distribution_policy where localoid='foo'::regclass;
  distkey |  distclass  
 ---------+-------------
- 1 2     | 10054 10054
+ 1 2     | 10055 10055
 (1 row)
 
 create table fooctas as select * from foo distributed by (i,i);


### PR DESCRIPTION
Commit aeec457de8a8820368e343e791accffe24dc7198 added new opfamily xid8_ops,
which shifted OIDs in pg_opfamily and pg_opclass by 1. This affected outputs
of several tests that need to be adjusted.
