### PR TITLE
Resolve conflicts in contrib/pgstattuple/pgstatapprox.c

### DIFF
--- a/contrib/pgstattuple/pgstatapprox.c
+++ b/contrib/pgstattuple/pgstatapprox.c
@@ -282,15 +282,11 @@ pgstattuple_approx_internal(Oid relid, FunctionCallInfo fcinfo)
 	 * map.
 	 */
 	if (!(rel->rd_rel->relkind == RELKIND_RELATION ||
-<<<<<<< HEAD
 		  rel->rd_rel->relkind == RELKIND_AOSEGMENTS ||
 		  rel->rd_rel->relkind == RELKIND_AOBLOCKDIR ||
 		  rel->rd_rel->relkind == RELKIND_AOVISIMAP ||
-		  rel->rd_rel->relkind == RELKIND_MATVIEW))
-=======
 		  rel->rd_rel->relkind == RELKIND_MATVIEW ||
 		  rel->rd_rel->relkind == RELKIND_TOASTVALUE))
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("\"%s\" is not a table, materialized view, or TOAST table",


### PR DESCRIPTION
Resolve conflicts in contrib/pgstattuple/pgstatapprox.c

Commit ee0202d5527 added RELKIND_TOASTVALUE to the relkind allowlist of
pgstattuple_approx, while earlier fork commit e595fc33a25 added the AO
auxiliary relkinds RELKIND_AOSEGMENTS, RELKIND_AOBLOCKDIR and
RELKIND_AOVISIMAP in the same place.

Both additions are kept, leaving the allowlist as plain heap, AO
auxiliary heaps, materialized views and TOAST tables.