### PR TITLE
Resolve conflicts in src/backend/commands/amcmds.c

### DIFF
--- a/src/backend/commands/amcmds.c
+++ b/src/backend/commands/amcmds.c
@@ -112,7 +112,6 @@ CreateAccessMethod(CreateAmStmt *stmt)
 
 	recordDependencyOnCurrentExtension(&myself, false);
 
-<<<<<<< HEAD
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		CdbDispatchUtilityStatement((Node *) stmt,
@@ -122,9 +121,8 @@ CreateAccessMethod(CreateAmStmt *stmt)
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
-=======
+
 	InvokeObjectPostCreateHook(AccessMethodRelationId, amoid, 0);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	table_close(rel, RowExclusiveLock);
 


### PR DESCRIPTION
Commit a995b37 in src/backend/commands/amcmds.c added a call to the
InvokeObjectPostCreateHook function in the CreateAccessMethod function, while
the earlier commit 38d8815 had already added GPDB-specific code to the same
location.