### PR TITLE
Resolve conflicts in doc/src/sgml/ref/pg_dump.sgml

### DIFF
--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -333,20 +333,12 @@ PostgreSQL documentation
        </para>
        <para>
         Requesting exclusive locks on database objects while running a parallel dump could
-<<<<<<< HEAD
-        cause the dump to fail. The reason is that the <application>pg_dump</application> coordinator process
-=======
         cause the dump to fail. The reason is that the <application>pg_dump</application> leader process
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         requests shared locks on the objects that the worker processes are going to dump later
         in order to
         make sure that nobody deletes them and makes them go away while the dump is running.
         If another client then requests an exclusive lock on a table, that lock will not be
-<<<<<<< HEAD
-        granted but will be queued waiting for the shared lock of the coordinator process to be
-=======
         granted but will be queued waiting for the shared lock of the leader process to be
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         released. Consequently any other access to the table will not be granted either and
         will queue after the exclusive lock request. This includes the worker process trying
         to dump the table. Without any precautions this would be a classic deadlock situation.
@@ -363,22 +355,14 @@ PostgreSQL documentation
         for standbys. With this feature, database clients can ensure they see
         the same data set even though they use different connections.
         <command>pg_dump -j</command> uses multiple database connections; it
-<<<<<<< HEAD
-        connects to the database once with the coordinator process and once again
-=======
         connects to the database once with the leader process and once again
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         for each worker job. Without the synchronized snapshot feature, the
         different worker jobs wouldn't be guaranteed to see the same data in
         each connection, which could lead to an inconsistent backup.
        </para>
        <para>
         If you want to run a parallel dump of a pre-9.2 server, you need to make sure that the
-<<<<<<< HEAD
-        database content doesn't change from between the time the coordinator connects to the
-=======
         database content doesn't change from between the time the leader connects to the
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         database until the last worker job has connected to the database. The easiest way to
         do this is to halt any data modifying processes (DDL and DML) accessing the database
         before starting the backup. You also need to specify the

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -333,20 +333,12 @@ PostgreSQL documentation
        </para>
        <para>
         Requesting exclusive locks on database objects while running a parallel dump could
-<<<<<<< HEAD
         cause the dump to fail. The reason is that the <application>pg_dump</application> coordinator process
-=======
-        cause the dump to fail. The reason is that the <application>pg_dump</application> leader process
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         requests shared locks on the objects that the worker processes are going to dump later
         in order to
         make sure that nobody deletes them and makes them go away while the dump is running.
         If another client then requests an exclusive lock on a table, that lock will not be
-<<<<<<< HEAD
         granted but will be queued waiting for the shared lock of the coordinator process to be
-=======
-        granted but will be queued waiting for the shared lock of the leader process to be
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         released. Consequently any other access to the table will not be granted either and
         will queue after the exclusive lock request. This includes the worker process trying
         to dump the table. Without any precautions this would be a classic deadlock situation.
@@ -363,22 +355,14 @@ PostgreSQL documentation
         for standbys. With this feature, database clients can ensure they see
         the same data set even though they use different connections.
         <command>pg_dump -j</command> uses multiple database connections; it
-<<<<<<< HEAD
         connects to the database once with the coordinator process and once again
-=======
-        connects to the database once with the leader process and once again
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         for each worker job. Without the synchronized snapshot feature, the
         different worker jobs wouldn't be guaranteed to see the same data in
         each connection, which could lead to an inconsistent backup.
        </para>
        <para>
         If you want to run a parallel dump of a pre-9.2 server, you need to make sure that the
-<<<<<<< HEAD
         database content doesn't change from between the time the coordinator connects to the
-=======
-        database content doesn't change from between the time the leader connects to the
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         database until the last worker job has connected to the database. The easiest way to
         do this is to halt any data modifying processes (DDL and DML) accessing the database
         before starting the backup. You also need to specify the

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -333,12 +333,20 @@ PostgreSQL documentation
        </para>
        <para>
         Requesting exclusive locks on database objects while running a parallel dump could
+<<<<<<< HEAD
         cause the dump to fail. The reason is that the <application>pg_dump</application> coordinator process
+=======
+        cause the dump to fail. The reason is that the <application>pg_dump</application> leader process
+>>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         requests shared locks on the objects that the worker processes are going to dump later
         in order to
         make sure that nobody deletes them and makes them go away while the dump is running.
         If another client then requests an exclusive lock on a table, that lock will not be
+<<<<<<< HEAD
         granted but will be queued waiting for the shared lock of the coordinator process to be
+=======
+        granted but will be queued waiting for the shared lock of the leader process to be
+>>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         released. Consequently any other access to the table will not be granted either and
         will queue after the exclusive lock request. This includes the worker process trying
         to dump the table. Without any precautions this would be a classic deadlock situation.
@@ -355,14 +363,22 @@ PostgreSQL documentation
         for standbys. With this feature, database clients can ensure they see
         the same data set even though they use different connections.
         <command>pg_dump -j</command> uses multiple database connections; it
+<<<<<<< HEAD
         connects to the database once with the coordinator process and once again
+=======
+        connects to the database once with the leader process and once again
+>>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         for each worker job. Without the synchronized snapshot feature, the
         different worker jobs wouldn't be guaranteed to see the same data in
         each connection, which could lead to an inconsistent backup.
        </para>
        <para>
         If you want to run a parallel dump of a pre-9.2 server, you need to make sure that the
+<<<<<<< HEAD
         database content doesn't change from between the time the coordinator connects to the
+=======
+        database content doesn't change from between the time the leader connects to the
+>>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
         database until the last worker job has connected to the database. The easiest way to
         do this is to halt any data modifying processes (DDL and DML) accessing the database
         before starting the backup. You also need to specify the


### PR DESCRIPTION
Resolve conflicts in doc/src/sgml/ref/pg_dump.sgml in favour of upstream

The four parallel-dump passages now read leader process and leader
connects, matching upstream. Documentation conflicts are kept aligned
with upstream so that the page does not diverge while the docs are
moved to a separate project.