### PR TITLE
Resolve conflicts in src/backend/commands/copy.c

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1334,7 +1334,6 @@ DoCopy(ParseState *pstate, const CopyStmt *stmt,
 								 stmt->filename, stmt->is_program,
 								 stmt->attlist, options);
 
-<<<<<<< HEAD
 			/*
 			 * "copy t to file on segment"					CopyDispatchOnSegment
 			 * "copy (select * from t) to file on segment"	CopyToQueryOnSegment
@@ -1363,21 +1362,13 @@ DoCopy(ParseState *pstate, const CopyStmt *stmt,
 
 		EndCopyTo(cstate, processed);
 	}
-	/*
-	 * Close the relation.  If reading, we can release the AccessShareLock we
-	 * got; if writing, we should hold the lock until end of transaction to
-	 * ensure that updates will be committed before lock is released.
-	 */
+
 	if (rel != NULL)
-		table_close(rel, (is_from ? NoLock : AccessShareLock));
+		table_close(rel, NoLock);
 
 	/* Issue automatic ANALYZE if conditions are satisfied (MPP-4082). */
 	if (Gp_role == GP_ROLE_DISPATCH && is_from)
 		auto_stats(AUTOSTATS_CMDTYPE_COPY, relid, *processed, false /* inFunction */);
-=======
-	if (rel != NULL)
-		table_close(rel, NoLock);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 }
 
 /*


### PR DESCRIPTION
Commit a9cf48a in src/backend/commands/copy.c removed the AccessShareLock
conditional lock when calling the table_close function in the DoCopy function.
However, earlier commits had already added a lot of GPDB-specific code to the
same location.