### PR TITLE
Fix test src/test/recovery/t/020_archive_status.pl

### DIFF
--- a/src/test/recovery/t/020_archive_status.pl
+++ b/src/test/recovery/t/020_archive_status.pl
@@ -12,10 +12,8 @@ my $primary = get_new_node('master');
 $primary->init(
 	has_archiving    => 1,
 	allows_streaming => 1);
-$primary->append_conf('postgresql.conf', qq(
-autovacuum = off
-wal_keep_segments = 0
-));
+$primary->append_conf('postgresql.conf', 'autovacuum = off');
+$primary->append_conf('postgresql.conf', 'wal_keep_segments = 0');
 $primary->start;
 my $primary_data = $primary->data_dir;
 

--- a/src/test/recovery/t/020_archive_status.pl
+++ b/src/test/recovery/t/020_archive_status.pl
@@ -12,7 +12,10 @@ my $primary = get_new_node('master');
 $primary->init(
 	has_archiving    => 1,
 	allows_streaming => 1);
-$primary->append_conf('postgresql.conf', 'autovacuum = off');
+$primary->append_conf('postgresql.conf', qq(
+autovacuum = off
+wal_keep_segments = 0
+));
 $primary->start;
 my $primary_data = $primary->data_dir;
 
@@ -137,7 +140,10 @@ $primary->poll_query_until('postgres',
 # Test standby with archive_mode = on.
 my $standby1 = get_new_node('standby');
 $standby1->init_from_backup($primary, 'backup', has_restoring => 1);
-$standby1->append_conf('postgresql.conf', "archive_mode = on");
+$standby1->append_conf('postgresql.conf', qq(
+autovacuum = off
+wal_keep_segments = 0
+));
 my $standby1_data = $standby1->data_dir;
 $standby1->start;
 

--- a/src/test/recovery/t/020_archive_status.pl
+++ b/src/test/recovery/t/020_archive_status.pl
@@ -138,10 +138,7 @@ $primary->poll_query_until('postgres',
 # Test standby with archive_mode = on.
 my $standby1 = get_new_node('standby');
 $standby1->init_from_backup($primary, 'backup', has_restoring => 1);
-$standby1->append_conf('postgresql.conf', qq(
-autovacuum = off
-wal_keep_segments = 0
-));
+$standby1->append_conf('postgresql.conf', "archive_mode = on");
 my $standby1_data = $standby1->data_dir;
 $standby1->start;
 


### PR DESCRIPTION
Commit 4e87c4836ab9059cdec17b0a288db3622a42ac18 added new test, however
it relies on Postgres's default value wal_keep_size_mb = 0. In GPDB,
wal_keep_segments = 0 has to be set explicitly, since default value is 5.
