### PR TITLE
Resolve conflicts in GNUmakefile.in

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -115,7 +115,6 @@ distclean maintainer-clean:
 	@rm -rf autom4te.cache/
 	rm -f config.cache config.log config.status GNUmakefile
 
-<<<<<<< HEAD
 installcheck-resgroup:
 	$(MAKE) -C src/test/isolation2 $@
 
@@ -126,13 +125,9 @@ create-demo-cluster:
 destroy-demo-cluster:
 	$(MAKE) -C gpAux/gpdemo destroy-demo-cluster
 
+check-tests: | temp-install
 check-tests installcheck installcheck-parallel installcheck-tests: CHECKPREP_TOP=src/test/regress
 check-tests installcheck installcheck-parallel installcheck-tests: submake-generated-headers
-=======
-check-tests: | temp-install
-check check-tests installcheck installcheck-parallel installcheck-tests: CHECKPREP_TOP=src/test/regress
-check check-tests installcheck installcheck-parallel installcheck-tests: submake-generated-headers
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 	$(MAKE) -C src/test/regress $@
 
 check:
@@ -149,7 +144,6 @@ check:
 	  . $(prefix)/greenplum_path.sh && . $(top_builddir)/gpAux/gpdemo/gpdemo-env.sh && $(MAKE) -C $(top_builddir) installcheck; \
 	fi
 
-<<<<<<< HEAD
 $(call recurse,check-world,src/test src/pl src/interfaces/ecpg contrib src/bin gpcontrib,check)
 $(call recurse,checkprep,  src/test src/pl src/interfaces/ecpg contrib src/bin gpcontrib)
 
@@ -205,10 +199,6 @@ $(call recurse,installcheck-world,src/bin/pg_upgrade,check)
 unittest-check:
 	$(MAKE) CFLAGS=-DUNITTEST -C src/backend unittest-check
 	$(MAKE) CFLAGS=-DUNITTEST -C src/bin unittest-check
-=======
-$(call recurse,installcheck-world,src/test src/pl src/interfaces/ecpg contrib src/bin,installcheck)
-$(call recurse,install-tests,src/test/regress,install-tests)
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 GNUmakefile: GNUmakefile.in $(top_builddir)/config.status
 	./config.status $@


### PR DESCRIPTION
1) Commit 650eac8 in GNUmakefile.in added a new dependency for check-tests,
although the earlier commit ffa5911 had already changed the lines nearby.

2) Commit f85a485 in GNUmakefile.in added a new dependency for update-unicode,
although a lot of GPDB-specific code had already been added above it.