### PR TITLE
Fix standby startup

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -1035,7 +1035,7 @@ void
 DistributedLog_redo(XLogReaderState *record)
 {
 	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
-	Assert(!IS_QUERY_DISPATCHER());
+	Assert(!IS_QUERY_DISPATCHER() || info == DISTRIBUTEDLOG_FORGET);
 
 	if (info == DISTRIBUTEDLOG_ZEROPAGE)
 	{


### PR DESCRIPTION
After moving distributed_forget to the distributed log, the records of this
resource manager began to appear not only on the segments but also on the
coordinator.

This patch updates assert.