### PR TITLE
Fix test src/test/regress/expected/shared_scan.out

### DIFF
--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -119,7 +119,8 @@ $$;
 SELECT col_mismatch_func1();
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
-CONTEXT:  PL/pgSQL function col_mismatch_func1() line 6 at RETURN QUERY
+CONTEXT:  SQL statement "WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 LIMIT 10) SELECT a, 1 , 1 FROM cte JOIN t2 USING (a)"
+PL/pgSQL function col_mismatch_func1() line 6 at RETURN QUERY
 -- ORCA plan contains a Shared Scan producer with a sorted Motion below it
 EXPLAIN (COSTS OFF)
 WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 ORDER BY b LIMIT 10) SELECT a, 1, 1 FROM cte JOIN t2 USING (a);
@@ -159,4 +160,5 @@ $$;
 SELECT col_mismatch_func2();
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
-CONTEXT:  PL/pgSQL function col_mismatch_func2() line 6 at RETURN QUERY
+CONTEXT:  SQL statement "WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 ORDER BY b LIMIT 10) SELECT a, 1 , 1 FROM cte JOIN t2 USING (a)"
+PL/pgSQL function col_mismatch_func2() line 6 at RETURN QUERY

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -125,7 +125,8 @@ SELECT col_mismatch_func1();
 NOTICE:  An ERROR must have happened. Stopping a Shared Scan.
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
-CONTEXT:  PL/pgSQL function col_mismatch_func1() line 6 at RETURN QUERY
+CONTEXT:  SQL statement "WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 LIMIT 10) SELECT a, 1 , 1 FROM cte JOIN t2 USING (a)"
+PL/pgSQL function col_mismatch_func1() line 6 at RETURN QUERY
 -- ORCA plan contains a Shared Scan producer with a sorted Motion below it
 EXPLAIN (COSTS OFF)
 WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 ORDER BY b LIMIT 10) SELECT a, 1, 1 FROM cte JOIN t2 USING (a);
@@ -169,4 +170,5 @@ SELECT col_mismatch_func2();
 NOTICE:  An ERROR must have happened. Stopping a Shared Scan.
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
-CONTEXT:  PL/pgSQL function col_mismatch_func2() line 6 at RETURN QUERY
+CONTEXT:  SQL statement "WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 ORDER BY b LIMIT 10) SELECT a, 1 , 1 FROM cte JOIN t2 USING (a)"
+PL/pgSQL function col_mismatch_func2() line 6 at RETURN QUERY

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -122,7 +122,6 @@ END
 $$;
 -- This should only ERROR and should not SIGSEGV
 SELECT col_mismatch_func1();
-NOTICE:  An ERROR must have happened. Stopping a Shared Scan.
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
 CONTEXT:  SQL statement "WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 LIMIT 10) SELECT a, 1 , 1 FROM cte JOIN t2 USING (a)"
@@ -167,7 +166,6 @@ END
 $$;
 -- This should only ERROR and should not SIGSEGV
 SELECT col_mismatch_func2();
-NOTICE:  An ERROR must have happened. Stopping a Shared Scan.
 ERROR:  structure of query does not match function result type
 DETAIL:  Number of returned columns (3) does not match expected column count (2).
 CONTEXT:  SQL statement "WITH cte AS (SELECT * FROM t1 WHERE random() < 0.1 ORDER BY b LIMIT 10) SELECT a, 1 , 1 FROM cte JOIN t2 USING (a)"


### PR DESCRIPTION
Commit 2f48ede080f42b97b594fb14102c82ca1001b80c has updated SPI code to avoid
using cursors in RETURN QUERY statements. This changed the error message, so
tests should be updated.