### PR TITLE
Resolve conflicts in src/backend/catalog/heap.c

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1662,6 +1662,9 @@ heap_create_with_catalog(const char *relname,
 		relarrayname = makeArrayTypeName(relname, relnamespace);
 
 		/*
+		 * We'll make an array over the composite type, too.  For largely
+		 * historical reasons, the array type's OID is assigned first.
+		 *
 		 * If we are expected to get a preassigned Oid but receive InvalidOid,
 		 * get a new Oid. This can happen during upgrades from GPDB4 to 5 where
 		 * array types over relation rowtypes were introduced so there are no

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1627,9 +1627,8 @@ heap_create_with_catalog(const char *relname,
 	new_rel_desc->rd_rel->relrewrite = relrewrite;
 
 	/*
-<<<<<<< HEAD
-	 * Decide whether to create an array type over the relation's rowtype. We
-	 * do not create any array types for system catalogs (ie, those made
+	 * Decide whether to create a pg_type entry for the relation's rowtype. We
+	 * do not create these types for system catalogs (ie, those made
 	 * during initdb). We do not create them where the use of a relation as
 	 * such is an implementation detail: toast tables, sequences and indexes.
 	 *
@@ -1655,6 +1654,9 @@ heap_create_with_catalog(const char *relname,
 							  relkind == RELKIND_PARTITIONED_TABLE) &&
 		relnamespace != PG_BITMAPINDEX_NAMESPACE)
 	{
+		Oid			new_array_oid;
+		ObjectAddress new_type_addr;
+
 		/* OK, so pre-assign a type OID for the array type */
 		relarrayname = makeArrayTypeName(relname, relnamespace);
 
@@ -1665,55 +1667,6 @@ heap_create_with_catalog(const char *relname,
 		 * pre-existing array types to dump from the old cluster
 		 */
 		new_array_oid = AssignTypeArrayOid(relarrayname, relnamespace);
-	}
-
-	/*
-	 * Since defining a relation also defines a complex type, we add a new
-	 * system type corresponding to the new relation.  The OID of the type can
-	 * be preselected by the caller, but if reltypeid is InvalidOid, we'll
-	 * generate a new OID for it.
-	 *
-	 * NOTE: we could get a unique-index failure here, in case someone else is
-	 * creating the same type name in parallel but hadn't committed yet when
-	 * we checked for a duplicate name above.
-	 */
-	new_type_addr = AddNewRelationType(relname,
-									   relnamespace,
-									   relid,
-									   relkind,
-									   ownerid,
-									   reltypeid,
-									   new_array_oid);
-	new_type_oid = new_type_addr.objectId;
-	if (typaddress)
-		*typaddress = new_type_addr;
-
-	/*
-	 * Now make the array type if wanted.
-	 */
-	if (OidIsValid(new_array_oid))
-	{
-		if (!relarrayname)
-			relarrayname = makeArrayTypeName(relname, relnamespace);
-=======
-	 * Decide whether to create a pg_type entry for the relation's rowtype.
-	 * These types are made except where the use of a relation as such is an
-	 * implementation detail: toast tables, sequences and indexes.
-	 */
-	if (!(relkind == RELKIND_SEQUENCE ||
-		  relkind == RELKIND_TOASTVALUE ||
-		  relkind == RELKIND_INDEX ||
-		  relkind == RELKIND_PARTITIONED_INDEX))
-	{
-		Oid			new_array_oid;
-		ObjectAddress new_type_addr;
-		char	   *relarrayname;
-
-		/*
-		 * We'll make an array over the composite type, too.  For largely
-		 * historical reasons, the array type's OID is assigned first.
-		 */
-		new_array_oid = AssignTypeArrayOid();
 
 		/*
 		 * Make the pg_type entry for the composite type.  The OID of the
@@ -1736,9 +1689,6 @@ heap_create_with_catalog(const char *relname,
 			*typaddress = new_type_addr;
 
 		/* Now create the array type. */
-		relarrayname = makeArrayTypeName(relname, relnamespace);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
-
 		TypeCreate(new_array_oid,	/* force the type's OID to this */
 				   relarrayname,	/* Array type name */
 				   relnamespace,	/* Same namespace as parent */

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1509,7 +1509,6 @@ heap_create_with_catalog(const char *relname,
 	Oid			new_type_oid;
 	TransactionId relfrozenxid;
 	MultiXactId relminmxid;
-	char	   *relarrayname = NULL;
 
 	pg_class_desc = table_open(RelationRelationId, RowExclusiveLock);
 
@@ -1627,10 +1626,9 @@ heap_create_with_catalog(const char *relname,
 	new_rel_desc->rd_rel->relrewrite = relrewrite;
 
 	/*
-	 * Decide whether to create a pg_type entry for the relation's rowtype. We
-	 * do not create these types for system catalogs (ie, those made
-	 * during initdb). We do not create them where the use of a relation as
-	 * such is an implementation detail: toast tables, sequences and indexes.
+	 * Decide whether to create a pg_type entry for the relation's rowtype.
+	 * These types are made except where the use of a relation as such is an
+	 * implementation detail: toast tables, sequences and indexes.
 	 *
 	 * Also not for the auxiliary heaps created for bitmap indexes or append-
 	 * only tables.
@@ -1646,16 +1644,19 @@ heap_create_with_catalog(const char *relname,
 	 * OID first on QD and use the name as key to retrieve the pre-assigned
 	 * OID from QE.
 	 */
-	if (IsUnderPostmaster && ((relkind == RELKIND_RELATION  && !RelationIsAppendOptimized(new_rel_desc)) ||
-							  relkind == RELKIND_VIEW ||
-							  relkind == RELKIND_MATVIEW ||
-							  relkind == RELKIND_FOREIGN_TABLE ||
-							  relkind == RELKIND_COMPOSITE_TYPE ||
-							  relkind == RELKIND_PARTITIONED_TABLE) &&
+	if (!((relkind == RELKIND_RELATION && RelationIsAppendOptimized(new_rel_desc)) ||
+		  relkind == RELKIND_SEQUENCE ||
+		  relkind == RELKIND_TOASTVALUE ||
+		  relkind == RELKIND_INDEX ||
+		  relkind == RELKIND_PARTITIONED_INDEX ||
+		  relkind == RELKIND_AOSEGMENTS ||
+		  relkind == RELKIND_AOBLOCKDIR ||
+		  relkind == RELKIND_AOVISIMAP) &&
 		relnamespace != PG_BITMAPINDEX_NAMESPACE)
 	{
 		Oid			new_array_oid;
 		ObjectAddress new_type_addr;
+		char	   *relarrayname = NULL;
 
 		/* OK, so pre-assign a type OID for the array type */
 		relarrayname = makeArrayTypeName(relname, relnamespace);


### PR DESCRIPTION
Commits f7f70d5e22aa2330b8cc31dfc8732cd26ef0bbdd and
f3faf35f370f558670c8213a08f2683f3811ffc7 refactored code for array type
creation, however there is GPDB-specific code, in particular added by commit
675b2991429c410456fb911c5135676e7f7ade4e. Adjust changes for GPDB-specific
code.
