### PR TITLE
Resolve conflicts in src/interfaces/libpq/fe-connect.c

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -4155,27 +4155,8 @@ freePGconn(PGconn *conn)
 		free(conn->gsslib);
 	if (conn->connip)
 		free(conn->connip);
-<<<<<<< HEAD
-#ifdef ENABLE_GSS
-	if (conn->gcred != GSS_C_NO_CREDENTIAL)
-	{
-		OM_uint32	minor;
-
-		gss_release_cred(&minor, &conn->gcred);
-		conn->gcred = GSS_C_NO_CREDENTIAL;
-	}
-	if (conn->gctx)
-	{
-		OM_uint32	minor;
-
-		gss_delete_sec_context(&minor, &conn->gctx, GSS_C_NO_BUFFER);
-		conn->gctx = NULL;
-	}
-#endif
 	if (conn->gpqeid)			/* CDB */
 		free(conn->gpqeid);
-=======
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	/* Note that conn->Pfdebug is not ours to close or free */
 	if (conn->last_query)
 		free(conn->last_query);


### PR DESCRIPTION
Resolve conflicts in src/interfaces/libpq/fe-connect.c

Upstream commit 25fe5ac45a7 moved GSSAPI gcred and gctx cleanup out of
freePGconn into pqDropConnection so that connection resets and server
switches release the GSS resources correctly, while earlier repo
commit 8f9fcd7344d added a CDB-only free of conn->gpqeid in the same
place.

The GSS block in freePGconn is dropped because pqDropConnection in
this file already performs the cleanup at the upstream-style location.
The CDB gpqeid free is kept.