### PR TITLE
Resolve conflicts in src/include/utils/numeric.h

### DIFF
--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -62,12 +62,9 @@ extern Numeric numeric_li_value(float8 f, Numeric y0, Numeric y1);
  * Utility functions in numeric.c
  */
 extern bool numeric_is_nan(Numeric num);
-<<<<<<< HEAD
 extern int16 *numeric_digits(Numeric num);
 extern int numeric_len(Numeric num);
-=======
 extern bool numeric_is_inf(Numeric num);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 int32		numeric_maximum_size(int32 typmod);
 extern char *numeric_out_sci(Numeric num, int scale);
 extern char *numeric_normalize(Numeric num);


### PR DESCRIPTION
Commit a57d312 added a definition of the new function numeric_is_inf to
src/include/utils/numeric.h, while an earlier commit, 76f3ff7, had
already added definitions of the functions numeric_digits and
numeric_len in the same location