### PR TITLE
Fix conflicts in src/test/regress/expected/sysviews.out

### DIFF
--- a/src/test/regress/expected/sysviews.out
+++ b/src/test/regress/expected/sysviews.out
@@ -74,11 +74,7 @@ select name, setting from pg_settings where name like 'enable%';
 --------------------------------+---------
  enable_bitmapscan              | on
  enable_gathermerge             | on
-<<<<<<< HEAD
  enable_groupagg                | on
- enable_groupingsets_hash_disk  | off
-=======
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
  enable_hashagg                 | on
  enable_hashjoin                | on
  enable_incrementalsort         | off
@@ -95,11 +91,7 @@ select name, setting from pg_settings where name like 'enable%';
  enable_seqscan                 | on
  enable_sort                    | on
  enable_tidscan                 | on
-<<<<<<< HEAD
-(21 rows)
-=======
-(18 rows)
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
+(19 rows)
 
 -- Test that the pg_timezone_names and pg_timezone_abbrevs views are
 -- more-or-less working.  We can't test their contents in any great detail


### PR DESCRIPTION
Commit 92c58fd94801dd5c81ee20e26c5bb71ad64552a8 removed two GUCs
enable_groupingsets_hash_disk and enable_hashagg_disk, however there was
a GPDB-specific GUC enable_groupagg.
