### PR TITLE
Resolve conflicts in src/backend/utils/init/globals.c

### DIFF
--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -134,7 +134,6 @@ int			IntervalStyle = INTSTYLE_POSTGRES;
 
 bool		enableFsync = true;
 bool		allowSystemTableMods = false;
-<<<<<<< HEAD
 int			planner_work_mem = 32768;
 int			work_mem = 32768;
 int			statement_mem = 256000;
@@ -144,10 +143,7 @@ int			max_statement_mem = 2048000;
  * do not enforce per-query memory limit
  */
 int			gp_vmem_limit_per_query = 0;
-=======
-int			work_mem = 4096;
 double		hash_mem_multiplier = 1.0;
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 int			maintenance_work_mem = 65536;
 int			max_parallel_maintenance_workers = 2;
 


### PR DESCRIPTION
Commit 947456a in src/backend/utils/init/globals.c changed the initial
value of the global variable work_mem, and commit d6c08e2 added a new
global variable hash_mem_multiplier. However, an earlier commit,
6b0e52b, had already changed the initial value of the same variable
work_mem and added the global variables planner_work_mem,
statement_mem, max_statement_mem, and gp_vmem_limit_per_query in the
same location.