### PR TITLE
Resolve conflicts in copyfuncs.c, outfuncs.c, and readfuncs.c

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3666,13 +3666,9 @@ _copyQuery(const Query *from)
 	COPY_NODE_FIELD(constraintDeps);
 	COPY_NODE_FIELD(withCheckOptions);
 	COPY_LOCATION_FIELD(stmt_location);
-<<<<<<< HEAD
-	COPY_LOCATION_FIELD(stmt_len);
+	COPY_SCALAR_FIELD(stmt_len);
 	COPY_SCALAR_FIELD(parentStmtType);
 	COPY_NODE_FIELD(intoPolicy);
-=======
-	COPY_SCALAR_FIELD(stmt_len);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -366,9 +366,8 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 #endif /* COMPILING_BINARY_FUNCS */
 	WRITE_NODE_FIELD(paramExecTypes);
 	WRITE_NODE_FIELD(utilityStmt);
-<<<<<<< HEAD
-    WRITE_LOCATION_FIELD(stmt_location);
-    WRITE_LOCATION_FIELD(stmt_len);
+	WRITE_LOCATION_FIELD(stmt_location);
+	WRITE_INT_FIELD(stmt_len);
 
 	WRITE_INT_ARRAY(subplan_sliceIds, list_length(node->subplans));
 
@@ -472,10 +471,6 @@ _outOidAssignment(StringInfo str, const OidAssignment *node)
 	WRITE_OID_FIELD(keyOid1);
 	WRITE_OID_FIELD(keyOid2);
 	WRITE_OID_FIELD(oid);
-=======
-	WRITE_LOCATION_FIELD(stmt_location);
-	WRITE_INT_FIELD(stmt_len);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 }
 
 /*
@@ -4421,14 +4416,10 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_NODE_FIELD(constraintDeps);
 	WRITE_NODE_FIELD(withCheckOptions);
 	WRITE_LOCATION_FIELD(stmt_location);
-<<<<<<< HEAD
-	WRITE_LOCATION_FIELD(stmt_len);
+	WRITE_INT_FIELD(stmt_len);
 	WRITE_BOOL_FIELD(parentStmtType);
 
 	/* Don't serialize policy */
-=======
-	WRITE_INT_FIELD(stmt_len);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 }
 #endif /* COMPILING_BINARY_FUNCS */
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -362,17 +362,13 @@ _readQuery(void)
 	READ_NODE_FIELD(rowMarks);
 	READ_NODE_FIELD(setOperations);
 	READ_NODE_FIELD(constraintDeps);
-<<<<<<< HEAD
     READ_NODE_FIELD(withCheckOptions);
-    local_node->intoPolicy = NULL;
-    READ_BOOL_FIELD(parentStmtType);
     READ_LOCATION_FIELD(stmt_location);
-    READ_LOCATION_FIELD(stmt_len);
-=======
-	READ_NODE_FIELD(withCheckOptions);
-	READ_LOCATION_FIELD(stmt_location);
 	READ_INT_FIELD(stmt_len);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+    READ_BOOL_FIELD(parentStmtType);
+
+	/* Don't deserialize policy */
+    local_node->intoPolicy = NULL;
 
 	READ_DONE();
 }


### PR DESCRIPTION
1) Commit 587322d in src/backend/nodes/copyfuncs.c in the _copyQuery function
replaced COPY_LOCATION_FIELD(stmt_len) with COPY_SCALAR_FIELD(stmt_len).
Earlier commits by bad6ceb and 19cd1cf had already added copying of the
parentStmtType and intoPolicy fields after this point.

2) Commit 587322d in src/backend/nodes/outfuncs.c in the _outPlannedStmt
function replaced WRITE_LOCATION_FIELD(stmt_len) with
WRITE_INT_FIELD(stmt_len), while several earlier commits had already added a
lot of GPDB-specific code to the same location.

3) Commit 587322d in src/backend/nodes/outfuncs.c in the _outQuery function
replaced WRITE_LOCATION_FIELD(stmt_len) with WRITE_INT_FIELD(stmt_len), while
an earlier commit by bad6ceb had already added a parentStmtType field entry
after this location.

4) Commit 587322d in the src/backend/nodes/readfuncs.c file in the _readQuery
function replaced READ_LOCATION_FIELD(stmt_len) with READ_INT_FIELD(stmt_len),
while the earlier commit 19cd1cf already added reading of the parentStmtType
field after this place.