### PR TITLE
Resolve conflicts in heapam.h, heapam_visibility.c and pruneheap.c

### DIFF
--- a/src/backend/access/heap/heapam_visibility.c
+++ b/src/backend/access/heap/heapam_visibility.c
@@ -1308,7 +1308,7 @@ HeapTupleSatisfiesVacuum(Relation relation, HeapTuple htup, TransactionId Oldest
 	TransactionId dead_after = InvalidTransactionId;
 	HTSV_Result res;
 
-	res = HeapTupleSatisfiesVacuumHorizon(htup, buffer, &dead_after);
+	res = HeapTupleSatisfiesVacuumHorizon(relation, htup, buffer, &dead_after);
 
 	if (res == HEAPTUPLE_RECENTLY_DEAD)
 	{

--- a/src/backend/access/heap/heapam_visibility.c
+++ b/src/backend/access/heap/heapam_visibility.c
@@ -1336,7 +1336,7 @@ HeapTupleSatisfiesVacuum(Relation relation, HeapTuple htup, TransactionId Oldest
  * transaction aborted.
  */
 HTSV_Result
-HeapTupleSatisfiesVacuumHorizon(HeapTuple htup, Buffer buffer, TransactionId *dead_after)
+HeapTupleSatisfiesVacuumHorizon(Relation relation, HeapTuple htup, Buffer buffer, TransactionId *dead_after)
 {
 	HeapTupleHeader tuple = htup->t_data;
 
@@ -1573,14 +1573,10 @@ HeapTupleSatisfiesNonVacuumable(Relation relation,
 								HeapTuple htup, Snapshot snapshot,
 								Buffer buffer)
 {
-<<<<<<< HEAD
-	return HeapTupleSatisfiesVacuum(relation, htup, snapshot->xmin, buffer)
-		!= HEAPTUPLE_DEAD;
-=======
 	TransactionId dead_after = InvalidTransactionId;
 	HTSV_Result res;
 
-	res = HeapTupleSatisfiesVacuumHorizon(htup, buffer, &dead_after);
+	res = HeapTupleSatisfiesVacuumHorizon(relation, htup, buffer, &dead_after);
 
 	if (res == HEAPTUPLE_RECENTLY_DEAD)
 	{
@@ -1593,7 +1589,6 @@ HeapTupleSatisfiesNonVacuumable(Relation relation,
 		Assert(!TransactionIdIsValid(dead_after));
 
 	return res != HEAPTUPLE_DEAD;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 }
 
 

--- a/src/backend/access/heap/pruneheap.c
+++ b/src/backend/access/heap/pruneheap.c
@@ -391,7 +391,7 @@ heap_prune_satisfies_vacuum(PruneState *prstate, HeapTuple tup, Buffer buffer)
 	HTSV_Result res;
 	TransactionId dead_after;
 
-	res = HeapTupleSatisfiesVacuumHorizon(tup, buffer, &dead_after);
+	res = HeapTupleSatisfiesVacuumHorizon(prstate->rel, tup, buffer, &dead_after);
 
 	if (res != HEAPTUPLE_RECENTLY_DEAD)
 		return res;
@@ -524,11 +524,7 @@ heap_prune_chain(Buffer buffer, OffsetNumber rootoffnum, PruneState *prstate)
 			 * either here or while following a chain below.  Whichever path
 			 * gets there first will mark the tuple unused.
 			 */
-<<<<<<< HEAD
-			if (HeapTupleSatisfiesVacuum(relation, &tup, OldestXmin, buffer)
-=======
 			if (heap_prune_satisfies_vacuum(prstate, &tup, buffer)
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 				== HEAPTUPLE_DEAD && !HeapTupleHeaderIsHotUpdated(htup))
 			{
 				heap_prune_record_unused(prstate, rootoffnum);
@@ -612,11 +608,7 @@ heap_prune_chain(Buffer buffer, OffsetNumber rootoffnum, PruneState *prstate)
 		 */
 		tupdead = recent_dead = false;
 
-<<<<<<< HEAD
-		switch (HeapTupleSatisfiesVacuum(relation, &tup, OldestXmin, buffer))
-=======
 		switch (heap_prune_satisfies_vacuum(prstate, &tup, buffer))
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 		{
 			case HEAPTUPLE_DEAD:
 				tupdead = true;

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -196,21 +196,13 @@ extern TM_Result HeapTupleSatisfiesUpdate(Relation relation, HeapTuple stup, Com
 										  Buffer buffer);
 extern HTSV_Result HeapTupleSatisfiesVacuum(Relation relation, HeapTuple stup, TransactionId OldestXmin,
 											Buffer buffer);
-<<<<<<< HEAD
+extern HTSV_Result HeapTupleSatisfiesVacuumHorizon(Relation relation, HeapTuple stup, Buffer buffer,
+												   TransactionId *dead_after);
 extern void HeapTupleSetHintBits(HeapTupleHeader tuple, Buffer buffer, Relation rel,
 								 uint16 infomask, TransactionId xid);
 extern bool HeapTupleHeaderIsOnlyLocked(HeapTupleHeader tuple);
-extern bool HeapTupleIsSurelyDead(HeapTuple htup, TransactionId OldestXmin);
-=======
-extern HTSV_Result HeapTupleSatisfiesVacuumHorizon(HeapTuple stup, Buffer buffer,
-												   TransactionId *dead_after);
-extern void HeapTupleSetHintBits(HeapTupleHeader tuple, Buffer buffer,
-								 uint16 infomask, TransactionId xid);
-extern bool HeapTupleHeaderIsOnlyLocked(HeapTupleHeader tuple);
-extern bool XidInMVCCSnapshot(TransactionId xid, Snapshot snapshot);
 extern bool HeapTupleIsSurelyDead(HeapTuple htup,
 								  struct GlobalVisState *vistest);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 
 /*
  * To avoid leaking too much knowledge about reorderbuffer implementation


### PR DESCRIPTION
1) Commit dc7420c added a definition of the new function
HeapTupleSatisfiesVacuumHorizon to src/include/access/heapam.h and
changed the second argument in HeapTupleIsSurelyDead. However, an
earlier commit 19cd1cf already added the third argument, Relation rel,
to the function and moved the definition of the function
XidInMVCCSnapshot to src/include/utils/snapmgr.h.

2) Commit dc7420c in src/backend/access/heap/heapam_visibility.c
rewrote the HeapTupleSatisfiesNonVacuumable function to use the new
HeapTupleSatisfiesVacuumHorizon function. However, the earlier commit
19cd1cf had already added the first argument, Relation, to the
HeapTupleSatisfiesVacuum function.

3) Commit dc7420c in src/backend/access/heap/pruneheap.c in the
heap_prune_chain function replaced the call to the
HeapTupleSatisfiesVacuum function with a call to the new
heap_prune_satisfies_vacuum function. However, the earlier commit
19cd1cf had already added the first argument, Relation, to the
HeapTupleSatisfiesVacuum function.