### PR TITLE
Fix the test_GetNewTransactionId_xid_warn_limit init-test

### DIFF
--- a/src/backend/access/transam/test/varsup_test.c
+++ b/src/backend/access/transam/test/varsup_test.c
@@ -88,8 +88,14 @@ test_GetNewTransactionId_xid_warn_limit(void **state)
 	const int xid = 25;
 	VariableCacheData data;
 	PGPROC proc;
+	PROC_HDR procGlobal;
+	XidCacheStatus subxidStates[1] = {0};
+	TransactionId xids[1] = {0};
 
 	MyProc = &proc;
+	ProcGlobal = &procGlobal;
+	procGlobal.subxidStates = (XidCacheStatus *)&subxidStates;
+	procGlobal.xids = (TransactionId *)&xids;
 	/*
 	 * make sure nextXid is between xidWarnLimit and xidStopLimit to trigger
 	 * the ereport(WARNING).


### PR DESCRIPTION
Commits 941697c and 73487a6 in src/backend/access/transam/varsup.c
added the use of the ProcGlobal->xids and ProcGlobal->subxidStates
fields to the GetNewTransactionId function. Add their initialization to
the test_GetNewTransactionId_xid_warn_limit unit-test.