### PR TITLE
Resolve conflicts in src/bin/psql/tab-complete.c

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -4228,12 +4228,8 @@ _complete_from_query(const char *simple_query,
 			 */
 			if (strcmp(schema_query->catname,
 					   "pg_catalog.pg_class c") == 0 &&
-<<<<<<< HEAD
 				strncmp(text, "pg_", 3) != 0 &&
 				strncmp(text, "gp_", 3) != 0)
-=======
-				strncmp(text, "pg_", 3) != 0)
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 			{
 				appendPQExpBufferStr(&query_buffer,
 									 " AND c.relnamespace <> (SELECT oid FROM"


### PR DESCRIPTION
Commit fa27dd4 in src/bin/psql/tab-complete.c formatted the condition in the
_complete_from_query function, while an earlier commit, 6b0e52b, had already
added another GPDB-specific condition in the same location.