### PR TITLE
amend! Resolve conflicts in src/backend/parser/gram.y (#2393)

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -3475,6 +3475,8 @@ ExecAlterExtensionContentsStmt_internal(AlterExtensionContentsStmt *stmt,
 		case OBJECT_STATISTIC_EXT:
 		case OBJECT_SUBSCRIPTION:
 		case OBJECT_TABLESPACE:
+		case OBJECT_RESQUEUE:
+		case OBJECT_RESGROUP:
 			ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 				 errmsg("cannot add an object of this type to an extension")));

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -3471,12 +3471,12 @@ ExecAlterExtensionContentsStmt_internal(AlterExtensionContentsStmt *stmt,
 		case OBJECT_EXTENSION:
 		case OBJECT_INDEX:
 		case OBJECT_PUBLICATION:
+		case OBJECT_RESQUEUE:
+		case OBJECT_RESGROUP:
 		case OBJECT_ROLE:
 		case OBJECT_STATISTIC_EXT:
 		case OBJECT_SUBSCRIPTION:
 		case OBJECT_TABLESPACE:
-		case OBJECT_RESQUEUE:
-		case OBJECT_RESGROUP:
 			ereport(ERROR,
 				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 				 errmsg("cannot add an object of this type to an extension")));

--- a/src/backend/commands/seclabel.c
+++ b/src/backend/commands/seclabel.c
@@ -72,6 +72,7 @@ SecLabelSupportsObjectType(ObjectType objtype)
 		case OBJECT_DEFACL:
 		case OBJECT_DOMCONSTRAINT:
 		case OBJECT_EXTENSION:
+		case OBJECT_EXTPROTOCOL:
 		case OBJECT_FDW:
 		case OBJECT_FOREIGN_SERVER:
 		case OBJECT_INDEX:
@@ -80,6 +81,8 @@ SecLabelSupportsObjectType(ObjectType objtype)
 		case OBJECT_OPFAMILY:
 		case OBJECT_POLICY:
 		case OBJECT_PUBLICATION_REL:
+		case OBJECT_RESQUEUE:
+		case OBJECT_RESGROUP:
 		case OBJECT_RULE:
 		case OBJECT_STATISTIC_EXT:
 		case OBJECT_TABCONSTRAINT:
@@ -90,8 +93,6 @@ SecLabelSupportsObjectType(ObjectType objtype)
 		case OBJECT_TSPARSER:
 		case OBJECT_TSTEMPLATE:
 		case OBJECT_USER_MAPPING:
-		case OBJECT_RESQUEUE:
-		case OBJECT_RESGROUP:
 			return false;
 
 			/*

--- a/src/backend/commands/seclabel.c
+++ b/src/backend/commands/seclabel.c
@@ -90,6 +90,8 @@ SecLabelSupportsObjectType(ObjectType objtype)
 		case OBJECT_TSPARSER:
 		case OBJECT_TSTEMPLATE:
 		case OBJECT_USER_MAPPING:
+		case OBJECT_RESQUEUE:
+		case OBJECT_RESGROUP:
 			return false;
 
 			/*

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -8738,6 +8738,8 @@ object_type_name:
 			| ROLE									{ $$ = OBJECT_ROLE; }
 			| SUBSCRIPTION							{ $$ = OBJECT_SUBSCRIPTION; }
 			| TABLESPACE							{ $$ = OBJECT_TABLESPACE; }
+			| RESOURCE QUEUE						{ $$ = OBJECT_RESQUEUE; }
+			| RESOURCE GROUP_P						{ $$ = OBJECT_RESGROUP; }
 		;
 
 drop_type_name:


### PR DESCRIPTION
Resolve conflicts in src/backend/parser/gram.y (#2393)

1. Commit c7d65a252cdb7219deb48899fa643c5fd2cc3877 removed part_strategy,
however partspec type nearby has three keywords in GPDB instead of two.
2. Commit 3fbd4bb6f494dd70cc5075536a754261853de167 removed DropPLangStmt,
however there are GPDB-specific DropQueueStmt and DropResourceGroupStmt
nearby.
3. Commit c7d65a252cdb7219deb48899fa643c5fd2cc3877 removed part_strategy,
however the code it's used in is different in GPDB. Also remove it from
GPDB-specific code.
4. Commit a332b366d4fa19ee3578a864993a8dc7abb47177 removed
comment_type_any_name and comment_type_name, however there are more options in
GPDB.
5. Commits a332b366d4fa19ee3578a864993a8dc7abb47177 and
8f5b5967441f05e56446fa4cdeffd0774c01e553 refactored grammar so that COMMENT,
SECURITY LABEL and ALTER EXTENSION use the same list of object types. Add
RESOURCE QUEUE and RESOURCE GROUP back for COMMENT, and disable them for
SECURITY LABEL and ALTER EXTENSION, since they were not supported.
