### PR TITLE
Resolve conflicts in src/test/regress/pg_regress.c

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -763,14 +763,9 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 {
 	char		testtablespace[MAXPGPATH];
 	char		indir[MAXPGPATH];
-<<<<<<< HEAD
 	char		cgroup_mnt_point[MAXPGPATH];
 	replacements repls;
-	struct stat st;
-	int			ret;
-=======
 	char		outdir_sub[MAXPGPATH];
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 	char	  **name;
 	char	  **names;
 	int			count = 0;
@@ -793,20 +788,12 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 		/* Error logged in pgfnames */
 		exit(2);
 
-<<<<<<< HEAD
-	/* also create the output directory if not present */
-	if (!directory_exists(dest_subdir))
-		make_directory(dest_subdir);
-
-	snprintf(testtablespace, MAXPGPATH, "%s/testtablespace", tablespacedir);
-=======
 	/* Create the "dest" subdirectory if not present */
 	snprintf(outdir_sub, MAXPGPATH, "%s/%s", dest_dir, dest_subdir);
 	if (!directory_exists(outdir_sub))
 		make_directory(outdir_sub);
 
-	snprintf(testtablespace, MAXPGPATH, "%s/testtablespace", outputdir);
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+	snprintf(testtablespace, MAXPGPATH, "%s/testtablespace", tablespacedir);
 
 #ifdef WIN32
 


### PR DESCRIPTION
1) Commit e78900a in src/test/regress/pg_regress.c in the function
convert_sourcefiles_in replaced the local variables st and ret with the new
local variable outdir_sub. Earlier commits 2f6e842 and 041dd8a had already
added the new local variables cgroup_mnt_point and repls to the same location.

2) Commit e78900a in src/test/regress/pg_regress.c added creation of outdir_sub
directory in convert_sourcefiles_in function, while earlier commit 321c052
already added creation of dest_subdir directory above this, and earlier commit
7a6ea5e already replaced outputdir argument with tablespacedir when calling
snprintf function after this.