### PR TITLE
Resolve conflicts in src/backend/catalog/objectaddress.c

### DIFF
--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -606,25 +606,6 @@ static const ObjectPropertyType ObjectProperty[] =
 		InvalidAttrNumber,		/* no ACL (same as relation) */
 		OBJECT_STATISTIC_EXT,
 		true
-<<<<<<< HEAD
-	}
-
-
-	/* GPDB additions */
-	,
-	{
-		ExtprotocolRelationId,
-		ExtprotocolOidIndexId,
-		EXTPROTOCOLOID,
-		EXTPROTOCOLNAME,
-		Anum_pg_extprotocol_oid,
-		Anum_pg_extprotocol_ptcname,
-		InvalidAttrNumber,
-		Anum_pg_extprotocol_ptcowner,
-		Anum_pg_extprotocol_ptcacl,
-		OBJECT_EXTPROTOCOL,
-		true
-=======
 	},
 	{
 		"user mapping",
@@ -639,7 +620,22 @@ static const ObjectPropertyType ObjectProperty[] =
 		InvalidAttrNumber,
 		OBJECT_USER_MAPPING,
 		false
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+	},
+
+	/* GPDB additions */
+	{
+		"ext protocol",
+		ExtprotocolRelationId,
+		ExtprotocolOidIndexId,
+		EXTPROTOCOLOID,
+		EXTPROTOCOLNAME,
+		Anum_pg_extprotocol_oid,
+		Anum_pg_extprotocol_ptcname,
+		InvalidAttrNumber,
+		Anum_pg_extprotocol_ptcowner,
+		Anum_pg_extprotocol_ptcacl,
+		OBJECT_EXTPROTOCOL,
+		true
 	},
 };
 


### PR DESCRIPTION
Commit b1d32d3 added a new class_descr field to the ObjectPropertyType
structure in src/backend/catalog/objectaddress.c and added a new element for
user mapping to the ObjectProperty array of these structures. However, the
earlier commit 7ebc17a had already added a GPDB-specific element for the ext
protocol in the same location.