### PR TITLE
Resolve conflicts in src/backend/access/rmgrdesc/xlogdesc.c

### DIFF
--- a/src/backend/access/rmgrdesc/xlogdesc.c
+++ b/src/backend/access/rmgrdesc/xlogdesc.c
@@ -90,14 +90,9 @@ xlog_desc(StringInfo buf, XLogReaderState *record)
 						 checkpoint->ThisTimeLineID,
 						 checkpoint->PrevTimeLineID,
 						 checkpoint->fullPageWrites ? "true" : "false",
-<<<<<<< HEAD
-						 EpochFromFullTransactionId(checkpoint->nextFullXid),
-						 XidFromFullTransactionId(checkpoint->nextFullXid),
-						 checkpoint->nextGxid,
-=======
 						 EpochFromFullTransactionId(checkpoint->nextXid),
 						 XidFromFullTransactionId(checkpoint->nextXid),
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+						 checkpoint->nextGxid,
 						 checkpoint->nextOid,
 						 checkpoint->nextRelfilenode,
 						 checkpoint->nextMulti,

--- a/src/backend/access/transam/clog.c
+++ b/src/backend/access/transam/clog.c
@@ -751,7 +751,7 @@ CLOGTransactionIsOld(TransactionId xid)
 	if (ShmemVariableCache == NULL)
 		return false;	// In case we are called very early in the life of the backend process, etc.
 
-	nextXid = XidFromFullTransactionId(ShmemVariableCache->nextFullXid);
+	nextXid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
 
 	if (nextXid < xid)
 		return false;	// Not sure what is going on.

--- a/src/backend/access/transam/gp_distributed_log.c
+++ b/src/backend/access/transam/gp_distributed_log.c
@@ -73,7 +73,7 @@ gp_distributed_log(PG_FUNCTION_ARGS)
 		context = (Context *) palloc(sizeof(Context));
 		funcctx->user_fctx = (void *) context;
 
-		context->indexXid = XidFromFullTransactionId(ShmemVariableCache->nextFullXid);
+		context->indexXid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
 												// Start with last possible + 1.
 
 		funcctx->user_fctx = (void *) context;

--- a/src/backend/access/transam/gp_transaction_log.c
+++ b/src/backend/access/transam/gp_transaction_log.c
@@ -70,7 +70,7 @@ gp_transaction_log(PG_FUNCTION_ARGS)
 		context = (Context *) palloc(sizeof(Context));
 		funcctx->user_fctx = (void *) context;
 
-		context->indexXid = XidFromFullTransactionId(ShmemVariableCache->nextFullXid);
+		context->indexXid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
 												// Start with last possible + 1.
 
 		funcctx->user_fctx = (void *) context;

--- a/src/backend/access/transam/test/varsup_test.c
+++ b/src/backend/access/transam/test/varsup_test.c
@@ -52,7 +52,7 @@ test_GetNewTransactionId_xid_stop_limit(void **state)
 	 * and it's larger than xidStopLimit to trigger the ereport(ERROR).
 	 */
 	ShmemVariableCache = &data;
-	ShmemVariableCache->nextFullXid.value = 30;
+	ShmemVariableCache->nextXid.value = 30;
 	ShmemVariableCache->xidVacLimit = 10;
 	ShmemVariableCache->xidStopLimit = 20;
 	IsUnderPostmaster = true;
@@ -97,7 +97,7 @@ test_GetNewTransactionId_xid_warn_limit(void **state)
 	 * the ereport(WARNING).
 	 */
 	ShmemVariableCache = &data;
-	ShmemVariableCache->nextFullXid.value = xid;
+	ShmemVariableCache->nextXid.value = xid;
 	ShmemVariableCache->xidVacLimit = 10;
 	ShmemVariableCache->xidWarnLimit = 20;
 	ShmemVariableCache->xidStopLimit = 30;

--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -224,13 +224,13 @@ GetNewTransactionId(bool isSubXact)
 		 */
 		const uint64      page_extend_limit = 4 * 1024;
 
-		xx = U64FromFullTransactionId(ShmemVariableCache->nextFullXid);
+		xx = U64FromFullTransactionId(ShmemVariableCache->nextXid);
 
 		r = xx % page_extend_limit;
 		if (r > 1 && r < (page_extend_limit - 1))
 		{
 			xx += page_extend_limit - r - 1;
-			ShmemVariableCache->nextFullXid.value = xx;
+			ShmemVariableCache->nextXid.value = xx;
 		}
 	}
 


### PR DESCRIPTION
1) Commit fea10a6 in src/backend/access/rmgrdesc/xlogdesc.c in the
xlog_desc function when calling the appendStringInfo function renamed
the nextFullXid field of the checkpoint structure to nextXid, although
the earlier commit 24e2740 had already added the nextGxid field to the
same location.

2) Commit fea10a6 in src/include/access/transam.h in the
VariableCacheData structure renamed the nextFullXid field to nextXid.
Rename in GPDB-specific places.