### PR TITLE
Resolve conflicts src/backend/storage/lmgr/lwlocknames.txt

### DIFF
--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -50,22 +50,23 @@ MultiXactTruncationLock				41
 OldSnapshotTimeMapLock				42
 LogicalRepWorkerLock				43
 XactTruncationLock					44
+# 45 was XactTruncationLock until removal of BackendRandomLock
+WrapLimitsVacuumLock				46
+NotifyQueueTailLock					47
 
 # Additional individual locks in GPDB
-SharedSnapshotLock					45
-DistributedLogControlLock			46
+SharedSnapshotLock					48
+DistributedLogControlLock			49
 # 47 is available; was formerly AOSegFileLock
-ResQueueLock						48
-ResGroupLock						49
-ErrorLogLock						50
-SessionStateLock					51
-RelfilenodeGenLock					52
-WorkFileManagerLock					53
-DistributedLogTruncateLock			54
-TwophaseCommitLock				55
-ShareInputScanLock				56
-FTSReplicationStatusLock			57
-GxidBumpLock						58
-ParallelCursorEndpointLock			59
-WrapLimitsVacuumLock				60
-NotifyQueueTailLock					61
+ResQueueLock						50
+ResGroupLock						51
+ErrorLogLock						52
+SessionStateLock					53
+RelfilenodeGenLock					54
+WorkFileManagerLock					55
+DistributedLogTruncateLock			56
+TwophaseCommitLock					57
+ShareInputScanLock					58
+FTSReplicationStatusLock			59
+GxidBumpLock						60
+ParallelCursorEndpointLock			61

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -50,7 +50,6 @@ MultiXactTruncationLock				41
 OldSnapshotTimeMapLock				42
 LogicalRepWorkerLock				43
 XactTruncationLock					44
-<<<<<<< HEAD
 
 # Additional individual locks in GPDB
 SharedSnapshotLock					45
@@ -68,8 +67,5 @@ ShareInputScanLock				56
 FTSReplicationStatusLock			57
 GxidBumpLock						58
 ParallelCursorEndpointLock			59
-=======
-# 45 was XactTruncationLock until removal of BackendRandomLock
-WrapLimitsVacuumLock				46
-NotifyQueueTailLock					47
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+WrapLimitsVacuumLock				60
+NotifyQueueTailLock					61

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -57,7 +57,6 @@ NotifyQueueTailLock					47
 # Additional individual locks in GPDB
 SharedSnapshotLock					48
 DistributedLogControlLock			49
-# 47 is available; was formerly AOSegFileLock
 ResQueueLock						50
 ResGroupLock						51
 ErrorLogLock						52


### PR DESCRIPTION
Commit 566372b3d6435639e4cc4476d79b8505a0297c87 added new locks to the
lwlocknames.txt, while earlier commit 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4
added gpdb specific locks to the same place.