### PR TITLE
Resolve conflicts in src/include/executor/nodeAgg.h

### DIFF
--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -281,15 +281,9 @@ typedef struct AggStatePerPhaseData
 
 	ExprState  *evaltrans;		/* evaluation of transition functions  */
 
-<<<<<<< HEAD
 	int		   *group_id;		/* on per gset */
 	int		   *gset_id;		/* on per gset */
 
-	/* cached variants of the compiled expression */
-	ExprState  *evaltrans_cache
-				[2]		/* 0: outerops; 1: TTSOpsMinimalTuple */
-				[2];	/* 0: no NULL check; 1: with NULL check */
-=======
 	/*----------
 	 * Cached variants of the compiled expression.
 	 * first subscript: 0: outerops; 1: TTSOpsMinimalTuple
@@ -297,7 +291,6 @@ typedef struct AggStatePerPhaseData
 	 *----------
 	 */
 	ExprState  *evaltrans_cache[2][2];
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 }			AggStatePerPhaseData;
 
 /*


### PR DESCRIPTION
Commit 5cbfce5 changed the formatting of the evaltrans_cache field in the
AggStatePerPhaseData structure in src/include/executor/nodeAgg.h. However, the
earlier commit 19cd1cf had already added two GPDB-specific fields, group_id and
gset_id, to the same location.