### PR TITLE
Fix compilation of src/backend/storage/lmgr/lwlock.c

### DIFF
--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -177,7 +177,9 @@ static const char *const BuiltinTrancheNames[] = {
 	/* LWTRANCHE_PARALLEL_APPEND: */
 	"ParallelAppend",
 	/* LWTRANCHE_PER_XACT_PREDICATE_LIST: */
-	"PerXactPredicateList"
+	"PerXactPredicateList",
+	/* LWTRANCHE_DISTRIBUTEDLOG_BUFFERS: */
+	"DistributedBuffers"
 };
 
 StaticAssertDecl(lengthof(BuiltinTrancheNames) ==


### PR DESCRIPTION
Commit 29c3e2d in src/backend/storage/lmgr/lwlock.c added the
BuiltinTrancheNames array with locks from the BuiltinTrancheIds enumeration,
and a new StaticAssertDecl after it. However, earlier commit 38d8815 had
already added the new LWTRANCHE_DISTRIBUTEDLOG_BUFFERS option to the
BuiltinTrancheIds enumeration.