### PR TITLE
Resolve conflicts in src/backend/replication/basebackup.c

### DIFF
--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -401,7 +401,7 @@ perform_base_backup(basebackup_options *opt)
 
 				if (tmp->path == NULL)
 					tmp->size = sendDir(".", 1, true, tablespaces, true, NULL,
-										NULL);
+										NULL, opt->exclude);
 				else
 					tmp->size = sendTablespace(tmp->path, tmp->oid, true,
 											   NULL);

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -341,6 +341,20 @@ perform_base_backup(basebackup_options *opt)
 	startptr = do_pg_start_backup(opt->label, opt->fastcheckpoint, &starttli,
 								  labelfile, &tablespaces,
 								  tblspc_map_file, opt->sendtblspcmapfile);
+	Assert(!XLogRecPtrIsInvalid(startptr));
+
+	elogif(!debug_basebackup, LOG,
+		   "basebackup perform -- "
+		   "Basebackup start xlog location = %X/%X",
+		   (uint32) (startptr >> 32), (uint32) startptr);
+
+	/*
+	 * Set xlogCleanUpTo so that checkpoint process knows
+	 * which old xlog files should not be cleaned
+	 */
+	WalSndSetXLogCleanUpTo(startptr);
+
+	SIMPLE_FAULT_INJECTOR("base_backup_post_create_checkpoint");
 
 	/*
 	 * Once do_pg_start_backup has been called, ensure that any failure causes

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -76,14 +76,11 @@ typedef struct
 	HTAB	   *exclude;
 } basebackup_options;
 
-<<<<<<< HEAD
 
 static bool match_exclude_list(char *path, HTAB *exclude);
 
-=======
 static int64 sendTablespace(char *path, char *oid, bool sizeonly,
 							struct backup_manifest_info *manifest);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 static int64 sendDir(const char *path, int basepathlen, bool sizeonly,
 					 List *tablespaces, bool sendtblspclinks,
 					 backup_manifest_info *manifest, const char *spcoid,
@@ -343,26 +340,7 @@ perform_base_backup(basebackup_options *opt)
 								 PROGRESS_BASEBACKUP_PHASE_WAIT_CHECKPOINT);
 	startptr = do_pg_start_backup(opt->label, opt->fastcheckpoint, &starttli,
 								  labelfile, &tablespaces,
-<<<<<<< HEAD
-								  tblspc_map_file,
-								  opt->progress, opt->sendtblspcmapfile);
-	Assert(!XLogRecPtrIsInvalid(startptr));
-
-	elogif(!debug_basebackup, LOG,
-		   "basebackup perform -- "
-		   "Basebackup start xlog location = %X/%X",
-		   (uint32) (startptr >> 32), (uint32) startptr);
-
-	/*
-	 * Set xlogCleanUpTo so that checkpoint process knows
-	 * which old xlog files should not be cleaned
-	 */
-	WalSndSetXLogCleanUpTo(startptr);
-
-	SIMPLE_FAULT_INJECTOR("base_backup_post_create_checkpoint");
-=======
 								  tblspc_map_file, opt->sendtblspcmapfile);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	/*
 	 * Once do_pg_start_backup has been called, ensure that any failure causes
@@ -391,14 +369,7 @@ perform_base_backup(basebackup_options *opt)
 
 		/* Add a node for the base directory at the end */
 		ti = palloc0(sizeof(tablespaceinfo));
-<<<<<<< HEAD
-		if (opt->progress)
-			ti->size = sendDir(".", 1, true, tablespaces, true, NULL, NULL, opt->exclude);
-		else
-			ti->size = -1;
-=======
 		ti->size = -1;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 		tablespaces = lappend(tablespaces, ti);
 
 		/*
@@ -732,18 +703,14 @@ perform_base_backup(basebackup_options *opt)
 						 errmsg("unexpected WAL file size \"%s\"", walFileName)));
 			}
 
-<<<<<<< HEAD
 			elogif(debug_basebackup, LOG,
 				   "basebackup perform -- Sent xlog file %s", walFileName);
 
-			/* wal_segment_size is a multiple of 512, so no need for padding */
-=======
 			/*
 			 * wal_segment_size is a multiple of TAR_BLOCK_SIZE, so no need
 			 * for padding.
 			 */
 			Assert(wal_segment_size % TAR_BLOCK_SIZE == 0);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 			FreeFile(fp);
 


### PR DESCRIPTION
1. Commit 1fa092913d260056b1aaf627ebc9cd9655c3a27c added function
sendTablespace while earlier commit
b6236a50e5f5c15a97b4b68a063be88b72164ad3 added function match_exclude_list
to the same place.
2. Commit 1fa092913d260056b1aaf627ebc9cd9655c3a27c removed argument
infotbssize from do_pg_start_backup, however there is GPDB-specific code
nearby.
3. Commit 1fa092913d260056b1aaf627ebc9cd9655c3a27c removed call to sendDir,
however earlier commit b6236a50e5f5c15a97b4b68a063be88b72164ad3 already added
a new argument exclude to it.
4. Commit 2961c9711c17e5fe05fb1fbd72c3e47f3b601ee4 added an assert however
there is GPDB-specific logging nearby.
