### PR TITLE
Fix tests in src/test/regress/expected/privileges.out

### DIFF
--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -202,6 +202,7 @@ CREATE INDEX ON atest12 (a);
 CREATE INDEX ON atest12 (abs(a));
 -- results below depend on having quite accurate stats for atest12, so...
 ALTER TABLE atest12 SET (autovacuum_enabled = off);
+WARNING:  autovacuum is not supported in Greenplum
 SET default_statistics_target = 10000;
 VACUUM ANALYZE atest12;
 RESET default_statistics_target;


### PR DESCRIPTION
Commit 05dea24 in src/test/regress/sql/privileges.sql added an option to
disable autovacuum for the atest12 table, although autovacuum is not supported
in GPDB.