### PR TITLE
Resolve conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302604061
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202006151
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+#define CATALOG_VERSION_NO	302604171
 
 #endif


### PR DESCRIPTION
Commit 46241b2 updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.