### PR TITLE
Fix tests in src/test/regress/expected/role.out

### DIFF
--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -87,9 +87,7 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE USER jonathan12 WITH PASSWORD 'abc2';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER USER jonathan11 RENAME TO jona11;
-NOTICE:  MD5 password cleared because of role rename
 ALTER USER jonathan12 RENAME TO jona12;
-NOTICE:  MD5 password cleared because of role rename
 DROP USER jona11;
 DROP USER jona12;
 CREATE USER jonathan12 WITH PASSWORD 'abc2';
@@ -97,7 +95,6 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER USER jonathan11 RENAME TO jona11;
 ERROR:  role "jonathan11" does not exist
 ALTER USER jonathan12 RENAME TO jona12;
-NOTICE:  MD5 password cleared because of role rename
 CREATE GROUP marketing WITH USER jona11,jona12;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  role "jona11" does not exist


### PR DESCRIPTION
Commit c7eab0e changed the default value of the password_encryption GUC from
md5 to scram-sha-256. Remove the notification about resetting the MD5 password
when renaming roles in GPDB-specific tests.