### PR TITLE
Resolve conflicts in src/backend/access/transam/xlog.c

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5322,13 +5322,9 @@ BootStrapXLOG(void)
 	checkPoint.time = (pg_time_t) time(NULL);
 	checkPoint.oldestActiveXid = InvalidTransactionId;
 
-<<<<<<< HEAD
-	ShmemVariableCache->nextFullXid = checkPoint.nextFullXid;
+	ShmemVariableCache->nextXid = checkPoint.nextXid;
 	ShmemVariableCache->nextGxid = checkPoint.nextGxid;
 	ShmemVariableCache->GxidCount = 0;
-=======
-	ShmemVariableCache->nextXid = checkPoint.nextXid;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	ShmemVariableCache->nextOid = checkPoint.nextOid;
 	ShmemVariableCache->oidCount = 0;
 	ShmemVariableCache->nextRelfilenode = checkPoint.nextRelfilenode;
@@ -7014,15 +7010,9 @@ StartupXLOG(void)
 							 (uint32) (checkPoint.redo >> 32), (uint32) checkPoint.redo,
 							 wasShutdown ? "true" : "false")));
 	ereport(DEBUG1,
-<<<<<<< HEAD
 			(errmsg_internal("next transaction ID: " UINT64_FORMAT "; next OID: %u; next relfilenode: %u",
-							 U64FromFullTransactionId(checkPoint.nextFullXid),
-							 checkPoint.nextOid, checkPoint.nextRelfilenode)));
-=======
-			(errmsg_internal("next transaction ID: " UINT64_FORMAT "; next OID: %u",
 							 U64FromFullTransactionId(checkPoint.nextXid),
-							 checkPoint.nextOid)));
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+							 checkPoint.nextOid, checkPoint.nextRelfilenode)));
 	ereport(DEBUG1,
 			(errmsg_internal("next MultiXactId: %u; next MultiXactOffset: %u",
 							 checkPoint.nextMulti, checkPoint.nextMultiOffset)));
@@ -7041,13 +7031,9 @@ StartupXLOG(void)
 				(errmsg("invalid next transaction ID")));
 
 	/* initialize shared memory variables from the checkpoint record */
-<<<<<<< HEAD
-	ShmemVariableCache->nextFullXid = checkPoint.nextFullXid;
+	ShmemVariableCache->nextXid = checkPoint.nextXid;
 	ShmemVariableCache->nextGxid = checkPoint.nextGxid;
 	ShmemVariableCache->GxidCount = 0;
-=======
-	ShmemVariableCache->nextXid = checkPoint.nextXid;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	ShmemVariableCache->nextOid = checkPoint.nextOid;
 	ShmemVariableCache->oidCount = 0;
 	ShmemVariableCache->nextRelfilenode = checkPoint.nextRelfilenode;
@@ -8240,18 +8226,13 @@ StartupXLOG(void)
 
 	/* also initialize latestCompletedXid, to nextXid - 1 */
 	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
-<<<<<<< HEAD
-	ShmemVariableCache->latestCompletedXid = XidFromFullTransactionId(ShmemVariableCache->nextFullXid);
+	ShmemVariableCache->latestCompletedXid = ShmemVariableCache->nextXid;
 	ShmemVariableCache->latestCompletedGxid = ShmemVariableCache->nextGxid;
-	TransactionIdRetreat(ShmemVariableCache->latestCompletedXid);
+	FullTransactionIdRetreat(&ShmemVariableCache->latestCompletedXid);
 	if (IsNormalProcessingMode())
 		elog(LOG, "latest completed transaction id is %u and next transaction id is %u",
 			 ShmemVariableCache->latestCompletedXid,
 			 XidFromFullTransactionId(ShmemVariableCache->nextFullXid));
-=======
-	ShmemVariableCache->latestCompletedXid = ShmemVariableCache->nextXid;
-	FullTransactionIdRetreat(&ShmemVariableCache->latestCompletedXid);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	LWLockRelease(ProcArrayLock);
 
 	/*
@@ -9636,11 +9617,7 @@ CreateCheckPoint(int flags)
 	 * StartupSUBTRANS hasn't been called yet.
 	 */
 	if (!RecoveryInProgress())
-<<<<<<< HEAD
-		TruncateSUBTRANS(GetLocalOldestXmin(NULL, PROCARRAY_FLAGS_DEFAULT));
-=======
 		TruncateSUBTRANS(GetOldestTransactionIdConsideredRunning());
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 
 	/* Real work is done, but log and update stats before releasing lock. */
 	LogCheckpointEnd(false);
@@ -10120,15 +10097,8 @@ GetWALAvailability(XLogRecPtr targetLSN)
 	 * oldestSlotSeg to the current segment.
 	 */
 	currpos = GetXLogWriteRecPtr();
-<<<<<<< HEAD
-
-	/* calculate oldest segment currently needed by slots */
-	XLByteToSeg(targetLSN, targetSeg, wal_segment_size);
-	KeepLogSeg(currpos, &oldestSlotSeg, InvalidXLogRecPtr);
-=======
 	XLByteToSeg(currpos, oldestSlotSeg, wal_segment_size);
-	KeepLogSeg(currpos, &oldestSlotSeg);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+	KeepLogSeg(currpos, &oldestSlotSeg, InvalidXLogRecPtr);
 
 	/*
 	 * Find the oldest extant segment file. We get 1 until checkpoint removes
@@ -10250,19 +10220,6 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 	/* but, keep at least wal_keep_size if that's set */
 	if (wal_keep_size_mb > 0)
 	{
-<<<<<<< HEAD
-		/* avoid underflow, don't go below 1 */
-		if (currSegNo <= wal_keep_segments)
-			segno = 1;
-		else
-			segno = currSegNo - wal_keep_segments;
-
-		setvalue = true;
-	}
-
-	/* don't delete WAL segments newer than the calculated segment */
-	if (setvalue && (XLogRecPtrIsInvalid(*logSegNo) || segno < *logSegNo))
-=======
 		uint64		keep_segs;
 
 		keep_segs = ConvertToXSegs(wal_keep_size_mb, wal_segment_size);
@@ -10274,11 +10231,12 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 			else
 				segno = currSegNo - keep_segs;
 		}
+
+		setvalue = true;
 	}
 
 	/* don't delete WAL segments newer than the calculated segment */
-	if (segno < *logSegNo)
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+	if (setvalue && segno < *logSegNo)
 		*logSegNo = segno;
 }
 


### PR DESCRIPTION
1) Commit fea10a6 in src/backend/access/transam/xlog.c renamed the
nextFullXid field to nextXid in the BootStrapXLOG function, while
earlier commit 24e2740 had already added the initialization of the
nextGxid and GxidCount fields next to it.

2) Commit fea10a6 in src/backend/access/transam/xlog.c in the
StartupXLOG function when calling the errmsg_internal function renamed
the nextFullXid field to nextXid, while earlier commit 38d8815 had
already added the use of the nextRelfilenode field next to it.

3) Commit fea10a6 in src/backend/access/transam/xlog.c renamed the
nextFullXid field to nextXid in the StartupXLOG function. However,
earlier commit 24e2740 had already added the initialization of the
nextGxid and GxidCount fields next to it.

4) Commit 3bd7f99 in src/backend/access/transam/xlog.c in the
StartupXLOG function removed the call to the XidFromFullTransactionId
function and replaced the call to the TransactionIdRetreat function
with FullTransactionIdRetreat. However, earlier commits 24e2740,
1af089b, and 19cd1cf had already added GPDB-specific code to the same
location.

5) Commit dc7420c in src/backend/access/transam/xlog.c replaced the
GetOldestXmin function call with
GetOldestTransactionIdConsideredRunning in the CreateCheckPoint
function, while earlier commit 19cd1cf had already replaced the
GetOldestXmin function call with GetLocalOldestXmin.

6) Commit b5b4c0f in src/backend/access/transam/xlog.c replaced the
targetLSN and targetSeg arguments with currpos and oldestSlotSeg in the
GetWALAvailability function call in the XLByteToSeg function, while
earlier commit 185c7d7 had already added a new InvalidXLogRecPtr
argument to the XLByteToSeg function call.

7) Commit c3fe108 in the file src/backend/access/transam/xlog.c in the
KeepLogSeg function changed the calculation of segno, while the earlier
commit 1617960 had already added the setvalue setting in the same
place.