### PR TITLE
Resolve conflicts in src/include/optimizer/cost.h

### DIFF
--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -73,11 +73,8 @@ extern PGDLLIMPORT bool enable_tidscan;
 extern PGDLLIMPORT bool enable_sort;
 extern PGDLLIMPORT bool enable_incremental_sort;
 extern PGDLLIMPORT bool enable_hashagg;
-<<<<<<< HEAD
 extern PGDLLIMPORT bool enable_groupagg;
 extern PGDLLIMPORT bool hashagg_avoid_disk_plan;
-=======
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 extern PGDLLIMPORT bool enable_nestloop;
 extern PGDLLIMPORT bool enable_material;
 extern PGDLLIMPORT bool enable_mergejoin;


### PR DESCRIPTION
Commit e61225f in src/include/optimizer/cost.h renamed the variable
declaration enable_incrementalsort to enable_incremental_sort, while
earlier commits 19cd1cf and 92c58fd had already added declarations of
the new variables enable_groupagg and hashagg_avoid_disk_plan alongside
them.