### PR TITLE
Fix updating shared local snapshot when reusing snapshot

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2626,7 +2626,7 @@ GetSnapshotDataInitOldSnapshot(Snapshot snapshot)
  * least in the case we already hold a snapshot), but that's for another day.
  */
 static bool
-GetSnapshotDataReuse(Snapshot snapshot)
+GetSnapshotDataReuse(Snapshot snapshot, DtxContext distributedTransactionContext)
 {
 	uint64 curXactCompletionCount;
 
@@ -2669,6 +2669,19 @@ GetSnapshotDataReuse(Snapshot snapshot)
 	snapshot->active_count = 0;
 	snapshot->regd_count = 0;
 	snapshot->copied = false;
+
+	/*
+	 * MPP Addition. If we are the chief then we'll save our local snapshot
+	 * into the shared snapshot. Note: we need to use the shared local
+	 * snapshot for the "Local Implicit using Distributed Snapshot" case, too.
+	 */
+	if (distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
+		distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
+		distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT)
+	{
+		Assert(SharedLocalSnapshotSlot != NULL);
+		updateSharedLocalSnapshot(&QEDtxContextInfo, distributedTransactionContext, snapshot, "GetSnapshotDataReuse");
+	}
 
 	GetSnapshotDataInitOldSnapshot(snapshot);
 
@@ -2815,7 +2828,7 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
-	if (GetSnapshotDataReuse(snapshot))
+	if (GetSnapshotDataReuse(snapshot, distributedTransactionContext))
 	{
 		LWLockRelease(ProcArrayLock);
 		return snapshot;


### PR DESCRIPTION
Commit 623a9ba79bbdd11c5eccb30b8bd5c446130e521c introduced a shortcut to reuse
an existing snapshot if there are no newly committed transactions. In ggdb we
also need to update the shared local snapshot; otherwise, the reader process
will hang in waiting.