### PR TITLE
Fix assertion in procarray.c for types with xids

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4800,7 +4800,6 @@ GlobalVisTestFor(Relation rel)
 		Assert(rel->rd_rel->relkind == RELKIND_RELATION ||
 			   rel->rd_rel->relkind == RELKIND_MATVIEW ||
 			   rel->rd_rel->relkind == RELKIND_TOASTVALUE ||
-			   rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE ||
 			   rel->rd_rel->relkind == RELKIND_AOSEGMENTS ||
 			   rel->rd_rel->relkind == RELKIND_AOBLOCKDIR ||
 			   rel->rd_rel->relkind == RELKIND_AOVISIMAP);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4799,7 +4799,11 @@ GlobalVisTestFor(Relation rel)
 		 */
 		Assert(rel->rd_rel->relkind == RELKIND_RELATION ||
 			   rel->rd_rel->relkind == RELKIND_MATVIEW ||
-			   rel->rd_rel->relkind == RELKIND_TOASTVALUE);
+			   rel->rd_rel->relkind == RELKIND_TOASTVALUE ||
+			   rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE ||
+			   rel->rd_rel->relkind == RELKIND_AOSEGMENTS ||
+			   rel->rd_rel->relkind == RELKIND_AOBLOCKDIR ||
+			   rel->rd_rel->relkind == RELKIND_AOVISIMAP);
 
 		need_shared = rel->rd_rel->relisshared || RecoveryInProgress();
 		need_catalog = IsCatalogRelation(rel) || RelationIsAccessibleInLogicalDecoding(rel);


### PR DESCRIPTION
Commit dc7420c added a new function, GlobalVisTestFor, to
src/backend/storage/ipc/procarray.c with an assertion for relation,
matview, and toastvalue. However, there are other types in the GPDB
that also contain xids.