### PR TITLE
Fix compilation of tablecmds_gp.c, outfuncs.c, readfuncs.c, and gram.y

### DIFF
--- a/src/backend/commands/tablecmds_gp.c
+++ b/src/backend/commands/tablecmds_gp.c
@@ -511,7 +511,7 @@ AtExecGPExchangePartition(Relation rel, AlterTableCmd *cmd)
 		atstmt->relation = makeRangeVar(get_namespace_name(RelationGetNamespace(rel)),
 										pstrdup(RelationGetRelationName(rel)),
 										pc->location);
-		atstmt->relkind = OBJECT_TABLE;
+		atstmt->objtype = OBJECT_TABLE;
 		atstmt->missing_ok = false;
 		atstmt->cmds = list_make1(atcmd);
 		atstmt->is_internal = true; /* set this to avoid transform */
@@ -538,7 +538,7 @@ AtExecGPExchangePartition(Relation rel, AlterTableCmd *cmd)
 		atstmt->relation = makeRangeVar(get_namespace_name(RelationGetNamespace(rel)),
 										pstrdup(RelationGetRelationName(rel)),
 										pc->location);
-		atstmt->relkind = OBJECT_TABLE;
+		atstmt->objtype = OBJECT_TABLE;
 		atstmt->missing_ok = false;
 		atstmt->cmds = list_make1(atcmd);
 		atstmt->is_internal = true; /* set this to avoid transform */
@@ -684,7 +684,7 @@ AtExecGPSplitPartition(Relation rel, AlterTableCmd *cmd)
 		atstmt->relation = makeRangeVar(get_namespace_name(RelationGetNamespace(rel)),
 										pstrdup(RelationGetRelationName(rel)),
 										pc->location);
-		atstmt->relkind = OBJECT_TABLE;
+		atstmt->objtype = OBJECT_TABLE;
 		atstmt->missing_ok = false;
 		atstmt->cmds = list_make1(atcmd);
 		atstmt->is_internal = true; /* set this to avoid transform */
@@ -1327,7 +1327,7 @@ ATExecGPPartCmds(Relation origrel, AlterTableCmd *cmd)
 			newstmt->relation = makeRangeVar(get_namespace_name(rel->rd_rel->relnamespace),
 											 pstrdup(RelationGetRelationName(rel)), -1);
 			newstmt->cmds = list_make1(cmd);
-			newstmt->relkind = OBJECT_TABLE;
+			newstmt->objtype = OBJECT_TABLE;
 			newstmt->missing_ok = false;
 
 			stmts = lappend(stmts, newstmt);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3415,7 +3415,7 @@ _outAlterTableStmt(StringInfo str, const AlterTableStmt *node)
 
 	WRITE_NODE_FIELD(relation);
 	WRITE_NODE_FIELD(cmds);
-	WRITE_ENUM_FIELD(relkind, ObjectType);
+	WRITE_ENUM_FIELD(objtype, ObjectType);
 
 	WRITE_INT_FIELD(lockmode);
 	/*

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -914,7 +914,7 @@ _readAlterTableStmt(void)
 
 	READ_NODE_FIELD(relation);
 	READ_NODE_FIELD(cmds);
-	READ_ENUM_FIELD(relkind, ObjectType);
+	READ_ENUM_FIELD(objtype, ObjectType);
 	READ_INT_FIELD(lockmode);
 	READ_NODE_FIELD(wqueue);
 

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -2657,7 +2657,7 @@ AlterTableStmt:
 					AlterTableStmt *n = makeNode(AlterTableStmt);
 					n->relation = $4;
 					n->cmds = $5;
-					n->relkind = OBJECT_FOREIGN_TABLE;
+					n->objtype = OBJECT_FOREIGN_TABLE;
 					n->missing_ok = false;
 					$$ = (Node *)n;
 				}


### PR DESCRIPTION
Commit cc35d89 in src/include/nodes/parsenodes.h renamed the relkind
field to objtype in the AlterTableStmt and CreateTableAsStmt
structures. Rename in GPDB-specific places.