### PR TITLE
Resolve conflicts in src/include/utils/tuplesort.h

### DIFF
--- a/src/include/utils/tuplesort.h
+++ b/src/include/utils/tuplesort.h
@@ -93,14 +93,10 @@ typedef struct TuplesortInstrumentation
 {
 	TuplesortMethod sortMethod; /* sort algorithm used */
 	TuplesortSpaceType spaceType;	/* type of space spaceUsed represents */
-<<<<<<< HEAD
-	long		spaceUsed;		/* space consumption, in kB */
+	int64		spaceUsed;		/* space consumption, in kB */
 
 	Size		workmemused;
 	Size		execmemused;
-=======
-	int64		spaceUsed;		/* space consumption, in kB */
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 } TuplesortInstrumentation;
 
 


### PR DESCRIPTION
Commit 6ee3b5f changed the spaceUsed field in the
TuplesortInstrumentation structure from long to int64 in
src/include/utils/tuplesort.h. Earlier commits 19cd1cf and fe0a9dd had
already added the workmemused and execmemused fields to the same
location.