### PR TITLE
Resolve conflicts in src/include/executor/spi.h

### DIFF
--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -84,53 +84,32 @@ extern PGDLLIMPORT int SPI_result;
 extern int	SPI_connect(void);
 extern int	SPI_connect_ext(int options);
 extern int	SPI_finish(void);
-<<<<<<< HEAD
 extern int	SPI_execute(const char *src, bool read_only, int64 tcount);
-extern int SPI_execute_plan(SPIPlanPtr plan, Datum *Values, const char *Nulls,
-							bool read_only, int64 tcount);
-extern int SPI_execute_plan_with_paramlist(SPIPlanPtr plan,
-										   ParamListInfo params,
-										   bool read_only, long tcount);
-extern int	SPI_exec(const char *src, int64 tcount);
-extern int SPI_execp(SPIPlanPtr plan, Datum *Values, const char *Nulls,
-					 int64 tcount);
-extern int SPI_execute_snapshot(SPIPlanPtr plan,
-								Datum *Values, const char *Nulls,
-								Snapshot snapshot,
-								Snapshot crosscheck_snapshot,
-								bool read_only, bool fire_triggers, int64 tcount);
-extern int SPI_execute_with_args(const char *src,
-								 int nargs, Oid *argtypes,
-								 Datum *Values, const char *Nulls,
-								 bool read_only, int64 tcount);
-=======
-extern int	SPI_execute(const char *src, bool read_only, long tcount);
 extern int	SPI_execute_plan(SPIPlanPtr plan, Datum *Values, const char *Nulls,
-							 bool read_only, long tcount);
+							 bool read_only, int64 tcount);
 extern int	SPI_execute_plan_with_paramlist(SPIPlanPtr plan,
 											ParamListInfo params,
-											bool read_only, long tcount);
+											bool read_only, int64 tcount);
 extern int	SPI_execute_plan_with_receiver(SPIPlanPtr plan,
 										   ParamListInfo params,
-										   bool read_only, long tcount,
+										   bool read_only, int64 tcount,
 										   DestReceiver *dest);
-extern int	SPI_exec(const char *src, long tcount);
+extern int	SPI_exec(const char *src, int64 tcount);
 extern int	SPI_execp(SPIPlanPtr plan, Datum *Values, const char *Nulls,
-					  long tcount);
+					  int64 tcount);
 extern int	SPI_execute_snapshot(SPIPlanPtr plan,
 								 Datum *Values, const char *Nulls,
 								 Snapshot snapshot,
 								 Snapshot crosscheck_snapshot,
-								 bool read_only, bool fire_triggers, long tcount);
+								 bool read_only, bool fire_triggers, int64 tcount);
 extern int	SPI_execute_with_args(const char *src,
 								  int nargs, Oid *argtypes,
 								  Datum *Values, const char *Nulls,
-								  bool read_only, long tcount);
+								  bool read_only, int64 tcount);
 extern int	SPI_execute_with_receiver(const char *src,
 									  ParamListInfo params,
-									  bool read_only, long tcount,
+									  bool read_only, int64 tcount,
 									  DestReceiver *dest);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 extern SPIPlanPtr SPI_prepare(const char *src, int nargs, Oid *argtypes);
 extern SPIPlanPtr SPI_prepare_cursor(const char *src, int nargs, Oid *argtypes,
 									 int cursorOptions);


### PR DESCRIPTION
Commit 2f48ede added definitions for the new functions
SPI_execute_plan_with_receiver, SPI_execute_with_receiver, and
SPI_cursor_parse_open_with_paramlist to src/include/executor/spi.h. However, an
earlier commit, 9643bac, had already changed the type of the tcount argument
from long to int64.