### PR TITLE
Fix test src/test/regress/expected/tid.out

### DIFF
--- a/src/test/regress/expected/tid.out
+++ b/src/test/regress/expected/tid.out
@@ -1,22 +1,18 @@
+-- start_matchignore
+-- m/NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"/
+-- m/HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column./
+-- end_matchignore
 -- tests for functions related to TID handling
 CREATE TABLE tid_tab (a int, b int default 0) distributed by (b);
 -- min() and max() for TIDs
 INSERT INTO tid_tab VALUES (1), (2);
 SELECT min(ctid) FROM tid_tab;
-NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
-HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
-NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
-HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
   min  
 -------
  (0,1)
 (1 row)
 
 SELECT max(ctid) FROM tid_tab;
-NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
-HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
-NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
-HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
   max  
 -------
  (0,2)

--- a/src/test/regress/expected/tid.out
+++ b/src/test/regress/expected/tid.out
@@ -1,20 +1,26 @@
 -- tests for functions related to TID handling
-CREATE TABLE tid_tab (a int);
+CREATE TABLE tid_tab (a int, b int default 0) distributed by (b);
 -- min() and max() for TIDs
-INSERT INTO tid_tab VALUES (0), (1), (2);
-SELECT gp_segment_id, min(ctid) FROM tid_tab GROUP BY gp_segment_id;
- gp_segment_id |  min  
----------------+-------
-             0 | (0,1)
-             1 | (0,1)
-(2 rows)
+INSERT INTO tid_tab VALUES (1), (2);
+SELECT min(ctid) FROM tid_tab;
+NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+  min  
+-------
+ (0,1)
+(1 row)
 
-SELECT gp_segment_id, max(ctid) FROM tid_tab GROUP BY gp_segment_id;
- gp_segment_id |  max  
----------------+-------
-             0 | (0,1)
-             1 | (0,2)
-(2 rows)
+SELECT max(ctid) FROM tid_tab;
+NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+  max  
+-------
+ (0,2)
+(1 row)
 
 TRUNCATE tid_tab;
 -- Tests for currtid() and currtid2() with various relation kinds

--- a/src/test/regress/expected/tid.out
+++ b/src/test/regress/expected/tid.out
@@ -1,106 +1,85 @@
 -- tests for functions related to TID handling
 CREATE TABLE tid_tab (a int);
 -- min() and max() for TIDs
-INSERT INTO tid_tab VALUES (1), (2);
-SELECT min(ctid) FROM tid_tab;
-  min  
--------
- (0,1)
-(1 row)
+INSERT INTO tid_tab VALUES (0), (1), (2);
+SELECT gp_segment_id, min(ctid) FROM tid_tab GROUP BY gp_segment_id;
+ gp_segment_id |  min  
+---------------+-------
+             0 | (0,1)
+             1 | (0,1)
+(2 rows)
 
-SELECT max(ctid) FROM tid_tab;
-  max  
--------
- (0,2)
-(1 row)
+SELECT gp_segment_id, max(ctid) FROM tid_tab GROUP BY gp_segment_id;
+ gp_segment_id |  max  
+---------------+-------
+             0 | (0,1)
+             1 | (0,2)
+(2 rows)
 
 TRUNCATE tid_tab;
 -- Tests for currtid() and currtid2() with various relation kinds
+-- Not supported in GPDB
 -- Materialized view
 CREATE MATERIALIZED VIEW tid_matview AS SELECT a FROM tid_tab;
 SELECT currtid('tid_matview'::regclass::oid, '(0,1)'::tid); -- fails
-ERROR:  tid (0, 1) is not valid for relation "tid_matview"
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_matview'::text, '(0,1)'::tid); -- fails
-ERROR:  tid (0, 1) is not valid for relation "tid_matview"
+ERROR:  function currtid2 is not supported by GPDB
 INSERT INTO tid_tab VALUES (1);
 REFRESH MATERIALIZED VIEW tid_matview;
 SELECT currtid('tid_matview'::regclass::oid, '(0,1)'::tid); -- ok
- currtid 
----------
- (0,1)
-(1 row)
-
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_matview'::text, '(0,1)'::tid); -- ok
- currtid2 
-----------
- (0,1)
-(1 row)
-
+ERROR:  function currtid2 is not supported by GPDB
 DROP MATERIALIZED VIEW tid_matview;
 TRUNCATE tid_tab;
 -- Sequence
 CREATE SEQUENCE tid_seq;
 SELECT currtid('tid_seq'::regclass::oid, '(0,1)'::tid); -- ok
- currtid 
----------
- (0,1)
-(1 row)
-
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_seq'::text, '(0,1)'::tid); -- ok
- currtid2 
-----------
- (0,1)
-(1 row)
-
+ERROR:  function currtid2 is not supported by GPDB
 DROP SEQUENCE tid_seq;
 -- Index, fails with incorrect relation type
 CREATE INDEX tid_ind ON tid_tab(a);
 SELECT currtid('tid_ind'::regclass::oid, '(0,1)'::tid); -- fails
-ERROR:  "tid_ind" is an index
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_ind'::text, '(0,1)'::tid); -- fails
-ERROR:  "tid_ind" is an index
+ERROR:  function currtid2 is not supported by GPDB
 DROP INDEX tid_ind;
 -- Partitioned table, no storage
 CREATE TABLE tid_part (a int) PARTITION BY RANGE (a);
 SELECT currtid('tid_part'::regclass::oid, '(0,1)'::tid); -- fails
-ERROR:  cannot look at latest visible tid for relation "public.tid_part"
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_part'::text, '(0,1)'::tid); -- fails
-ERROR:  cannot look at latest visible tid for relation "public.tid_part"
+ERROR:  function currtid2 is not supported by GPDB
 DROP TABLE tid_part;
 -- Views
 -- ctid not defined in the view
 CREATE VIEW tid_view_no_ctid AS SELECT a FROM tid_tab;
 SELECT currtid('tid_view_no_ctid'::regclass::oid, '(0,1)'::tid); -- fails
-ERROR:  currtid cannot handle views with no CTID
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_view_no_ctid'::text, '(0,1)'::tid); -- fails
-ERROR:  currtid cannot handle views with no CTID
+ERROR:  function currtid2 is not supported by GPDB
 DROP VIEW tid_view_no_ctid;
 -- ctid fetched directly from the source table.
 CREATE VIEW tid_view_with_ctid AS SELECT ctid, a FROM tid_tab;
 SELECT currtid('tid_view_with_ctid'::regclass::oid, '(0,1)'::tid); -- fails
-ERROR:  tid (0, 1) is not valid for relation "tid_tab"
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_view_with_ctid'::text, '(0,1)'::tid); -- fails
-ERROR:  tid (0, 1) is not valid for relation "tid_tab"
+ERROR:  function currtid2 is not supported by GPDB
 INSERT INTO tid_tab VALUES (1);
 SELECT currtid('tid_view_with_ctid'::regclass::oid, '(0,1)'::tid); -- ok
- currtid 
----------
- (0,1)
-(1 row)
-
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_view_with_ctid'::text, '(0,1)'::tid); -- ok
- currtid2 
-----------
- (0,1)
-(1 row)
-
+ERROR:  function currtid2 is not supported by GPDB
 DROP VIEW tid_view_with_ctid;
 TRUNCATE tid_tab;
 -- ctid attribute with incorrect data type
 CREATE VIEW tid_view_fake_ctid AS SELECT 1 AS ctid, 2 AS a;
 SELECT currtid('tid_view_fake_ctid'::regclass::oid, '(0,1)'::tid); -- fails
-ERROR:  ctid isn't of type TID
+ERROR:  function currtid is not supported by GPDB
 SELECT currtid2('tid_view_fake_ctid'::text, '(0,1)'::tid); -- fails
-ERROR:  ctid isn't of type TID
+ERROR:  function currtid2 is not supported by GPDB
 DROP VIEW tid_view_fake_ctid;
 DROP TABLE tid_tab CASCADE;

--- a/src/test/regress/sql/tid.sql
+++ b/src/test/regress/sql/tid.sql
@@ -1,3 +1,8 @@
+-- start_matchignore
+-- m/NOTICE:  SELECT uses system-defined column "tid_tab.ctid" without the necessary companion column "tid_tab.gp_segment_id"/
+-- m/HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column./
+-- end_matchignore
+
 -- tests for functions related to TID handling
 
 CREATE TABLE tid_tab (a int, b int default 0) distributed by (b);

--- a/src/test/regress/sql/tid.sql
+++ b/src/test/regress/sql/tid.sql
@@ -3,12 +3,13 @@
 CREATE TABLE tid_tab (a int);
 
 -- min() and max() for TIDs
-INSERT INTO tid_tab VALUES (1), (2);
-SELECT min(ctid) FROM tid_tab;
-SELECT max(ctid) FROM tid_tab;
+INSERT INTO tid_tab VALUES (0), (1), (2);
+SELECT gp_segment_id, min(ctid) FROM tid_tab GROUP BY gp_segment_id;
+SELECT gp_segment_id, max(ctid) FROM tid_tab GROUP BY gp_segment_id;
 TRUNCATE tid_tab;
 
 -- Tests for currtid() and currtid2() with various relation kinds
+-- Not supported in GPDB
 
 -- Materialized view
 CREATE MATERIALIZED VIEW tid_matview AS SELECT a FROM tid_tab;

--- a/src/test/regress/sql/tid.sql
+++ b/src/test/regress/sql/tid.sql
@@ -1,11 +1,11 @@
 -- tests for functions related to TID handling
 
-CREATE TABLE tid_tab (a int);
+CREATE TABLE tid_tab (a int, b int default 0) distributed by (b);
 
 -- min() and max() for TIDs
-INSERT INTO tid_tab VALUES (0), (1), (2);
-SELECT gp_segment_id, min(ctid) FROM tid_tab GROUP BY gp_segment_id;
-SELECT gp_segment_id, max(ctid) FROM tid_tab GROUP BY gp_segment_id;
+INSERT INTO tid_tab VALUES (1), (2);
+SELECT min(ctid) FROM tid_tab;
+SELECT max(ctid) FROM tid_tab;
 TRUNCATE tid_tab;
 
 -- Tests for currtid() and currtid2() with various relation kinds


### PR DESCRIPTION
Commit e786be5fcb257a09b05bd8e509c8d1b82e626352 added new test for currtid()
and currtid2(), however they are not supported in GPDB. Also modify a part
of the test about min/max of TIDs to work correctly in GPDB.
