### PR TITLE
Resolve conflicts in src/bin/pg_rewind/libpq_fetch.c

### DIFF
--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -23,13 +23,9 @@
 #include "pg_rewind.h"
 #include "port/pg_bswap.h"
 
-<<<<<<< HEAD
 #include "pqexpbuffer.h"
 
-PGconn *conn = NULL;
-=======
 PGconn	   *conn = NULL;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 /*
  * Files are fetched max CHUNKSIZE bytes at a time.


### PR DESCRIPTION
Commit 5cbfce5 in src/bin/pg_rewind/libpq_fetch.c changed the formatting of the
conn variable declaration, while the earlier commit 0e0153b had already added a
new pqexpbuffer.h include above.