### PR TITLE
Resolve conflicts in src/test/regress/parallel_schedule

### DIFF
--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -105,13 +105,9 @@ test: brin gin gist spgist privileges init_privs security_label collate matview 
 # ----------
 # Another group of parallel tests
 # ----------
-<<<<<<< HEAD
-test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tidscan collate.icu.utf8
+test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tid tidscan collate.icu.utf8
 # GPDB_13_MERGE_FIXME: enable incremental sort
 # incremental_sort
-=======
-test: create_table_like alter_generic alter_operator misc async dbsize misc_functions sysviews tsrf tid tidscan collate.icu.utf8 incremental_sort
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 # rules cannot run concurrently with any test that creates
 # a view or rule in the public schema


### PR DESCRIPTION
Commit e786be5 added the tid test to src/test/regress/parallel_schedule, while
an earlier commit, 2feb2cc, had already disabled the incremental_sort test in
the same location.