### PR TITLE
Fix tests in src/test/regress/expected/aggregates_optimizer.out

### DIFF
--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1270,22 +1270,16 @@ drop table p_t1;
 create temp table t1(f1 int, f2 bigint);
 create temp table t2(f1 bigint, f22 bigint);
 select f1 from t1 left join t2 using (f1) group by f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  CTranslatorQueryToDXL.cpp:4060: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
  f1 
 ----
 (0 rows)
 
 select f1 from t1 left join t2 using (f1) group by t1.f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  CTranslatorQueryToDXL.cpp:4060: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
  f1 
 ----
 (0 rows)
 
 select t1.f1 from t1 left join t2 using (f1) group by t1.f1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  CTranslatorQueryToDXL.cpp:4060: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
  f1 
 ----
 (0 rows)

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -454,9 +454,16 @@ drop table p_t1;
 create temp table t1(f1 int, f2 bigint);
 create temp table t2(f1 bigint, f22 bigint);
 
+-- start_ignore
+-- FIXME: ORCA CTranslatorQueryToDXL.cpp:4067: Failed assertion: ((((const Node*)(join_alias_node))->type) == T_Var) || ((((const Node*)(join_alias_node))->type) == T_CoalesceExpr)
+SET optimizer_trace_fallback = off;
+-- end_ignore
 select f1 from t1 left join t2 using (f1) group by f1;
 select f1 from t1 left join t2 using (f1) group by t1.f1;
 select t1.f1 from t1 left join t2 using (f1) group by t1.f1;
+-- start_ignore
+SET optimizer_trace_fallback = on;
+-- end_ignore
 -- only this one should fail:
 select t1.f1 from t1 left join t2 using (f1) group by f1;
 


### PR DESCRIPTION
Commit 524b651 added code to
src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp. In the
src/test/regress/expected/aggregates_optimizer.out test, the line numbers from
CTranslatorQueryToDXL.cpp were hardcoded, which have now changed. Temporarily
disable the optimizer_trace_fallback GUC for these queries.