### PR TITLE
Resolve conflicts in pg_proc.dat and pg_upgrade_support.c

### DIFF
--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -67,23 +67,6 @@ binary_upgrade_set_next_array_pg_type_oid(PG_FUNCTION_ARGS)
 }
 
 Datum
-<<<<<<< HEAD
-binary_upgrade_set_next_toast_pg_type_oid(PG_FUNCTION_ARGS)
-{
-	Oid			typoid = PG_GETARG_OID(0);
-	Oid			typnamespaceoid = PG_GETARG_OID(1);
-	char	   *typname = GET_STR(PG_GETARG_TEXT_P(2));
-
-	CHECK_IS_BINARY_UPGRADE;
-	AddPreassignedOidFromBinaryUpgrade(typoid, TypeRelationId, typname,
-						typnamespaceoid, InvalidOid, InvalidOid);
-
-	PG_RETURN_VOID();
-}
-
-Datum
-=======
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 binary_upgrade_set_next_heap_pg_class_oid(PG_FUNCTION_ARGS)
 {
 	Oid			reloid = PG_GETARG_OID(0);

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10422,13 +10422,6 @@
   proname => 'binary_upgrade_set_next_array_pg_type_oid', provolatile => 'v',
   proparallel => 'r', prorettype => 'void', proargtypes => 'oid oid text',
   prosrc => 'binary_upgrade_set_next_array_pg_type_oid' },
-<<<<<<< HEAD
-{ oid => '3585', descr => 'for use by pg_upgrade',
-  proname => 'binary_upgrade_set_next_toast_pg_type_oid', provolatile => 'v',
-  proparallel => 'r', prorettype => 'void', proargtypes => 'oid oid text',
-  prosrc => 'binary_upgrade_set_next_toast_pg_type_oid' },
-=======
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 { oid => '3586', descr => 'for use by pg_upgrade',
   proname => 'binary_upgrade_set_next_heap_pg_class_oid', provolatile => 'v',
   proparallel => 'r', prorettype => 'void', proargtypes => 'oid oid text',


### PR DESCRIPTION
1) Commit f3faf35 in src/include/catalog/pg_proc.dat removed the
declaration of the binary_upgrade_set_next_toast_pg_type_oid function,
although the earlier commit 19cd1cf had already added two additional
arguments to it.

2) Commit f3faf35 in src/backend/utils/adt/pg_upgrade_support.c removed
the binary_upgrade_set_next_toast_pg_type_oid function, although the
earlier commit 19cd1cf had already added two additional arguments,
typnamespaceoid and typname.