### PR TITLE
Resolve conflicts in src/bin/pg_dump/pg_backup.h

### DIFF
--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -283,11 +283,7 @@ typedef int DumpId;
  * Function pointer prototypes for assorted callback methods.
  */
 
-<<<<<<< HEAD
 typedef int (*DataDumperPtr) (Archive *AH, const void *userArg);
-=======
-typedef int (*DataDumperPtr) (Archive *AH, void *userArg);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 
 typedef void (*SetupWorkerPtrType) (Archive *AH);
 


### PR DESCRIPTION
Resolve conflicts in src/bin/pg_dump/pg_backup.h

Earlier fork commit bdfea29a6ab backported upstream's pg_dump const
decorations from PG14, leaving DataDumperPtr typedef'd with a
const void *userArg parameter, while the merged-in PG12-era upstream
still carried the older non-const void *userArg signature.

The const variant is kept because the existing dumpTableData_copy and
dumpTableData_insert callers in pg_dump.c are already declared with
const void *dcontext.