### PR TITLE
Resolve conflicts in the backendid.h

### DIFF
--- a/src/include/storage/backendid.h
+++ b/src/include/storage/backendid.h
@@ -53,11 +53,6 @@ extern PGDLLIMPORT BackendId ParallelLeaderBackendId;
  *
  * In GPDB, we use TempRelBackendId for everything.
  */
-<<<<<<< HEAD
 #define BackendIdForTempRelations() TempRelBackendId
-=======
-#define BackendIdForTempRelations() \
-	(ParallelLeaderBackendId == InvalidBackendId ? MyBackendId : ParallelLeaderBackendId)
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 
 #endif							/* BACKENDID_H */


### PR DESCRIPTION
Commit e07633646a22734e85d7fc58a66855f747128e6b renamed the variable in the
macro BackendIdForTempRelations, but commit
38d88155520790b268b1a380caa9a2d9508edc66 changed that macro.