### PR TITLE
Fix tests in src/test/regress/sql/create_index.sql

### DIFF
--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -2328,6 +2328,7 @@ SELECT indexrelid::regclass, indisreplident FROM pg_index
 (1 row)
 
 REINDEX TABLE CONCURRENTLY concur_replident;
+ERROR:  REINDEX CONCURRENTLY is not supported
 SELECT indexrelid::regclass, indisreplident FROM pg_index
   WHERE indrelid = 'concur_replident'::regclass;
        indexrelid       | indisreplident 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -2312,6 +2312,28 @@ SELECT indexrelid::regclass, indisclustered FROM pg_index
 (1 row)
 
 DROP TABLE concur_clustered;
+-- Check that indisreplident updates are preserved.
+CREATE TABLE concur_replident(i int NOT NULL);
+CREATE UNIQUE INDEX concur_replident_i_idx ON concur_replident(i);
+ALTER TABLE concur_replident REPLICA IDENTITY
+  USING INDEX concur_replident_i_idx;
+SELECT indexrelid::regclass, indisreplident FROM pg_index
+  WHERE indrelid = 'concur_replident'::regclass;
+       indexrelid       | indisreplident 
+------------------------+----------------
+ concur_replident_i_idx | t
+(1 row)
+
+REINDEX TABLE CONCURRENTLY concur_replident;
+ERROR:  REINDEX CONCURRENTLY is not supported
+SELECT indexrelid::regclass, indisreplident FROM pg_index
+  WHERE indrelid = 'concur_replident'::regclass;
+       indexrelid       | indisreplident 
+------------------------+----------------
+ concur_replident_i_idx | t
+(1 row)
+
+DROP TABLE concur_replident;
 -- Partitions
 -- Create some partitioned tables
 CREATE TABLE concur_reindex_part (c1 int, c2 int) PARTITION BY RANGE (c1);


### PR DESCRIPTION
Commit 1127f0e added new tests to src/test/regress/sql/create_index.sql. Adapt
their output to GPDB, which doesn't support REINDEX CONCURRENTLY. Also, add
their output to ORCA.