### PR TITLE
Fix ProcArrayLock locking

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -3305,9 +3305,7 @@ PrepareTransaction(void)
 	 * done *after* the prepared transaction has been marked valid, else
 	 * someone may think it is unlocked and recyclable.
 	 */
-	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
 	ProcArrayClearTransaction(MyProc);
-	LWLockRelease(ProcArrayLock);
 
 	/*
 	 * In normal commit-processing, this is all non-critical post-transaction


### PR DESCRIPTION
Commit 941697c added a shared ProcArrayLock lock to the
ProcArrayClearTransaction function in
src/backend/storage/ipc/procarray.c, and commit 1fe1f42 changed it to
an exclusive lock. However, an earlier commit, d0a8968, had already
added the same exclusive lock to the PrepareTransaction function on top
of the ProcArrayClearTransaction function. Commit 0a51e70 removed it,
but commit 6b0e52b reinstated it.