### PR TITLE
Resolve conflicts in the catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302604171
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202008191
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+#define CATALOG_VERSION_NO	302605041
 
 #endif


### PR DESCRIPTION
Commit 3e98c0bafb28de87ae095b341687dc082371af54 updates the catalog version,
but we use a different format.