### PR TITLE
Fix compilation of elog.c, cdbgang.c and fts.c

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -27,6 +27,7 @@
 #include "tcop/tcopprot.h"
 #include "utils/int8.h"
 #include "utils/sharedsnapshot.h"
+#include "utils/timestamp.h"
 #include "tcop/pquery.h"
 
 #include "libpq-fe.h"

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -46,6 +46,7 @@
 #include "utils/fmgroids.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/timestamp.h"
 
 #include "catalog/gp_configuration_history.h"
 #include "catalog/gp_segment_configuration.h"

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3004,11 +3004,7 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 				break;
 
 			case 'P':
-				if( Gp_role == GP_ROLE_EXECUTE )
-				{
-					appendStringInfoChar(buf, 'P');
-				}
-				else if (MyProc)
+				if (MyProc)
 				{
 					PGPROC	   *leader = MyProc->lockGroupLeader;
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3004,7 +3004,11 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 				break;
 
 			case 'P':
-				if (MyProc)
+				if( Gp_role == GP_ROLE_EXECUTE )
+				{
+					appendStringInfoChar(buf, 'P');
+				}
+				else if (MyProc)
 				{
 					PGPROC	   *leader = MyProc->lockGroupLeader;
 
@@ -3215,12 +3219,6 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 				if (j < buf->len &&
 					buf->data[buf->len - 1] == ' ')
 					buf->len--;
-				break;
-			case 'P':
-				if( Gp_role == GP_ROLE_EXECUTE )
-				{
-					appendStringInfoChar(buf, 'P');
-				}
 				break;
 			case 'R':
 				if (!MyProcPort)

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -88,6 +88,7 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
+#include "utils/timestamp.h"
 
 #include "cdb/cdbvars.h"  /* GpIdentity.segindex */
 #include "cdb/cdbtm.h"


### PR DESCRIPTION
Commit b8fdee7 added handling for the 'P' case for parallel workers in
the log_line_prefix function of src/backend/utils/error/elog.c. An
earlier commit, 6b0e52b, already added handling for this same case, but
for different purposes. Remove the unused GPDB handling. Add missing header.