### PR TITLE
fixup c9449da!

### DIFF
--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -20,6 +20,7 @@
 #include "executor/execdesc.h"
 #include "nodes/plannodes.h"
 #include "storage/lock.h"
+#include "storage/proc.h"
 #include "tcop/dest.h"
 #include "cdb/memquota.h"
 #include "utils/portal.h"


### PR DESCRIPTION
Commit c9449da in src/include/utils/resscheduler.h changed the type of the
waitStatus argument from int to ProcWaitStatus in the definition of the
ResProcWakeup function, but forgot to include storage/proc.h.