### PR TITLE
Resolve conflicts in src/backend/executor/nodeAgg.c

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -313,15 +313,6 @@
 #define HASHAGG_READ_BUFFER_SIZE BLCKSZ
 #define HASHAGG_WRITE_BUFFER_SIZE BLCKSZ
 
-<<<<<<< HEAD
-/*
- * Estimate chunk overhead as a constant 16 bytes. XXX: should this be
- * improved?
- */
-#define CHUNKHDRSZ 16
-
-=======
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 /*
  * Estimate chunk overhead as a constant 16 bytes. XXX: should this be
  * improved?
@@ -427,18 +418,11 @@ static void hashagg_recompile_expressions(AggState *aggstate, bool minslot,
 static long hash_choose_num_buckets(double hashentrysize,
 									long estimated_nbuckets,
 									Size memory);
-<<<<<<< HEAD
-static int hash_choose_num_partitions(AggState *aggstate,
-									  uint64 input_groups,
-									  double hashentrysize,
-									  int used_bits,
-									  int *log2_npartittions);
-=======
-static int	hash_choose_num_partitions(uint64 input_groups,
+static int	hash_choose_num_partitions(AggState *aggstate,
+									   uint64 input_groups,
 									   double hashentrysize,
 									   int used_bits,
 									   int *log2_npartittions);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 static AggStatePerGroup lookup_hash_entry(AggState *aggstate, uint32 hash,
 										  bool *in_hash_table);
 static void lookup_hash_entries(AggState *aggstate);
@@ -1813,21 +1797,16 @@ hash_agg_set_limits(AggState *aggstate, double hashentrysize, uint64 input_group
 					Size *mem_limit, uint64 *ngroups_limit,
 					int *num_partitions)
 {
-<<<<<<< HEAD
-	int npartitions;
-	Size partition_mem;
-	uint64 strict_memlimit = work_mem;
+	int			npartitions;
+	Size		partition_mem;
+	uint64		strict_memlimit = work_mem;
 
 	if (aggstate)
 	{
-		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
+		uint64		operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
 		if (operator_mem < strict_memlimit)
 			strict_memlimit = operator_mem;
 	}
-=======
-	int			npartitions;
-	Size		partition_mem;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	/* if not expected to spill, use all of work_mem */
 	if (input_groups * hashentrysize < strict_memlimit * 1024L)
@@ -2030,25 +2009,18 @@ static int
 hash_choose_num_partitions(AggState *aggstate, uint64 input_groups, double hashentrysize,
 						   int used_bits, int *log2_npartitions)
 {
-<<<<<<< HEAD
-	Size	mem_wanted;
-	int		partition_limit;
-	int		npartitions;
-	int		partition_bits;
-	uint64	strict_memlimit = work_mem;
-
-	if (aggstate)
-	{
-		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
-		if (operator_mem < strict_memlimit)
-			strict_memlimit = operator_mem;
-	}
-=======
 	Size		mem_wanted;
 	int			partition_limit;
 	int			npartitions;
 	int			partition_bits;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+	uint64		strict_memlimit = work_mem;
+
+	if (aggstate)
+	{
+		uint64		operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
+		if (operator_mem < strict_memlimit)
+			strict_memlimit = operator_mem;
+	}
 
 	/*
 	 * Avoid creating so many partitions that the memory requirements of the
@@ -2767,13 +2739,8 @@ agg_refill_hash_table(AggState *aggstate)
 				 * that we don't assign tapes that will never be used.
 				 */
 				spill_initialized = true;
-<<<<<<< HEAD
 				hashagg_spill_init(aggstate, &spill, tapeinfo, batch->used_bits,
-					   ngroups_estimate, aggstate->hashentrysize);
-=======
-				hashagg_spill_init(&spill, tapeinfo, batch->used_bits,
 								   ngroups_estimate, aggstate->hashentrysize);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 			}
 			/* no memory for a new group, spill */
 			hashagg_spill_tuple(&spill, slot, hash);
@@ -3049,13 +3016,8 @@ hashagg_spill_init(AggState *aggstate, HashAggSpill *spill, HashTapeInfo *tapein
 	int			npartitions;
 	int			partition_bits;
 
-<<<<<<< HEAD
-	npartitions = hash_choose_num_partitions(aggstate,
-		input_groups, hashentrysize, used_bits, &partition_bits);
-=======
-	npartitions = hash_choose_num_partitions(input_groups, hashentrysize,
+	npartitions = hash_choose_num_partitions(aggstate, input_groups, hashentrysize,
 											 used_bits, &partition_bits);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	spill->partitions = palloc0(sizeof(int) * npartitions);
 	spill->ntuples = palloc0(sizeof(int64) * npartitions);


### PR DESCRIPTION
1) Commit 1b2c294 in src/backend/executor/nodeAgg.c removed the
HASHAGG_MIN_BUCKETS definition, while earlier commit 19cd1cf had already
defined CHUNKHDRSZ a second time below.

2) Commit 5cbfce5 in src/backend/executor/nodeAgg.c reformatted the
hash_choose_num_partitions function definition, while earlier commit 19cd1cf
had already added the new aggstate argument to it.

3) Commit 5cbfce5 in src/backend/executor/nodeAgg.c in the function
hash_agg_set_limits formatted the definition of the local variables npartitions
and partition_mem, while the earlier commit 19cd1cf had already added the new
local variable strict_memlimit and handling of the new aggstate argument to it.

4) Commit 5cbfce5 in src/backend/executor/nodeAgg.c in the function
hash_choose_num_partitions formatted the definition of the local variables
mem_wanted, partition_limit, npartitions, and partition_bits, while the earlier
commit 19cd1cf had already added the new local variable strict_memlimit and
handling of the new aggstate argument to it.

5) Commit 5cbfce5 in src/backend/executor/nodeAgg.c in the
agg_refill_hash_table function formatted the call to the hashagg_spill_init
function, while the earlier commit 19cd1cf had already added the new aggstate
argument to it.

6) Commit 5cbfce5 in src/backend/executor/nodeAgg.c in the hashagg_spill_init
function formatted the call to the hash_choose_num_partitions function, while
the earlier commit 19cd1cf had already added the new aggstate argument to it.