### PR TITLE
Resolve conflicts in src/include/replication/walsender_private.h

### DIFF
--- a/src/include/replication/walsender_private.h
+++ b/src/include/replication/walsender_private.h
@@ -98,20 +98,12 @@ typedef struct WalSnd
 	 * Timestamp of the last message received from standby.
 	 */
 	TimestampTz replyTime;
-<<<<<<< HEAD
-
-	/* Statistics for transactions spilled to disk. */
-	int64		spillTxns;
-	int64		spillCount;
-	int64		spillBytes;
 
 	/*
 	 * Indicates whether the WalSnd represents a connection with a Greenplum
 	 * mirror in streaming mode
 	 */
 	bool 		is_for_gp_walreceiver;
-=======
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 } WalSnd;
 
 extern WalSnd *MyWalSnd;


### PR DESCRIPTION
Commit d973747 in src/include/replication/walsender_private.h in the
WalSnd structure removed the spillTxns, spillCount, and spillBytes
fields. However, an earlier commit, e03a755, had already added the
is_for_gp_walreceiver field to the same location.