### PR TITLE
Resolve conflicts in the snapshot.h

### DIFF
--- a/src/include/utils/snapshot.h
+++ b/src/include/utils/snapshot.h
@@ -212,18 +212,17 @@ typedef struct SnapshotData
 	XLogRecPtr	lsn;			/* position in the WAL stream when taken */
 
 	/*
-<<<<<<< HEAD
 	 * GP: Global information about which transactions are visible for a
 	 * distributed transaction, with cached local xids
 	 */
 	DistributedSnapshotWithLocalMapping	distribSnapshotWithLocalMapping;
-=======
+
+	/*
 	 * The transaction completion count at the time GetSnapshotData() built
 	 * this snapshot. Allows to avoid re-computing static snapshots when no
 	 * transactions completed since the last GetSnapshotData().
 	 */
 	uint64		snapXactCompletionCount;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 } SnapshotData;
 
 #endif							/* SNAPSHOT_H */


### PR DESCRIPTION
Commit 623a9ba79bbdd11c5eccb30b8bd5c446130e521c added a new field to the
SnapshotData struct, but earlier commit 3b4cd7887fd16542339ae9cb13df252d7c58fc11
added a field nearby.