### PR TITLE
Resolve conflicts in src/backend/storage/ipc/procarray.c

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -487,7 +487,6 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 			ProcArrayGroupClearXid(proc, latestXid);
 	}
 
-<<<<<<< HEAD
 	/*
 	 * If we have no XID, we don't need to lock, since we won't affect
 	 * anyone else's calculation of a snapshot.  We might change their
@@ -499,14 +498,6 @@ ProcArrayEndTransaction(PGPROC *proc, TransactionId latestXid)
 	 */
 	Assert(!TransactionIdIsValid(allPgXact[proc->pgprocno].xid));
 	Assert(!TransactionIdIsValid(allTmGxact[proc->pgprocno].gxid));
-=======
-		proc->lxid = InvalidLocalTransactionId;
-		pgxact->xmin = InvalidTransactionId;
-		/* must be cleared with xid/xmin: */
-		pgxact->vacuumFlags &= ~PROC_VACUUM_STATE_MASK;
-		proc->delayChkpt = false;	/* be sure this is cleared in abort */
-		proc->recoveryConflictPending = false;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	proc->lxid = InvalidLocalTransactionId;
 	pgxact->xmin = InvalidTransactionId;


### PR DESCRIPTION
Commit 5cbfce562f7cd2aab0cdc4694ce298ec3567930e changed formatting, however
earlier commit 2225945244fba162d8a6e9d577b3817666cb5f5e had already fixed it
and added more GPDB-specific code
