### PR TITLE
Resolve conflicts in src/test/regress/sql/groupingsets.sql

### DIFF
--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -1852,7 +1852,10 @@ select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,1999) g;
 analyze gs_data_1;
 alter table gs_data_1 set (autovacuum_enabled = 'false');
+WARNING:  autovacuum is not supported in Greenplum
+SET allow_system_table_mods = true;
 update pg_class set reltuples = 10 where relname='gs_data_1';
+RESET allow_system_table_mods;
 SET work_mem='64kB';
 WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
@@ -1861,8 +1864,8 @@ set jit_above_cost = 0;
 explain (costs off)
 select g100, g10, sum(g::numeric), count(*), max(g::text)
 from gs_data_1 group by cube (g1000, g100,g10);
-             QUERY PLAN             
-------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  GroupAggregate
    Group Key: g1000, g100, g10
    Group Key: g1000, g100
@@ -1874,10 +1877,13 @@ from gs_data_1 group by cube (g1000, g100,g10);
    Sort Key: g10, g1000
      Group Key: g10, g1000
      Group Key: g10
-   ->  Sort
-         Sort Key: g1000, g100, g10
-         ->  Seq Scan on gs_data_1
-(14 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: g1000, g100, g10
+         ->  Sort
+               Sort Key: g1000, g100, g10
+               ->  Seq Scan on gs_data_1
+ Optimizer: Postgres query optimizer
+(17 rows)
 
 create table gs_group_1 as
 select g100, g10, sum(g::numeric), count(*), max(g::text)
@@ -1888,8 +1894,8 @@ set enable_sort = false;
 explain (costs off)
 select g100, g10, sum(g::numeric), count(*), max(g::text)
 from gs_data_1 group by cube (g1000, g100,g10);
-          QUERY PLAN          
-------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  MixedAggregate
    Hash Key: g1000, g100, g10
    Hash Key: g1000, g100
@@ -1899,8 +1905,10 @@ from gs_data_1 group by cube (g1000, g100,g10);
    Hash Key: g10, g1000
    Hash Key: g10
    Group Key: ()
-   ->  Seq Scan on gs_data_1
-(10 rows)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on gs_data_1
+ Optimizer: Postgres query optimizer
+(12 rows)
 
 create table gs_hash_1 as
 select g100, g10, sum(g::numeric), count(*), max(g::text)
@@ -1923,8 +1931,6 @@ SET optimizer TO off;
 RESET optimizer;
 drop table gs_group_1;
 drop table gs_hash_1;
-<<<<<<< HEAD
-SET enable_groupingsets_hash_disk TO DEFAULT;
 select a, rank(a+3) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
 group by rollup (a) order by a;
@@ -1970,7 +1976,5 @@ group by rollup (a,b) order by a;
    |   |    6
 (8 rows)
 
-=======
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 -- end
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -2143,102 +2143,182 @@ DETAIL:  Feature not supported: Multi-argument UNNEST() or TABLE()
 --
 -- Compare results between plans using sorting and plans using hash
 -- aggregation. Force spilling in both cases by setting work_mem low
--- and turning on enable_groupingsets_hash_disk.
+-- and altering the statistics.
 --
-SET enable_groupingsets_hash_disk = true;
+create table gs_data_1 as
+select g%1000 as g1000, g%100 as g100, g%10 as g10, g
+   from generate_series(0,1999) g;
+analyze gs_data_1;
+alter table gs_data_1 set (autovacuum_enabled = 'false');
+WARNING:  autovacuum is not supported in Greenplum
+SET allow_system_table_mods = true;
+update pg_class set reltuples = 10 where relname='gs_data_1';
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Queries on master-only tables
+RESET allow_system_table_mods;
 SET work_mem='64kB';
 WARNING:  "work_mem": setting is deprecated, and may be removed in a future release.
 -- Produce results with sorting.
 set enable_hashagg = false;
 set jit_above_cost = 0;
 explain (costs off)
-select g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,1999) g) s
-group by cube (g1000, g100,g10);
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Sequence
-   ->  Shared Scan (share slice:id 0:0)
-         ->  Function Scan on generate_series
-   ->  Append
-         ->  HashAggregate
-               Group Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref3.g100, share0_ref3.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref4.g1000, share0_ref4.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref5.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref6.g1000, share0_ref6.g100
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref7.g100
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref8.g1000
-               ->  Shared Scan (share slice:id 0:0)
-         ->  Aggregate
-               ->  Shared Scan (share slice:id 0:0)
+select g100, g10, sum(g::numeric), count(*), max(g::text)
+from gs_data_1 group by cube (g1000, g100,g10);
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on gs_data_1
+         ->  Append
+               ->  GroupAggregate
+                     Group Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+                     ->  Sort
+                           Sort Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+                                 ->  Shared Scan (share slice:id 2:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref3.g100, share0_ref3.g10
+                     ->  Sort
+                           Sort Key: share0_ref3.g100, share0_ref3.g10
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: share0_ref3.g100, share0_ref3.g10
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 3:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref4.g1000, share0_ref4.g10
+                     ->  Sort
+                           Sort Key: share0_ref4.g1000, share0_ref4.g10
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 Hash Key: share0_ref4.g1000, share0_ref4.g10
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 4:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref5.g10
+                     ->  Sort
+                           Sort Key: share0_ref5.g10
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 Hash Key: share0_ref5.g10
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 5:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref6.g1000, share0_ref6.g100
+                     ->  Sort
+                           Sort Key: share0_ref6.g1000, share0_ref6.g100
+                           ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                 Hash Key: share0_ref6.g1000, share0_ref6.g100
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 6:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref7.g100
+                     ->  Sort
+                           Sort Key: share0_ref7.g100
+                           ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                 Hash Key: share0_ref7.g100
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 7:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref8.g1000
+                     ->  Sort
+                           Sort Key: share0_ref8.g1000
+                           ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                                 Hash Key: share0_ref8.g1000
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 8:0)
+               ->  Result
+                     ->  Redistribute Motion 1:3  (slice9)
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice10; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Shared Scan (share slice:id 10:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(67 rows)
 
 create table gs_group_1 as
-select g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,1999) g) s
-group by cube (g1000, g100,g10);
+select g100, g10, sum(g::numeric), count(*), max(g::text)
+from gs_data_1 group by cube (g1000, g100,g10);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- Produce results with hash aggregation.
 set enable_hashagg = true;
 set enable_sort = false;
 explain (costs off)
-select g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,1999) g) s
-group by cube (g1000, g100,g10);
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Sequence
-   ->  Shared Scan (share slice:id 0:0)
-         ->  Function Scan on generate_series
-   ->  Append
-         ->  HashAggregate
-               Group Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref3.g100, share0_ref3.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref4.g1000, share0_ref4.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref5.g10
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref6.g1000, share0_ref6.g100
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref7.g100
-               ->  Shared Scan (share slice:id 0:0)
-         ->  HashAggregate
-               Group Key: share0_ref8.g1000
-               ->  Shared Scan (share slice:id 0:0)
-         ->  Aggregate
-               ->  Shared Scan (share slice:id 0:0)
+select g100, g10, sum(g::numeric), count(*), max(g::text)
+from gs_data_1 group by cube (g1000, g100,g10);
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on gs_data_1
+         ->  Append
+               ->  GroupAggregate
+                     Group Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+                     ->  Sort
+                           Sort Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+                                 ->  Shared Scan (share slice:id 2:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref3.g100, share0_ref3.g10
+                     ->  Sort
+                           Sort Key: share0_ref3.g100, share0_ref3.g10
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: share0_ref3.g100, share0_ref3.g10
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 3:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref4.g1000, share0_ref4.g10
+                     ->  Sort
+                           Sort Key: share0_ref4.g1000, share0_ref4.g10
+                           ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 Hash Key: share0_ref4.g1000, share0_ref4.g10
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 4:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref5.g10
+                     ->  Sort
+                           Sort Key: share0_ref5.g10
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 Hash Key: share0_ref5.g10
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 5:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref6.g1000, share0_ref6.g100
+                     ->  Sort
+                           Sort Key: share0_ref6.g1000, share0_ref6.g100
+                           ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                 Hash Key: share0_ref6.g1000, share0_ref6.g100
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 6:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref7.g100
+                     ->  Sort
+                           Sort Key: share0_ref7.g100
+                           ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                 Hash Key: share0_ref7.g100
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 7:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref8.g1000
+                     ->  Sort
+                           Sort Key: share0_ref8.g1000
+                           ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                                 Hash Key: share0_ref8.g1000
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 8:0)
+               ->  Result
+                     ->  Redistribute Motion 1:3  (slice9)
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice10; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Shared Scan (share slice:id 10:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(67 rows)
 
 create table gs_hash_1 as
-select g100, g10, sum(g::numeric), count(*), max(g::text) from
-  (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
-   from generate_series(0,1999) g) s
-group by cube (g1000, g100,g10);
+select g100, g10, sum(g::numeric), count(*), max(g::text)
+from gs_data_1 group by cube (g1000, g100,g10);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 set enable_sort = true;
 set work_mem to default;
@@ -2258,7 +2338,6 @@ SET optimizer TO off;
 RESET optimizer;
 drop table gs_group_1;
 drop table gs_hash_1;
-SET enable_groupingsets_hash_disk TO DEFAULT;
 select a, rank(a+3) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
 group by rollup (a) order by a;

--- a/src/test/regress/sql/groupingsets.sql
+++ b/src/test/regress/sql/groupingsets.sql
@@ -558,7 +558,9 @@ select g%1000 as g1000, g%100 as g100, g%10 as g10, g
 
 analyze gs_data_1;
 alter table gs_data_1 set (autovacuum_enabled = 'false');
+SET allow_system_table_mods = true;
 update pg_class set reltuples = 10 where relname='gs_data_1';
+RESET allow_system_table_mods;
 
 SET work_mem='64kB';
 
@@ -607,9 +609,6 @@ RESET optimizer;
 drop table gs_group_1;
 drop table gs_hash_1;
 
-<<<<<<< HEAD
-SET enable_groupingsets_hash_disk TO DEFAULT;
-
 select a, rank(a+3) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
 group by rollup (a) order by a;
@@ -626,7 +625,5 @@ select a, b, rank(b) within group (order by b nulls last)
 from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
 group by rollup (a,b) order by a;
 
-=======
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 -- end
 reset optimizer_trace_fallback;


### PR DESCRIPTION
Commit 92c58fd in src/test/regress/sql/groupingsets.sql added new tests,
changed existing ones, and removed the enable_groupingsets_hash_disk restore at
the end. However, the earlier commit ad40cc6 had already added new tests to the
same location. Adapt the test output for the GPDB and add them to the ORCA.