### PR TITLE
Resolve conflicts in src/backend/access/transam/subtrans.c

### DIFF
--- a/src/backend/access/transam/subtrans.c
+++ b/src/backend/access/transam/subtrans.c
@@ -99,7 +99,7 @@ SubTransGetData(TransactionId xid, SubTransData* subData)
 		subData->topMostParent = xid;
 	}
 
-	LWLockRelease(SubtransControlLock);
+	LWLockRelease(SubtransSLRULock);
 
 	return;
 }
@@ -163,28 +163,7 @@ SubTransGetParent(TransactionId xid)
 	SubTransData subData;
 	SubTransGetData(xid, &subData);
 
-<<<<<<< HEAD
 	return subData.parent;
-=======
-	/* Can't ask about stuff that might not be around anymore */
-	Assert(TransactionIdFollowsOrEquals(xid, TransactionXmin));
-
-	/* Bootstrap and frozen XIDs have no parent */
-	if (!TransactionIdIsNormal(xid))
-		return InvalidTransactionId;
-
-	/* lock is acquired by SimpleLruReadPage_ReadOnly */
-
-	slotno = SimpleLruReadPage_ReadOnly(SubTransCtl, pageno, xid);
-	ptr = (TransactionId *) SubTransCtl->shared->page_buffer[slotno];
-	ptr += entryno;
-
-	parent = *ptr;
-
-	LWLockRelease(SubtransSLRULock);
-
-	return parent;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 }
 
 /*


### PR DESCRIPTION
Commit 5da1493 in src/backend/access/transam/subtrans.c in the
SubTransGetParent function renamed the SubtransControlLock variable to
SubtransSLRULock, although an earlier commit, 6b0e52b, had already moved the
code for this function to the SubTransGetData function.