### PR TITLE
Resolve conflicts in src/test/perl/PostgresNode.pm

### DIFF
--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -1486,13 +1486,9 @@ sub psql
 	my $replication       = $params{replication};
 	my $timeout           = undef;
 	my $timeout_exception = 'psql timed out';
-<<<<<<< HEAD
 
 	local $ENV{PGOPTIONS} = '-c gp_role=utility';
 
-	my @psql_params =
-	  ('psql', '-XAtq', '-d', $self->connstr($dbname), '-f', '-');
-=======
 	my @psql_params       = (
 		'psql',
 		'-XAtq',
@@ -1501,7 +1497,6 @@ sub psql
 		  . (defined $replication ? " replication=$replication" : ""),
 		'-f',
 		'-');
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 	# If the caller wants an array and hasn't passed stdout/stderr
 	# references, allocate temporary ones to capture them so we


### PR DESCRIPTION
Commit 1d37430 in src/test/perl/PostgresNode.pm in the psql function formatted
the initialization of the psql_params array, although an earlier commit had
already added the gp_role=utility setting to PGOPTIONS.