### PR TITLE
Resolve conflicts in src/bin/pg_verifybackup/t/007_wal.pl

### DIFF
--- a/src/bin/pg_verifybackup/t/007_wal.pl
+++ b/src/bin/pg_verifybackup/t/007_wal.pl
@@ -10,20 +10,12 @@ use TestLib;
 use Test::More tests => 7;
 
 # Start up the server and take a backup.
-<<<<<<< HEAD
-my $master = get_new_node('master');
-$master->init(allows_streaming => 1);
-$master->start;
-my $backup_path = $master->backup_dir . '/test_wal';
-$master->command_ok([ 'pg_basebackup', '-D', $backup_path, '--no-sync',
-					'--target-gp-dbid', '1' ],
-=======
 my $primary = get_new_node('primary');
 $primary->init(allows_streaming => 1);
 $primary->start;
 my $backup_path = $primary->backup_dir . '/test_wal';
-$primary->command_ok([ 'pg_basebackup', '-D', $backup_path, '--no-sync' ],
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+$primary->command_ok([ 'pg_basebackup', '-D', $backup_path, '--no-sync',
+					'--target-gp-dbid', '1' ],
 	"base backup ok");
 
 # Rename pg_wal.


### PR DESCRIPTION
Resolve conflicts in src/bin/pg_verifybackup/t/007_wal.pl
    
Commit 229f8c2 in src/bin/pg_verifybackup/t/007_wal.pl changed the word
master to primary, while the earlier commit a98f6e1 had already added
GPDB-specific code to the same location.