### PR TITLE
Fix compilation of src/backend/storage/lmgr/lock.c

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -5035,7 +5035,7 @@ setFPHoldTillEndXact(Oid relid)
 	bool result = false;
 	PGPROC *proc = MyProc;
 
-	LWLockAcquire(&proc->backendLock, LW_EXCLUSIVE);
+	LWLockAcquire(&proc->fpInfoLock, LW_EXCLUSIVE);
 
 	for (f = 0; f < FP_LOCK_SLOTS_PER_BACKEND; ++f)
 	{
@@ -5051,7 +5051,7 @@ setFPHoldTillEndXact(Oid relid)
 		break;
 	}
 
-	LWLockRelease(&proc->backendLock);
+	LWLockRelease(&proc->fpInfoLock);
 
 	return result;
 }


### PR DESCRIPTION
Commit 36ac359 in src/include/storage/proc.h renamed the backendLock field to
fpInfoLock in the PGPROC structure. Rename in GPDB-specific code.