### PR TITLE
Fix test src/test/regress/expected/replication_slots.out

### DIFF
--- a/src/test/regress/expected/replication_slots.out
+++ b/src/test/regress/expected/replication_slots.out
@@ -11,9 +11,9 @@ HINT:  Creating replication slots on a single segment is not advised.  Replicati
 
 -- And I should see that my replication slot exists
 select * from pg_get_replication_slots() where not active;
-       slot_name       | plugin | slot_type | datoid | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn 
------------------------+--------+-----------+--------+-----------+--------+------------+------+--------------+-------------+---------------------
- some_replication_slot |        | physical  |        | f         | f      |            |      |              |             | 
+       slot_name       | plugin | slot_type | datoid | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn | wal_status | min_safe_lsn 
+-----------------------+--------+-----------+--------+-----------+--------+------------+------+--------------+-------------+---------------------+------------+--------------
+ some_replication_slot |        | physical  |        | f         | f      |            |      |              |             |                     |            | 
 (1 row)
 
 -- Cleanup:


### PR DESCRIPTION
Commit c6550776394e25c1620bc8258427c8f1d448080d added new columns wal_status
and min_safe_lsn to the output of pg_get_replication_slots(). The test output
should be updated to include these new columns.