### PR TITLE
Resolve conflicts in src/include/nodes/execnodes.h

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2618,7 +2618,7 @@ typedef struct AggState
 	AggStatePerGroup *all_pergroups;	/* array of first ->pergroups, than
 										 * ->hash_pergroup */
 	ProjectionInfo *combinedproj;	/* projection machinery */
-<<<<<<< HEAD
+	SharedAggInfo *shared_info; /* one entry per worker */
 
 	int			group_id;		/* GROUP_ID in current projection. This is passed
 								 * to GroupingSetId expressions, similar to the
@@ -2627,9 +2627,6 @@ typedef struct AggState
 
 	/* if input tuple has an AggExprId, save the Attribute Number */
 	Index       AggExprId_AttrNum;
-=======
-	SharedAggInfo *shared_info; /* one entry per worker */
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 } AggState;
 
 typedef struct TupleSplitState


### PR DESCRIPTION
Resolve conflicts in src/include/nodes/execnodes.h

Commit 9bdb300 added a new field, shared_info, to the AggState
structure in src/include/nodes/execnodes.h. Earlier commits 19cd1cf and
0138eed had already added new fields, group_id, gset_id, and
AggExprId_AttrNum, to the same location.