### PR TITLE
Fix GPDB-specific OIDs

### DIFF
--- a/src/include/catalog/gp_partition_template.h
+++ b/src/include/catalog/gp_partition_template.h
@@ -29,7 +29,7 @@
  *		typedef struct FormData_gp_partition_template
  * ----------------
  */
-CATALOG(gp_partition_template,5022,PartitionTemplateRelationId)
+CATALOG(gp_partition_template,8022,PartitionTemplateRelationId)
 {
 	Oid			relid;		/* partitioned table oid */
 	int16       level;

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -339,8 +339,8 @@ DECLARE_UNIQUE_INDEX(pg_extension_oid_index, 3080, on pg_extension using btree(o
 DECLARE_UNIQUE_INDEX(pg_extension_name_index, 3081, on pg_extension using btree(extname name_ops));
 #define ExtensionNameIndexId 3081
 
-DECLARE_UNIQUE_INDEX(gp_distribution_policy_localoid_index, 6103, on gp_distribution_policy using btree(localoid oid_ops));
-#define GpPolicyLocalOidIndexId  6103
+DECLARE_UNIQUE_INDEX(gp_distribution_policy_localoid_index, 8103, on gp_distribution_policy using btree(localoid oid_ops));
+#define GpPolicyLocalOidIndexId  8103
 
 DECLARE_UNIQUE_INDEX(pg_appendonly_relid_index, 7141, on pg_appendonly using btree(relid oid_ops));
 #define AppendOnlyRelidIndexId  7141
@@ -449,7 +449,7 @@ DECLARE_UNIQUE_INDEX(pg_subscription_subname_index, 6115, on pg_subscription usi
 DECLARE_UNIQUE_INDEX(pg_subscription_rel_srrelid_srsubid_index, 6117, on pg_subscription_rel using btree(srrelid oid_ops, srsubid oid_ops));
 #define SubscriptionRelSrrelidSrsubidIndexId 6117
 
-DECLARE_UNIQUE_INDEX(gp_partition_template_relid_level_index, 5023, on gp_partition_template using btree(relid oid_ops, level int2_ops));
-#define GpPartitionTemplateRelidLevelIndexId  5023
+DECLARE_UNIQUE_INDEX(gp_partition_template_relid_level_index, 8023, on gp_partition_template using btree(relid oid_ops, level int2_ops));
+#define GpPartitionTemplateRelidLevelIndexId  8023
 
 #endif							/* INDEXING_H */

--- a/src/include/catalog/toasting.h
+++ b/src/include/catalog/toasting.h
@@ -102,7 +102,7 @@ DECLARE_TOAST(pg_tablespace, 4185, 4186);
 #define PgTablespaceToastIndex 4186
 
 /* GPDB additional normal catalogs */
-DECLARE_TOAST(gp_partition_template, 5024, 5025);
+DECLARE_TOAST(gp_partition_template, 8024, 8025);
 DECLARE_TOAST(pg_attribute_encoding, 6233, 6234);
 DECLARE_TOAST(pg_type_encoding, 6222, 6223);
 DECLARE_TOAST(pg_extprotocol, 7173, 7174);


### PR DESCRIPTION
Commit 9bae7e4 used OIDs 5022, 5023, 5024, 5025, and 6103 in
src/include/catalog/pg_operator.dat and
src/include/catalog/pg_proc.dat, while earlier GPDB-specific commits
already used these same numbers. Replace the OIDs in GPDB-specific
locations with 8XXX.