### PR TITLE
Resolve conflicts in src/backend/utils/init/postinit.c

### DIFF
--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -818,16 +818,14 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	 * to prune them even if the process doesn't attempt to modify any
 	 * tuples.)
 	 *
-<<<<<<< HEAD
 	 * Skip these steps if we are responding to a FTS message on mirror.
 	 * Mirror operates in standby mode and is not ready to start a
 	 * transaction or create a snapshot.  Neither are they required to
 	 * respond to a FTS message.
-=======
+	 *
 	 * FIXME: This comment is inaccurate / the code buggy. A snapshot that is
 	 * not pushed/active does not reliably prevent HOT pruning (->xmin could
 	 * e.g. be cleared when cache invalidations are processed).
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	 */
 	if (!bootstrap && !am_mirror)
 	{


### PR DESCRIPTION
Commit dc7420c added a comment to the InitPostgres function in
src/backend/utils/init/postinit.c, while an earlier commit, 4d9c789,
had already added another comment in the same location.