### PR TITLE
Resolve conficts in the transam.h

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -115,7 +115,7 @@ void
 DistributedLog_InitOldestXmin(void)
 {
 	TransactionId oldestXmin = ShmemVariableCache->oldestXid;
-	TransactionId latestXid = ShmemVariableCache->latestCompletedXid;
+	TransactionId latestXid = XidFromFullTransactionId(ShmemVariableCache->latestCompletedXid);
 
 	/*
 	 * Start scanning from oldest datfrozenxid, until we find a

--- a/src/backend/access/transam/test/distributedlog_test.c
+++ b/src/backend/access/transam/test/distributedlog_test.c
@@ -39,7 +39,7 @@ MPP_20426(void **state, TransactionId nextXid)
 	VariableCacheData data;
 	ShmemVariableCache = &data;
 	ShmemVariableCache->oldestXid = 3;
-	ShmemVariableCache->latestCompletedXid = 4;
+	ShmemVariableCache->latestCompletedXid = FullTransactionIdFromEpochAndXid(0, 4);
 	DistributedLogShmem dls;
 	DistributedLogShared = &dls;
 

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -199,9 +199,8 @@ typedef struct VariableCacheData
 	/*
 	 * These fields are protected by ProcArrayLock.
 	 */
-<<<<<<< HEAD
-	TransactionId latestCompletedXid;	/* newest XID that has committed or
-										 * aborted */
+	FullTransactionId latestCompletedXid;	/* newest full XID that has
+											 * committed or aborted */
 	DistributedTransactionId latestCompletedGxid;	/* newest distributed XID that has
 													   committed or aborted */
 
@@ -213,9 +212,6 @@ typedef struct VariableCacheData
 	 */
 	DistributedTransactionId nextGxid;	/* next full XID to assign */
 	uint32		GxidCount;		/* Gxids available before must do XLOG work */
-=======
-	FullTransactionId latestCompletedXid;	/* newest full XID that has
-											 * committed or aborted */
 
 	/*
 	 * Number of top-level transactions with xids (i.e. which may have
@@ -225,7 +221,6 @@ typedef struct VariableCacheData
 	 * not. There are likely other users of this.  Always above 1.
 	 */
 	uint64 xactCompletionCount;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 
 	/*
 	 * These fields are protected by XactTruncationLock


### PR DESCRIPTION
Commit 3bd7f9969a240827bc2effa399170b7565238fd2 changes the field
latestCompletedXid in the VariableCacheData struct, and commit 
623a9ba79bbdd11c5eccb30b8bd5c446130e521c adds a new field to the
VariableCacheData struct, while earlier commit
24e274093461727b305fda4bae8ea41e2de6507b added two fields nearby.