### PR TITLE
Fix tests in src/test/regress/expected/incremental_sort.out

### DIFF
--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -105,9 +105,7 @@ test: brin gin gist spgist privileges init_privs security_label collate matview 
 # ----------
 # Another group of parallel tests
 # ----------
-test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tidscan collate.icu.utf
-# GPDB_13_MERGE_FIXME: enable incremental sort
-# incremental_sort
+test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tidscan collate.icu.utf8 incremental_sort
 
 # rules cannot run concurrently with any test that creates
 # a view or rule in the public schema

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -105,7 +105,9 @@ test: brin gin gist spgist privileges init_privs security_label collate matview 
 # ----------
 # Another group of parallel tests
 # ----------
-test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tidscan collate.icu.utf8 incremental_sort
+test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tidscan collate.icu.utf8
+# GPDB_13_MERGE_FIXME: enable incremental sort
+# incremental_sort
 
 # rules cannot run concurrently with any test that creates
 # a view or rule in the public schema

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -93,8 +93,7 @@ test: select_distinct_on
 #test: select_implicit
 test: select_having
 test: subselect
-# GPDB_13_MERGE_FIXME: enable incremental sort
-# test: incremental_sort
+test: incremental_sort
 test: union
 test: case
 test: join

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -93,7 +93,8 @@ test: select_distinct_on
 #test: select_implicit
 test: select_having
 test: subselect
-test: incremental_sort
+# GPDB_13_MERGE_FIXME: enable incremental sort
+# test: incremental_sort
 test: union
 test: case
 test: join


### PR DESCRIPTION
Commit d2d8a22 added new tests to src/test/regress/sql/incremental_sort.sql,
but incremental sort support is temporarily disabled in the GPDB. Temporarily
disable these tests.