### PR TITLE
Resolve conflicts in src/backend/utils/sort/logtape.c

### DIFF
--- a/src/backend/utils/sort/logtape.c
+++ b/src/backend/utils/sort/logtape.c
@@ -627,21 +627,12 @@ ltsInitTape(LogicalTape *lt)
 	lt->buffer = NULL;
 	lt->buffer_size = 0;
 	/* palloc() larger than MaxAllocSize would fail */
-<<<<<<< HEAD
-	lt->max_size          = MaxAllocSize;
-	lt->pos               = 0;
-	lt->nbytes            = 0;
-	lt->prealloc          = NULL;
-	lt->nprealloc         = 0;
-	lt->prealloc_size     = 0;
-=======
 	lt->max_size = MaxAllocSize;
 	lt->pos = 0;
 	lt->nbytes = 0;
 	lt->prealloc = NULL;
 	lt->nprealloc = 0;
 	lt->prealloc_size = 0;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 }
 
 /*


### PR DESCRIPTION
Commit 5cbfce562f7cd2aab0cdc4694ce298ec3567930e changed formatting while
commit 896ddf9b3cd7dcf70e43f733ae8fec5dfe6e31af added new lines, which were
indented differently in GPDB.