### PR TITLE
Fix tests in src/bin/pg_verifybackup/t/*.pl

### DIFF
--- a/src/bin/pg_verifybackup/t/002_algorithm.pl
+++ b/src/bin/pg_verifybackup/t/002_algorithm.pl
@@ -18,7 +18,7 @@ for my $algorithm (qw(bogus none crc32c sha224 sha256 sha384 sha512))
 	my $backup_path = $master->backup_dir . '/' . $algorithm;
 	my @backup = ('pg_basebackup', '-D', $backup_path,
 				  '--manifest-checksums', $algorithm,
-				  '--no-sync');
+				  '--no-sync', '--target-gp-dbid', '1');
 	my @verify = ('pg_verifybackup', '-e', $backup_path);
 
 	# A backup with a bogus algorithm should fail.

--- a/src/bin/pg_verifybackup/t/003_corruption.pl
+++ b/src/bin/pg_verifybackup/t/003_corruption.pl
@@ -113,7 +113,8 @@ for my $scenario (@scenario)
 		# See https://www.msys2.org/wiki/Porting/#filesystem-namespaces
 		local $ENV{MSYS2_ARG_CONV_EXCL} = $source_ts_prefix;
 		$master->command_ok(['pg_basebackup', '-D', $backup_path, '--no-sync',
-							'-T', "${source_ts_path}=${backup_ts_path}"],
+							'-T', "${source_ts_path}=${backup_ts_path}",
+							'--target-gp-dbid', '1'],
 							"base backup ok");
 		command_ok(['pg_verifybackup', $backup_path ],
 				   "intact backup verified");

--- a/src/bin/pg_verifybackup/t/004_options.pl
+++ b/src/bin/pg_verifybackup/t/004_options.pl
@@ -14,7 +14,8 @@ my $master = get_new_node('master');
 $master->init(allows_streaming => 1);
 $master->start;
 my $backup_path = $master->backup_dir . '/test_options';
-$master->command_ok(['pg_basebackup', '-D', $backup_path, '--no-sync' ],
+$master->command_ok(['pg_basebackup', '-D', $backup_path, '--no-sync',
+					'--target-gp-dbid', '1'],
 					"base backup ok");
 
 # Verify that pg_verifybackup -q succeeds and produces no output.

--- a/src/bin/pg_verifybackup/t/006_encoding.pl
+++ b/src/bin/pg_verifybackup/t/006_encoding.pl
@@ -13,7 +13,7 @@ $master->init(allows_streaming => 1);
 $master->start;
 my $backup_path = $master->backup_dir . '/test_encoding';
 $master->command_ok(['pg_basebackup', '-D', $backup_path, '--no-sync',
-					'--manifest-force-encode' ],
+					'--manifest-force-encode', '--target-gp-dbid', '1'],
 					"backup ok with forced hex encoding");
 
 my $manifest = slurp_file("$backup_path/backup_manifest");

--- a/src/bin/pg_verifybackup/t/007_wal.pl
+++ b/src/bin/pg_verifybackup/t/007_wal.pl
@@ -14,7 +14,8 @@ my $master = get_new_node('master');
 $master->init(allows_streaming => 1);
 $master->start;
 my $backup_path = $master->backup_dir . '/test_wal';
-$master->command_ok(['pg_basebackup', '-D', $backup_path, '--no-sync' ],
+$master->command_ok(['pg_basebackup', '-D', $backup_path, '--no-sync',
+					'--target-gp-dbid', '1'],
 					"base backup ok");
 
 # Rename pg_wal.

--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -553,7 +553,6 @@ sub init
 	# only creates an empty file. gpconfigurenewseg is tasked with
 	# populating the master's dbid.
 	open $conf, '>>', "$pgdata/internal.auto.conf";
-	print $conf "\n# Added by PostgresNode.pm\n";
 	print $conf "gp_dbid=$dbid\n";
 	close $conf;
 


### PR DESCRIPTION
Commit 0d8c9c1 added new tests to src/bin/pg_validatebackup/t/*.pl, and commit
dbc60c5 renamed pg_validatebackup to pg_verifybackup. In the GPDB, we need to
add the target-gp-dbid option when backuping. PostgresNode.pm wrote comments to
the internal.auto.conf file, but pg_basebackup did not, causing pg_verifybackup
to see file size differences. Don't write comments.