### PR TITLE
Resolve conflicts in src/tools/msvc/Solution.pm

### DIFF
--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -144,14 +144,9 @@ sub GetOpenSSLVersion
 
 sub GenerateFiles
 {
-<<<<<<< HEAD
-	my $self = shift;
-	my $buildclient = shift;
-	my $bits = $self->{platform} eq 'Win32' ? 32 : 64;
-=======
 	my $self          = shift;
+	my $buildclient   = shift;
 	my $bits          = $self->{platform} eq 'Win32' ? 32 : 64;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 	my $ac_init_found = 0;
 	my $package_name;
 	my $package_version;
@@ -175,15 +170,11 @@ sub GenerateFiles
 			$package_name      = $1;
 			$package_bugreport = $3;
 			#$package_tarname   = $4;
-<<<<<<< HEAD
-			$package_url       = $5;
+			$package_url = $5;
 		}
 		if (/\[PG_PACKAGE_VERSION=([^\]]+)\]/)
 		{
 			$package_version   = $1;
-=======
-			$package_url = $5;
->>>>>>> 1fa092913d260056b1aaf627ebc9cd9655c3a27c
 
 			if ($package_version !~ /^(\d+)(?:\.(\d+))?/)
 			{


### PR DESCRIPTION
1) Commit 5cbfce5 in src/tools/msvc/Solution.pm formatted the declaration of
the local variables self and bits in the GenerateFiles function, while the
earlier commit 8a5ad4b had already added the declaration of the new local
variable buildclient in the same location.

2) Commit 5cbfce5 in src/tools/msvc/Solution.pm formatted the assignment of the
variable package_url in the GenerateFiles function, while the earlier commit
89f85cc had already added GPDB-specific code in the same location.