### PR TITLE
Fix tests in src/test/regress/expected/gp_array_agg.out

### DIFF
--- a/src/test/regress/expected/gp_array_agg.out
+++ b/src/test/regress/expected/gp_array_agg.out
@@ -326,7 +326,7 @@ explain (verbose, costs off) select array_dims(gp_array_agg(distinct arr)) from 
                                  Output: arr
                                  Group Key: int_array_table.arr
                                  ->  Seq Scan on test_gp_array_agg.int_array_table
-                                       Output: a, arr
+                                       Output: arr
  Optimizer: Postgres query optimizer
  Settings: optimizer=off
 (19 rows)


### PR DESCRIPTION
Commit 4cad253 changed the logic in hash aggregation, which now omit columns in
the target list of the underlying node. Change this in GPDB-specific tests.