### PR TITLE
Resolve conflicts in src/backend/storage/sync/sync.c

### DIFF
--- a/src/backend/storage/sync/sync.c
+++ b/src/backend/storage/sync/sync.c
@@ -323,7 +323,6 @@ ProcessSyncRequests(void)
 	{
 		int			failures;
 
-<<<<<<< HEAD
 #ifdef FAULT_INJECTOR
 		if (entry->cycle_ctr != sync_cycle_ctr && !entry->canceled &&
 			(SIMPLE_FAULT_INJECTOR("fsync_counter") == FaultInjectorTypeSkip
@@ -358,8 +357,6 @@ ProcessSyncRequests(void)
 		}
 #endif
 
-=======
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 		/*
 		 * If the entry is new then don't process it this time; it is new.
 		 * Note "continue" bypasses the hash-remove call at the bottom of the

--- a/src/backend/storage/sync/sync.c
+++ b/src/backend/storage/sync/sync.c
@@ -418,11 +418,7 @@ ProcessSyncRequests(void)
 					processed++;
 
 					if (log_checkpoints)
-<<<<<<< HEAD
-						elog(DEBUG1, "checkpoint sync: number=%d file=%s time=%.3f msec",
-=======
 						elog(DEBUG1, "checkpoint sync: number=%d file=%s time=%.3f ms",
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 							 processed,
 							 path,
 							 (double) elapsed / 1000);


### PR DESCRIPTION
1. Commit e8abf585ab453ca9c2f66f2138baf6d3c9c8fbf0 refactored code, however
a backpatch of this commit was already present in merge commit
19cd1cf4b68faff2e29bc2fa884c480e4644cdb4 with PG12. Also, GPDB has a fault
injector in this place, we should leave it where the previous merge left it.
2. Commit 42181b1015b18e877e65be66ac5a2e90b731ac8b changed the log message.