### PR TITLE
Resolve conflicts in src/interfaces/ecpg/test/pg_regress_ecpg.c

### DIFF
--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -338,7 +338,7 @@ ExecuteRecoveryCommand(const char *command, const char *commandName, bool failOn
 					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
 					pg_ltoa(GpIdentity.segindex, contentid);
-					StrNCpy(dp, contentid, endp - dp);
+					strlcpy(dp, contentid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -839,7 +839,7 @@ static void MetaTrackAddUpdInternal(Oid			classid,
 	{
 		Form_pg_authid authid_tup = (Form_pg_authid) GETSTRUCT(roletup);
 
-		namecpy(&uname, &authid_tup->rolname);
+		namestrcpy(&uname, NameStr(authid_tup->rolname));
 		ReleaseSysCache(roletup);
 	}
 	else

--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -782,7 +782,7 @@ RetrievePersistentErrorLogFromRangeVar(RangeVar *relrv, AclMode mode, char *fnam
 				pg_namespace_tuple = (Form_pg_namespace) GETSTRUCT(tuple);
 				schemaname = pstrdup(NameStr(pg_namespace_tuple->nspname));
 				ReleaseSysCache(tuple);
-				StrNCpy(fname, filename, MAXPGPATH);
+				strlcpy(fname, filename, MAXPGPATH);
 				findfile = true;
 				break;
 			}

--- a/src/backend/cdb/endpoint/cdbendpoint.c
+++ b/src/backend/cdb/endpoint/cdbendpoint.c
@@ -483,7 +483,7 @@ static Endpoint
 						errmsg("failed to allocate endpoint for session id %d", gp_session_id)));
 
 	generate_endpoint_name(sharedEndpoints[i].name, cursorName);
-	StrNCpy(sharedEndpoints[i].cursorName, cursorName, NAMEDATALEN);
+	strlcpy(sharedEndpoints[i].cursorName, cursorName, NAMEDATALEN);
 	sharedEndpoints[i].databaseID = MyDatabaseId;
 	sharedEndpoints[i].sessionID = gp_session_id;
 	sharedEndpoints[i].userID = GetSessionUserId();

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -255,12 +255,12 @@ gp_get_endpoints(PG_FUNCTION_ARGS)
 
 				for (int j = 0; j < PQntuples(result); j++)
 				{
-					StrNCpy(all_info->infos[idx].name, PQgetvalue(result, j, 0), NAMEDATALEN);
-					StrNCpy(all_info->infos[idx].cursorName, PQgetvalue(result, j, 1), NAMEDATALEN);
+					strlcpy(all_info->infos[idx].name, PQgetvalue(result, j, 0), NAMEDATALEN);
+					strlcpy(all_info->infos[idx].cursorName, PQgetvalue(result, j, 1), NAMEDATALEN);
 					endpoint_token_str2arr(PQgetvalue(result, j, 2), all_info->infos[idx].token);
 					all_info->infos[idx].segmentIndex = atoi(PQgetvalue(result, j, 3));
 					all_info->infos[idx].state = state_string_to_enum(PQgetvalue(result, j, 4));
-					StrNCpy(all_info->infos[idx].userName, PQgetvalue(result, j, 5), NAMEDATALEN);
+					strlcpy(all_info->infos[idx].userName, PQgetvalue(result, j, 5), NAMEDATALEN);
 					all_info->infos[idx].sessionId = atoi(PQgetvalue(result, j, 6));
 					idx++;
 				}
@@ -310,11 +310,11 @@ gp_get_endpoints(PG_FUNCTION_ARGS)
 					info->segmentIndex = MASTER_CONTENT_ID;
 					get_token_from_session_hashtable(entry->sessionID, entry->userID,
 													 info->token);
-					StrNCpy(info->name, entry->name, NAMEDATALEN);
-					StrNCpy(info->cursorName, entry->cursorName, NAMEDATALEN);
+					strlcpy(info->name, entry->name, NAMEDATALEN);
+					strlcpy(info->cursorName, entry->cursorName, NAMEDATALEN);
 					info->state = entry->state;
 					info->sessionId = entry->sessionID;
-					StrNCpy(info->userName, GetUserNameFromId(entry->userID, false), NAMEDATALEN);
+					strlcpy(info->userName, GetUserNameFromId(entry->userID, false), NAMEDATALEN);
 					idx++;
 				}
 			}

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -467,7 +467,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			caps.memAuditor = value;
 			break;
 		case RESGROUP_LIMIT_TYPE_CPUSET:
-			StrNCpy(caps.cpuset, cpuset, sizeof(caps.cpuset));
+			strlcpy(caps.cpuset, cpuset, sizeof(caps.cpuset));
 			caps.cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 			break;
 		default:
@@ -617,7 +617,7 @@ GetResGroupCapabilities(Relation rel, Oid groupId, ResGroupCaps *resgroupCaps)
 												   getResgroupOptionName(type));
 				break;
 			case RESGROUP_LIMIT_TYPE_CPUSET:
-				StrNCpy(resgroupCaps->cpuset, value, sizeof(resgroupCaps->cpuset));
+				strlcpy(resgroupCaps->cpuset, value, sizeof(resgroupCaps->cpuset));
 				break;
 			default:
 				break;
@@ -1011,7 +1011,7 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		if (type == RESGROUP_LIMIT_TYPE_CPUSET) 
 		{
 			const char *cpuset = defGetString(defel);
-			StrNCpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
+			strlcpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
 			checkCpuSetByRole(cpuset);
 			caps->cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 		}
@@ -1234,7 +1234,7 @@ updateResgroupCapabilityEntry(Relation rel,
 
 	if (limitType == RESGROUP_LIMIT_TYPE_CPUSET)
 	{
-		StrNCpy(stringBuffer, strValue, sizeof(stringBuffer));
+		strlcpy(stringBuffer, strValue, sizeof(stringBuffer));
 	}
 	else
 	{

--- a/src/backend/commands/tablecmds_gp.c
+++ b/src/backend/commands/tablecmds_gp.c
@@ -1422,7 +1422,7 @@ ATExecGPPartCmds(Relation origrel, AlterTableCmd *cmd)
 
 			partrelid = GpFindTargetPartition(rel, pid, false);
 			targetrelation = table_open(partrelid, AccessExclusiveLock);
-			StrNCpy(targetrelname, RelationGetRelationName(targetrelation),
+			strlcpy(targetrelname, RelationGetRelationName(targetrelation),
 					NAMEDATALEN);
 			namespaceId = RelationGetNamespace(targetrelation);
 			table_close(targetrelation, AccessExclusiveLock);

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -128,7 +128,7 @@ FTSReplicationStatusCreateIfNotExist(const char *app_name)
 	if (replication_status != NULL)
 	{
 		replication_status->in_use = true;
-		strlcpy(NameStr(replication_status->name), application_name, NAMEDATALEN);
+		namestrcpy(&replication_status->name, application_name);
 		replication_status->con_attempt_count = 0;
 		replication_status->replica_disconnected_at = 0;
 

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -128,7 +128,7 @@ FTSReplicationStatusCreateIfNotExist(const char *app_name)
 	if (replication_status != NULL)
 	{
 		replication_status->in_use = true;
-		StrNCpy(NameStr(replication_status->name), application_name, NAMEDATALEN);
+		strlcpy(NameStr(replication_status->name), application_name, NAMEDATALEN);
 		replication_status->con_attempt_count = 0;
 		replication_status->replica_disconnected_at = 0;
 

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -60,7 +60,7 @@ test_setup(int pid, WalSndState state, int count)
 	MemSet(FTSRepStatusCtl, 0, FTSReplicationStatusShmemSize());
 
 	FTSRepStatusCtl->replications[0].in_use = true;
-	StrNCpy(NameStr(FTSRepStatusCtl->replications[0].name), GP_WALRECEIVER_APPNAME, NAMEDATALEN);
+	strlcpy(NameStr(FTSRepStatusCtl->replications[0].name), GP_WALRECEIVER_APPNAME, NAMEDATALEN);
 	SpinLockInit(&FTSRepStatusCtl->replications[0].mutex);
 
 	expect_lwlock(LW_SHARED, count);

--- a/src/backend/replication/test/gp_replication_test.c
+++ b/src/backend/replication/test/gp_replication_test.c
@@ -60,7 +60,7 @@ test_setup(int pid, WalSndState state, int count)
 	MemSet(FTSRepStatusCtl, 0, FTSReplicationStatusShmemSize());
 
 	FTSRepStatusCtl->replications[0].in_use = true;
-	strlcpy(NameStr(FTSRepStatusCtl->replications[0].name), GP_WALRECEIVER_APPNAME, NAMEDATALEN);
+	namestrcpy(&FTSRepStatusCtl->replications[0].name, GP_WALRECEIVER_APPNAME);
 	SpinLockInit(&FTSRepStatusCtl->replications[0].mutex);
 
 	expect_lwlock(LW_SHARED, count);

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -516,7 +516,7 @@ get_ps_display(int *displen)
 void
 set_ps_display_username(const char *username)
 {
-	StrNCpy(ps_username, username, sizeof(ps_username));
+	strlcpy(ps_username, username, sizeof(ps_username));
 }
 
 const char *

--- a/src/backend/utils/resgroup/cgroup.c
+++ b/src/backend/utils/resgroup/cgroup.c
@@ -403,7 +403,7 @@ readStr(Oid group, BaseDirType base, CGroupComponentType component,
 
 	readData(path, data, data_size);
 
-	StrNCpy(str, data, len);
+	strlcpy(str, data, len);
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -4362,7 +4362,7 @@ bool CpusetIsEmpty(const char *cpuset)
  */
 void SetCpusetEmpty(char *cpuset, int cpusetSize)
 {
-	StrNCpy(cpuset, DefaultCpuset, cpusetSize);
+	strlcpy(cpuset, DefaultCpuset, cpusetSize);
 }
 
 /*

--- a/src/interfaces/ecpg/test/pg_regress_ecpg.c
+++ b/src/interfaces/ecpg/test/pg_regress_ecpg.c
@@ -63,14 +63,8 @@ ecpg_filter(const char *sourcefile, const char *outfile)
 			/* plen is one more than the number of . and / characters */
 			if (plen > 1)
 			{
-<<<<<<< HEAD
 				memmove(p + 1, p + plen, strlen(p + plen) + 1);
 				/* we don't bother to fix up linebuf.len */
-=======
-				n = (char *) malloc(plen);
-				strlcpy(n, p + 1, plen);
-				replace_string(linebuf, n, "");
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 			}
 		}
 		fputs(linebuf.data, t);


### PR DESCRIPTION
Commit 1784f27 in src/interfaces/ecpg/test/pg_regress_ecpg.c in the
ecpg_filter function changed the call to the StrNCpy function to
strlcpy, although an earlier commit by b4c36a1 had already changed it
to memmove at this location. Replace StrNCpy to strlcpy,
StrNCpy(NameStr to namestrcpy in GPDB-specific places.