### PR TITLE
Resolve conflicts in src/backend/commands/async.c

### DIFF
--- a/src/backend/commands/async.c
+++ b/src/backend/commands/async.c
@@ -2011,12 +2011,8 @@ asyncQueueReadAllNotifications(void)
 			 * and possibly transmitting them to our frontend.  Copy only the
 			 * part of the page we will actually inspect.
 			 */
-<<<<<<< HEAD
-			slotno = SimpleLruReadPage_ReadOnly(AsyncCtl, curpage, InvalidTransactionId);
-=======
 			slotno = SimpleLruReadPage_ReadOnly(NotifyCtl, curpage,
 												InvalidTransactionId);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 			if (curpage == QUEUE_POS_PAGE(head))
 			{
 				/* we only want to read as far as head */


### PR DESCRIPTION
Commit 5da1493 in src/backend/commands/async.c in the
asyncQueueReadAllNotifications function when calling the
SimpleLruReadPage_ReadOnly function renamed the first argument from AsyncCtl to
NotifyCtl, although an earlier commit, e5d1779, had already reformatted the
same location.