### PR TITLE
Fix compilation in src/bin/pg_rewind/parsexlog.c

### DIFF
--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -9,6 +9,7 @@
  *-------------------------------------------------------------------------
  */
 
+#include "postgres.h"
 #include "postgres_fe.h"
 
 #include <unistd.h>


### PR DESCRIPTION
Commit a28d731 added a new include, access/xact.h, to
src/bin/pg_rewind/parsexlog.c. However, an earlier commit by fdf5a57
had already added a GPDB-specific include, cdb/cdbtm.h, to
src/include/access/xact.h. This includes nodes/plannodes.h, which
includes nodes/primnodes.h, which includes nodes/params.h, which
requires the Datum type, which is defined in src/include/postgres.h, to
be defined.