### PR TITLE
Resolve conflicts in nodeHash.h, nodeHash.c, and costsize.c

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -547,16 +547,11 @@ ExecHashTableCreate(HashState *state, HashJoinState *hjstate,
 	hashtable->spaceAllowed = space_allowed;
 	hashtable->spaceUsedSkew = 0;
 	hashtable->spaceAllowedSkew =
-<<<<<<< HEAD
-		hashtable->spaceAllowed * SKEW_WORK_MEM_PERCENT / 100;
+		hashtable->spaceAllowed * SKEW_HASH_MEM_PERCENT / 100;
 	hashtable->stats = NULL;
 	hashtable->eagerlyReleased = false;
 	hashtable->hjstate = hjstate;
 	hashtable->first_pass = true;
-
-=======
-		hashtable->spaceAllowed * SKEW_HASH_MEM_PERCENT / 100;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	hashtable->chunks = NULL;
 	hashtable->current_chunk = NULL;
 	hashtable->parallel_state = state->parallel_state;
@@ -718,12 +713,8 @@ ExecHashTableCreate(HashState *state, HashJoinState *hjstate,
 
 void
 ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
-<<<<<<< HEAD
                         uint64 operatorMemKB,
-						bool try_combined_work_mem,
-=======
 						bool try_combined_hash_mem,
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 						int parallel_workers,
 						size_t *space_allowed,
 						int *numbuckets,
@@ -757,11 +748,7 @@ ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
 	/*
 	 * Target in-memory hashtable size is hash_mem kilobytes.
 	 */
-<<<<<<< HEAD
 	hash_table_bytes = operatorMemKB * 1024L;
-=======
-	hash_table_bytes = hash_mem * 1024L;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 
 	/*
 	 * Parallel Hash tries to use the combined hash_mem of all workers to
@@ -882,13 +869,8 @@ ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
 		/*
 		 * Buckets are simple pointers to hashjoin tuples, while tupsize
 		 * includes the pointer, hash code, and MinimalTupleData.  So buckets
-<<<<<<< HEAD
-		 * should never really exceed 25% of work_mem (even for
-		 * gp_hashjoin_tuples_per_bucket=1); except maybe for work_mem values that are not
-=======
 		 * should never really exceed 25% of hash_mem (even for
-		 * NTUP_PER_BUCKET=1); except maybe for hash_mem values that are not
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+		 * gp_hashjoin_tuples_per_bucket=1); except maybe for hash_mem values that are not
 		 * 2^N bytes, where we might get more because of doubling. So let's
 		 * look for 50% here.
 		 */

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -746,7 +746,7 @@ ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
 	inner_rel_bytes = ntuples * tupsize;
 
 	/*
-	 * Target in-memory hashtable size is hash_mem kilobytes.
+	 * Target in-memory hashtable size is operatorMemKB kilobytes.
 	 */
 	hash_table_bytes = operatorMemKB * 1024L;
 

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -133,18 +133,12 @@ bool		enable_indexonlyscan = true;
 bool		enable_bitmapscan = true;
 bool		enable_tidscan = true;
 bool		enable_sort = true;
-<<<<<<< HEAD
 /* GPDB_13_MERGE_FIXME: enable incremental sort */
-bool		enable_incrementalsort = false;
+bool		enable_incremental_sort = false;
 bool		enable_hashagg = true;
 bool		enable_groupagg = true;
 bool		hashagg_avoid_disk_plan = true;
 bool		enable_nestloop = false;
-=======
-bool		enable_incremental_sort = true;
-bool		enable_hashagg = true;
-bool		enable_nestloop = true;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 bool		enable_material = true;
 bool		enable_mergejoin = false;
 bool		enable_hashjoin = true;
@@ -3817,14 +3811,6 @@ initial_cost_hashjoin(PlannerInfo *root, JoinCostWorkspace *workspace,
 	if (parallel_hash)
 		inner_path_rows_total *= get_parallel_divisor(inner_path);
 
-<<<<<<< HEAD
-	/* Get hash table size that executor would use for inner relation */
-	ExecChooseHashTableSize(inner_path_rows_total,
-							inner_path->pathtarget->width,
-							true,	/* useskew */
-							global_work_mem(root) / 1024L,
-							parallel_hash,	/* try_combined_work_mem */
-=======
 	/*
 	 * Get hash table size that executor would use for inner relation.
 	 *
@@ -3838,8 +3824,8 @@ initial_cost_hashjoin(PlannerInfo *root, JoinCostWorkspace *workspace,
 	ExecChooseHashTableSize(inner_path_rows_total,
 							inner_path->pathtarget->width,
 							true,	/* useskew */
+							global_work_mem(root) / 1024L,
 							parallel_hash,	/* try_combined_hash_mem */
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 							outer_path->parallel_workers,
 							&space_allowed,
 							&numbuckets,
@@ -3902,11 +3888,7 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 	Cost		run_cost = workspace->run_cost;
 	int			numbuckets = workspace->numbuckets;
 	int			numbatches = workspace->numbatches;
-<<<<<<< HEAD
-=======
 	int			hash_mem;
-	Cost		cpu_per_tuple;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	QualCost	hash_qual_cost;
 	QualCost	qp_qual_cost;
 	double		hashjointuples;

--- a/src/include/executor/nodeHash.h
+++ b/src/include/executor/nodeHash.h
@@ -69,22 +69,13 @@ extern bool ExecScanHashTableForUnmatched(HashJoinState *hjstate,
 extern void ExecHashTableReset(HashState *hashState, HashJoinTable hashtable);
 extern void ExecHashTableResetMatchFlags(HashJoinTable hashtable);
 extern void ExecChooseHashTableSize(double ntuples, int tupwidth, bool useskew,
-<<<<<<< HEAD
                                     uint64 operatorMemKB,
-                                    bool try_combined_work_mem,
+                                    bool try_combined_hash_mem,
                                     int parallel_workers,
                                     size_t *space_allowed,
                                     int *numbuckets,
                                     int *numbatches,
                                     int *num_skew_mcvs);
-=======
-									bool try_combined_hash_mem,
-									int parallel_workers,
-									size_t *space_allowed,
-									int *numbuckets,
-									int *numbatches,
-									int *num_skew_mcvs);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 extern int	ExecHashGetSkewBucket(HashJoinTable hashtable, uint32 hashvalue);
 extern void ExecHashEstimate(HashState *node, ParallelContext *pcxt);
 extern void ExecHashInitializeDSM(HashState *node, ParallelContext *pcxt);


### PR DESCRIPTION
1) Commit d6c08e2 in src/include/executor/nodeHash.h renamed the
try_combined_work_mem argument to try_combined_hash_mem in the
ExecChooseHashTableSize function definition, although commit 19cd1cf
had already added a new uint64 argument, operatorMemKB.

2) Commit d6c08e2 in src/backend/executor/nodeHash.c renamed the
try_combined_work_mem argument to try_combined_hash_mem in the
ExecChooseHashTableSize function, although commit 19cd1cf had already
added a new uint64 argument, operatorMemKB.

3) Commit d6c08e2 in src/backend/executor/nodeHash.c renamed the
SKEW_WORK_MEM_PERCENT define to SKEW_HASH_MEM_PERCENT in the
ExecHashTableCreate function, although earlier HashTable-specific
commits had already added initialization for the HashTable-specific
fields below.

4) Commit d6c08e2 in src/backend/executor/nodeHash.c in the
ExecChooseHashTableSize function renamed the work_mem variable to
hash_mem, although earlier commit 19cd1cf had already renamed it to
operatorMemKB.

5) Commit d6c08e2 in src/backend/executor/nodeHash.c changed the
comment in the ExecChooseHashTableSize function, although earlier
commit 8ae22d1 had already changed it.

6) Commit d6c08e2 in src/backend/optimizer/path/costsize.c in the
initial_cost_hashjoin function changed the try_combined_work_mem
comment to try_combined_hash_mem, although earlier commit c8ac464 had
already added the new argument global_work_mem(root) / 1024L before
that.

7) Commit e61225f in src/backend/optimizer/path/costsize.c renamed the
global variable enable_incrementalsort to enable_incremental_sort,
while an earlier commit by 2feb2cc had already changed its value from
true to false.

8) Commit d6c08e2 in src/backend/optimizer/path/costsize.c added a new
local variable hash_mem in the final_cost_hashjoin function, while an
earlier GPDB-specific commit by c8ac464 had already removed the local
variable cpu_per_tuple in the same location.