### PR TITLE
Resolve conflicts in src/include/c.h

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -2106,7 +2106,7 @@ ProcSendSignal(int pid)
  *	separate from its standard lock relatives - in the interest of not
  *	introducing new bugs or performance regressions into the lock code.
  */
-int
+ProcWaitStatus
 ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 {
 	LOCK	   *lock = locallock->lock;
@@ -2135,7 +2135,7 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 	MyProc->waitProcLock = (PROCLOCK *) proclock;
 	MyProc->waitLockMode = lockmode;
 
-	MyProc->waitStatus = STATUS_WAITING;	/* initialize result for error */
+	MyProc->waitStatus = PROC_WAIT_STATUS_WAITING;	/* initialize result for error */
 
 	/* Now check the status of the self lock footgun. */
 	selflock = ResCheckSelfDeadLock(lock, proclock, incrementSet);
@@ -2192,7 +2192,7 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 		CHECK_FOR_INTERRUPTS();
 
 		/*
-		 * waitStatus could change from STATUS_WAITING to something else
+		 * waitStatus could change from PROC_WAIT_STATUS_WAITING to something else
 		 * asynchronously.  Read it just once per loop to prevent surprising
 		 * behavior (such as missing log messages).
 		 */
@@ -2306,7 +2306,7 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 												lockHoldersNum, lock_holders_sbuf.data, lock_waiters_sbuf.data))));
 			}
 
-			if (myWaitStatus == STATUS_WAITING)
+			if (myWaitStatus == PROC_WAIT_STATUS_WAITING)
 				ereport(LOG,
 						(errmsg("process %d still waiting for %s on %s after %ld.%03d ms",
 								MyProcPid, modename, buf.data, msecs, usecs),
@@ -2348,7 +2348,7 @@ ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet)
 			pfree(lock_holders_sbuf.data);
 			pfree(lock_waiters_sbuf.data);
 		}
-	} while (myWaitStatus == STATUS_WAITING);
+	} while (myWaitStatus == PROC_WAIT_STATUS_WAITING);
 
 	if (LockTimeout > 0)
 	{
@@ -2419,7 +2419,7 @@ ResLockWaitCancel(void)
 	if (MyProc->links.next != NULL)
 	{
 		/* We could not have been granted the lock yet */
-		Assert(MyProc->waitStatus == STATUS_WAITING);
+		Assert(MyProc->waitStatus == PROC_WAIT_STATUS_WAITING);
 
 		/* We should only be trying to cancel resource locks */
 		Assert(LOCALLOCK_LOCKMETHOD(*lockAwaited) == RESOURCE_LOCKMETHOD);

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1104,7 +1104,7 @@ ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *inc
 	 *
 	 * NOTE: self-deadlocks will throw (do a non-local return).
 	 */
-	if (ResProcSleep(ExclusiveLock, locallock, incrementSet) != STATUS_OK)
+	if (ResProcSleep(ExclusiveLock, locallock, incrementSet) != PROC_WAIT_STATUS_OK)
 	{
 		/*
 		 * We failed as a result of a deadlock, see CheckDeadLock(). Quit now.
@@ -1207,7 +1207,7 @@ ResProcLockRemoveSelfAndWakeup(LOCK *lock)
 			ResGrantLock(lock, proc->waitProcLock);
 			ResLockUpdateLimit(lock, proc->waitProcLock, incrementSet, true, false);
 
-			proc = ResProcWakeup(proc, STATUS_OK);
+			proc = ResProcWakeup(proc, PROC_WAIT_STATUS_OK);
 		}
 		else
 		{
@@ -1228,7 +1228,7 @@ ResProcLockRemoveSelfAndWakeup(LOCK *lock)
  * (could we just use ProcWakeup here?)
  */
 PGPROC *
-ResProcWakeup(PGPROC *proc, int waitStatus)
+ResProcWakeup(PGPROC *proc, ProcWaitStatus waitStatus)
 {
 	PGPROC	   *retProc;
 
@@ -1298,7 +1298,7 @@ ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode)
 	/* Clean up the proc's own state */
 	proc->waitLock = NULL;
 	proc->waitProcLock = NULL;
-	proc->waitStatus = STATUS_ERROR;
+	proc->waitStatus = PROC_WAIT_STATUS_ERROR;
 
 	/*
 	 * Remove the waited on portal increment.

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -1156,11 +1156,7 @@ typedef union PGAlignedXLogBlock
 #define STATUS_OK				(0)
 #define STATUS_ERROR			(-1)
 #define STATUS_EOF				(-2)
-<<<<<<< HEAD
 #define STATUS_FOUND			(1)
-#define STATUS_WAITING			(2)
-=======
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 /*
  * gettext support

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -402,7 +402,7 @@ extern PGPROC *AuxiliaryPidGetProc(int pid);
 extern void BecomeLockGroupLeader(void);
 extern bool BecomeLockGroupMember(PGPROC *leader, int pid);
 
-extern int ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet);
+extern ProcWaitStatus ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet);
 
 extern void ResLockWaitCancel(void);
 extern bool ProcCanSetMppSessionId(void);

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -142,7 +142,7 @@ extern int				ResLockCheckLimit(LOCK *lock, PROCLOCK *proclock,
 extern ResQueue			GetResQueueFromLock(LOCK *lock);
 
 extern void				ResProcLockRemoveSelfAndWakeup(LOCK *lock);
-extern PGPROC 			*ResProcWakeup(PGPROC *proc, int waitStatus);
+extern PGPROC 			*ResProcWakeup(PGPROC *proc, ProcWaitStatus waitStatus);
 extern void				ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode);
 extern bool				ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incSet);
 


### PR DESCRIPTION
Commit a513f1d removed the STATUS_WAITING define in src/include/c.h, added a
new enumeration, ProcWaitStatus, and changed the waitStatus field type in the
PGPROC structure from int to ProcWaitStatus. Commit c096a80 removed the
STATUS_FOUND define. However, in the PGDB, the ResLockCheckLimit function can
return three statuses: STATUS_FOUND, STATUS_OK, and STATUS_ERROR, so the
STATUS_FOUND definition was not removed. Remove the STATUS_WAITING define from
the GPDB-specific code and change the type from int to ProcWaitStatus in the
appropriate places.