### PR TITLE
Fix conflicts in src/test/regress/sql/timetz.sql and timetz.out

### DIFF
--- a/src/test/regress/expected/timetz.out
+++ b/src/test/regress/expected/timetz.out
@@ -144,7 +144,6 @@ ERROR:  operator does not exist: time with time zone + time with time zone
 LINE 1: SELECT f1 + time with time zone '00:01' AS "Illegal" FROM TI...
                   ^
 HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
-<<<<<<< HEAD
 -- basic sanity of sample timezones
 set timezone = 'America/New_York';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as NYC;
@@ -187,7 +186,8 @@ SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Ca
           casablanca          
 ------------------------------
  Sat Aug 09 01:52:00 2014 +01
-=======
+(1 row)
+
 --
 -- test EXTRACT
 --
@@ -247,6 +247,5 @@ SELECT EXTRACT(EPOCH       FROM TIME WITH TIME ZONE '2020-05-26 13:30:25.575401-
   date_part   
 --------------
  63025.575401
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 (1 row)
 

--- a/src/test/regress/sql/timetz.sql
+++ b/src/test/regress/sql/timetz.sql
@@ -56,7 +56,6 @@ SELECT '25:00:00'::timetz;  -- not allowed
 
 SELECT f1 + time with time zone '00:01' AS "Illegal" FROM TIMETZ_TBL;
 
-<<<<<<< HEAD
 -- basic sanity of sample timezones
 set timezone = 'America/New_York';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as NYC;
@@ -71,7 +70,7 @@ SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Sh
 -- Casablanca time has changed in new timezone db lets verify it
 set timezone = 'Africa/Casablanca';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Casablanca;
-=======
+
 --
 -- test EXTRACT
 --
@@ -86,4 +85,3 @@ SELECT EXTRACT(TIMEZONE    FROM TIME WITH TIME ZONE '2020-05-26 13:30:25.575401-
 SELECT EXTRACT(TIMEZONE_HOUR   FROM TIME WITH TIME ZONE '2020-05-26 13:30:25.575401-04');
 SELECT EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '2020-05-26 13:30:25.575401-04');
 SELECT EXTRACT(EPOCH       FROM TIME WITH TIME ZONE '2020-05-26 13:30:25.575401-04');
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c


### PR DESCRIPTION
Commit 378badc8ebebc8fece7a18001f6b876cc00b12c0 added new tests, however there
were already GPDB-specific tests nearby.
