### PR TITLE
Fix clog.c compilation

### DIFF
--- a/src/backend/access/transam/clog.c
+++ b/src/backend/access/transam/clog.c
@@ -693,39 +693,39 @@ CLOGScanForPrevStatus(
 		if (lowXid == InvalidTransactionId)
 			lowXid = FirstNormalTransactionId;
 
-		LWLockAcquire(CLogControlLock, LW_EXCLUSIVE);
+		LWLockAcquire(XactSLRULock, LW_EXCLUSIVE);
 
 		/*
 		 * Peek to see if page exists.
 		 */
-		if (!SimpleLruDoesPhysicalPageExist(ClogCtl, pageno))
+		if (!SimpleLruDoesPhysicalPageExist(XactCtl, pageno))
 		{
-			LWLockRelease(CLogControlLock);
+			LWLockRelease(XactSLRULock);
 
 			*indexXid = InvalidTransactionId;
 			*status = TRANSACTION_STATUS_IN_PROGRESS;	// Set it to something.
 			return false;
 		}
 			
-		slotno = SimpleLruReadPage(ClogCtl, pageno, false, highXid);
+		slotno = SimpleLruReadPage(XactCtl, pageno, false, highXid);
 
 		for (xid = highXid; xid >= lowXid; xid--)
 		{
 			byteno = TransactionIdToByte(xid);
 			bshift = TransactionIdToBIndex(xid) * CLOG_BITS_PER_XACT;
-			byteptr = ClogCtl->shared->page_buffer[slotno] + byteno;
+			byteptr = XactCtl->shared->page_buffer[slotno] + byteno;
 			*status = (*byteptr >> bshift) & CLOG_XACT_BITMASK;
 
 			if (*status != TRANSACTION_STATUS_IN_PROGRESS)
 			{
-				LWLockRelease(CLogControlLock);
+				LWLockRelease(XactSLRULock);
 
 				*indexXid = xid;
 				return true;
 			}
 		}
 
-		LWLockRelease(CLogControlLock);
+		LWLockRelease(XactSLRULock);
 
 		if (lowXid == FirstNormalTransactionId)
 		{


### PR DESCRIPTION
1) Commit 5da1493 renamed the CLogControlLock lock to XactSLRULock. Rename in
GPDB-specific code.

2) Commit 5da1493 renamed the ClogCtl lock to XactCtl. Rename in GPDB-specific
code.