### PR TITLE
Resolve conflicts in src/backend/storage/smgr/smgr.c

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -19,15 +19,12 @@
  */
 #include "postgres.h"
 
-<<<<<<< HEAD
 #include "access/aomd.h"
 #include "access/xact.h"
+#include "access/xlog.h"
 #include "access/xlogutils.h"
 #include "catalog/catalog.h"
 #include "catalog/indexing.h"
-=======
-#include "access/xlog.h"
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 #include "lib/ilist.h"
 #include "postmaster/postmaster.h"
 #include "storage/bufmgr.h"
@@ -232,16 +229,10 @@ smgropen(RelFileNode rnode, BackendId backend, SMgrImpl which)
 		/* hash_search already filled in the lookup key */
 		reln->smgr_owner = NULL;
 		reln->smgr_targblock = InvalidBlockNumber;
-<<<<<<< HEAD
-		reln->smgr_fsm_nblocks = InvalidBlockNumber;
-		reln->smgr_vm_nblocks = InvalidBlockNumber;
-		reln->smgr_which = which;
-		reln->storageManager = smgr(backend, rnode, which);
-=======
 		for (int i = 0; i <= MAX_FORKNUM; ++i)
 			reln->smgr_cached_nblocks[i] = InvalidBlockNumber;
-		reln->smgr_which = 0;	/* we only have md.c at present */
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+		reln->smgr_which = which;
+		reln->storageManager = smgr(backend, rnode, which);
 
 		/* implementation-specific initialization */
 		smgrsw[reln->smgr_which].smgr_open(reln);
@@ -548,10 +539,8 @@ smgrextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 {
 	(*reln->storageManager).smgr_extend(reln, forknum, blocknum,
 										 buffer, skipFsync);
-<<<<<<< HEAD
     if (file_extend_hook)
         (*file_extend_hook)(reln->smgr_rnode);
-=======
 
 	/*
 	 * Normally we expect this to increase nblocks by one, but if the cached
@@ -562,7 +551,6 @@ smgrextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		reln->smgr_cached_nblocks[forknum] = blocknum + 1;
 	else
 		reln->smgr_cached_nblocks[forknum] = InvalidBlockNumber;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 }
 
 /*
@@ -636,9 +624,6 @@ smgrwriteback(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 BlockNumber
 smgrnblocks(SMgrRelation reln, ForkNumber forknum)
 {
-<<<<<<< HEAD
-	return (*reln->storageManager).smgr_nblocks(reln, forknum);
-=======
 	BlockNumber result;
 
 	/*
@@ -648,12 +633,11 @@ smgrnblocks(SMgrRelation reln, ForkNumber forknum)
 	if (InRecovery && reln->smgr_cached_nblocks[forknum] != InvalidBlockNumber)
 		return reln->smgr_cached_nblocks[forknum];
 
-	result = smgrsw[reln->smgr_which].smgr_nblocks(reln, forknum);
+	result = (*reln->storageManager).smgr_nblocks(reln, forknum);
 
 	reln->smgr_cached_nblocks[forknum] = result;
 
 	return result;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 }
 
 /*
@@ -692,14 +676,10 @@ smgrtruncate(SMgrRelation reln, ForkNumber *forknum, int nforks, BlockNumber *nb
 	/* Do the truncation */
 	for (i = 0; i < nforks; i++)
 	{
-<<<<<<< HEAD
-		(*reln->storageManager).smgr_truncate(reln, forknum[i], nblocks[i]);
-=======
 		/* Make the cached size is invalid if we encounter an error. */
 		reln->smgr_cached_nblocks[forknum[i]] = InvalidBlockNumber;
 
-		smgrsw[reln->smgr_which].smgr_truncate(reln, forknum[i], nblocks[i]);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+		(*reln->storageManager).smgr_truncate(reln, forknum[i], nblocks[i]);
 
 		/*
 		 * We might as well update the local smgr_cached_nblocks values. The


### PR DESCRIPTION
1) Commit c5315f4 in src/backend/storage/smgr/smgr.c added the
access/xlog.h include, while earlier GPDB-specific commits had already
added other includes in the same location.

2) Commit c5315f4 in src/backend/storage/smgr/smgr.c in the smgropen
function changed the initialization of the smgr_fsm_nblocks and
smgr_vm_nblocks fields to initialization of the smgr_cached_nblocks
field in a loop, while earlier commits 19cd1cf and b354832 had already
added initialization of the smgr_which and storageManager fields in the
same location.

3) Commit c5315f4 in src/backend/storage/smgr/smgr.c added caching in
the smgrextend function, while earlier commit 19cd1cf had already added
a call to file_extend_hook in the same location.

4) Commit c5315f4 in src/backend/storage/smgr/smgr.c optimized the
logic in the smgrnblocks and smgrtruncate functions, while earlier
commit b354832 had already changed smgrsw[reln->smgr_which] to
(*reln->storageManager) in the same location.