### PR TITLE
Resolve conflicts in the pg_controldata.c, pg_resetwal.c and pg_control.h

### DIFF
--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -257,15 +257,10 @@ main(int argc, char *argv[])
 	printf(_("Latest checkpoint's full_page_writes: %s\n"),
 		   ControlFile->checkPointCopy.fullPageWrites ? _("on") : _("off"));
 	printf(_("Latest checkpoint's NextXID:          %u:%u\n"),
-<<<<<<< HEAD
-		   EpochFromFullTransactionId(ControlFile->checkPointCopy.nextFullXid),
-		   XidFromFullTransactionId(ControlFile->checkPointCopy.nextFullXid));
-	printf(_("Latest checkpoint's NextGxid:         "UINT64_FORMAT"\n"),
-		   ControlFile->checkPointCopy.nextGxid);
-=======
 		   EpochFromFullTransactionId(ControlFile->checkPointCopy.nextXid),
 		   XidFromFullTransactionId(ControlFile->checkPointCopy.nextXid));
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+	printf(_("Latest checkpoint's NextGxid:         "UINT64_FORMAT"\n"),
+		   ControlFile->checkPointCopy.nextGxid);
 	printf(_("Latest checkpoint's NextOID:          %u\n"),
 		   ControlFile->checkPointCopy.nextOid);
 	printf(_("Latest checkpoint's NextRelfilenode:  %u\n"),

--- a/src/bin/pg_resetwal/pg_resetwal.c
+++ b/src/bin/pg_resetwal/pg_resetwal.c
@@ -554,18 +554,13 @@ main(int argc, char *argv[])
 
 	if (set_oldest_xid != 0)
 	{
-<<<<<<< HEAD
 		ControlFile.checkPointCopy.oldestXid = set_oldest_xid;
 		ControlFile.checkPointCopy.oldestXidDB = InvalidOid;
 	}
 
 	if (set_xid != 0)
-		ControlFile.checkPointCopy.nextFullXid =
-			FullTransactionIdFromEpochAndXid(EpochFromFullTransactionId(ControlFile.checkPointCopy.nextFullXid),
-=======
 		ControlFile.checkPointCopy.nextXid =
 			FullTransactionIdFromEpochAndXid(EpochFromFullTransactionId(ControlFile.checkPointCopy.nextXid),
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 											 set_xid);
 
 	if (set_gxid != 0)
@@ -938,15 +933,10 @@ PrintControlValues(bool guessed)
 	printf(_("Latest checkpoint's full_page_writes: %s\n"),
 		   ControlFile.checkPointCopy.fullPageWrites ? _("on") : _("off"));
 	printf(_("Latest checkpoint's NextXID:          %u:%u\n"),
-<<<<<<< HEAD
-		   EpochFromFullTransactionId(ControlFile.checkPointCopy.nextFullXid),
-		   XidFromFullTransactionId(ControlFile.checkPointCopy.nextFullXid));
-	printf(_("Latest checkpoint's NextGxid:         "UINT64_FORMAT"\n"),
-		   ControlFile.checkPointCopy.nextGxid);
-=======
 		   EpochFromFullTransactionId(ControlFile.checkPointCopy.nextXid),
 		   XidFromFullTransactionId(ControlFile.checkPointCopy.nextXid));
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+	printf(_("Latest checkpoint's NextGxid:         "UINT64_FORMAT"\n"),
+		   ControlFile.checkPointCopy.nextGxid);
 	printf(_("Latest checkpoint's NextOID:          %u\n"),
 		   ControlFile.checkPointCopy.nextOid);
 	printf(_("Latest checkpoint's NextRelfilenode:  %u\n"),

--- a/src/include/catalog/pg_control.h
+++ b/src/include/catalog/pg_control.h
@@ -45,12 +45,8 @@ typedef struct CheckPoint
 	TimeLineID	PrevTimeLineID; /* previous TLI, if this record begins a new
 								 * timeline (equals ThisTimeLineID otherwise) */
 	bool		fullPageWrites; /* current full_page_writes */
-<<<<<<< HEAD
-	FullTransactionId nextFullXid;	/* next free full transaction ID */
-	DistributedTransactionId nextGxid;	/* next free gxid */
-=======
 	FullTransactionId nextXid;	/* next free transaction ID */
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+	DistributedTransactionId nextGxid;	/* next free gxid */
 	Oid			nextOid;		/* next free OID */
 	Oid			nextRelfilenode;	/* next free Relfilenode */
 	MultiXactId nextMulti;		/* next free MultiXactId */


### PR DESCRIPTION
Commit fea10a64340e529805609126740a540c8f9daab4 renamed a field in the
CheckPoint, but commit 24e274093461727b305fda4bae8ea41e2de6507b added other
field nearby.

In pg_controldata.c commit 24e274093461727b305fda4bae8ea41e2de6507b added printf
nearby.
In pg_resetwal.c commits 26bc6228baa852caf458fb3c36ff4f03a8a8b6bd and
04d26d7d9e78a309a005adc62be03fb76c89c04a added code nearby.