### PR TITLE
Resolve conflicts in src/bin/pg_upgrade/server.c

### DIFF
--- a/src/bin/pg_upgrade/server.c
+++ b/src/bin/pg_upgrade/server.c
@@ -274,13 +274,8 @@ start_postmaster(ClusterInfo *cluster, bool report_and_exit_on_error)
 			  BINARY_UPGRADE_SERVER_FLAG_CAT_VER) ? " -b" :
 			 " -c autovacuum=off -c autovacuum_freeze_max_age=2000000000",
 			 (cluster == &new_cluster) ?
-<<<<<<< HEAD
-			 " -c synchronous_commit=off -c fsync=off -c full_page_writes=off" : "",
-			 cluster->pgopts ? cluster->pgopts : "", socket_string, version_opts);
-=======
 			 " -c synchronous_commit=off -c fsync=off -c full_page_writes=off -c vacuum_defer_cleanup_age=0" : "",
-			 cluster->pgopts ? cluster->pgopts : "", socket_string);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+			 cluster->pgopts ? cluster->pgopts : "", socket_string, version_opts);
 
 	/*
 	 * Don't throw an error right away, let connecting throw the error because


### PR DESCRIPTION
Commit 3f5863e added the vacuum_defer_cleanup_age option to the
start_postmaster function in src/bin/pg_upgrade/server.c, while the earlier
commit ecd3400 had already added version_opts to the same location.