### PR TITLE
Fix compilation of dependency.c and pg_depend.c

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -2986,8 +2986,8 @@ checkDependencies(const ObjectAddresses *objects,
 							DEPFLAG_EXTENSION))
 			continue;
 
-		objDesc = getObjectDescription(obj);
-		otherDesc = getObjectDescription(&extra->dependee);
+		objDesc = getObjectDescription(obj, false);
+		otherDesc = getObjectDescription(&extra->dependee, false);
 
 		if (numReportedClient < MAX_REPORTED_DEPS)
 		{

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -181,7 +181,7 @@ recordDependencyOnCurrentExtension(const ObjectAddress *object,
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					 errmsg("%s is not a member of extension \"%s\"",
-							getObjectDescription(object),
+							getObjectDescription(object, false),
 							get_extension_name(CurrentExtensionObject)),
 					 errdetail("An extension is not allowed to replace an object that it does not own.")));
 		}
@@ -232,7 +232,7 @@ checkMembershipInCurrentExtension(const ObjectAddress *object)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("%s is not a member of extension \"%s\"",
-						getObjectDescription(object),
+						getObjectDescription(object, false),
 						get_extension_name(CurrentExtensionObject)),
 				 errdetail("An extension may only use CREATE ... IF NOT EXISTS to skip object creation if the conflicting object is one that it already owns.")));
 	}


### PR DESCRIPTION
Commit 2a10fdc added a new bool missing_ok argument to the
getObjectDescription function in src/include/catalog/objectaddress.h.
Add this in GPDB-specific places.