### PR TITLE
Resolve conflicts in src/backend/optimizer/prep/prepunion.c

### DIFF
--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1152,8 +1152,7 @@ choose_hashed_setop(PlannerInfo *root, List *groupClauses,
 
 	/*
 	 * Don't do it if it doesn't look like the hashtable will fit into
-<<<<<<< HEAD
-	 * work_mem.
+	 * hash_mem.
 	 *
 	 * GPDB: In other places where we are building a Hash Aggregate, we use
 	 * calcHashAggTableSizes(), which takes into account that in GPDB, a Hash
@@ -1165,9 +1164,6 @@ choose_hashed_setop(PlannerInfo *root, List *groupClauses,
 	 * even more lame that we don't account the spilling correctly, if we are
 	 * in fact constructing a Hash Aggregate. A UNION is implemented with a
 	 * Hash Aggregate, only INTERSECT and EXCEPT use Hashed SetOp.
-=======
-	 * hash_mem.
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	 */
 	hashentrysize = MAXALIGN(input_path->pathtarget->width) + MAXALIGN(SizeofMinimalTupleHeader);
 


### PR DESCRIPTION
Resolve conflicts in src/backend/optimizer/prep/prepunion.c

Commit d6c08e2 renamed work_mem to hash_mem in the comments of
choose_hashed_setop(), while earlier commit b396ef2 added the
GPDB FIXME about Hashed SetOp not spilling to disk in the same
place.