### PR TITLE
Fix gpexpand test dead link

### DIFF
--- a/arenadata/scripts/behave_gpdb.bash
+++ b/arenadata/scripts/behave_gpdb.bash
@@ -15,7 +15,7 @@ function gen_env(){
 
 		if [[ ${FEATURE} == "gpexpand" ]]; then
 			mkdir -p /home/gpadmin/sqldump
-			wget -nv https://rt.adsw.io/artifactory/common/dump.sql.xz -O /home/gpadmin/sqldump/dump.sql.xz
+			wget -nv https://downloads.adsw.io/misc/dump.sql.xz -O /home/gpadmin/sqldump/dump.sql.xz
 
 			xz -d /home/gpadmin/sqldump/dump.sql.xz
 		fi


### PR DESCRIPTION
Fix gpexpand test dead link

The link for SQL dump used in the test was outdated. Update to a new link.

(cherry picked from commit f8cf2f1)

---
!!! REBASE !!!