### PR TITLE
Fix distributed snapshot

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2813,19 +2813,19 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
-	/* GP: QD takes a distributed snapshot */
-	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
-		!snapshot->haveDistribSnapshot && !Debug_disable_distributed_snapshot)
-	{
-		CreateDistributedSnapshot(ds);
-		snapshot->haveDistribSnapshot = true;
-
-		ereport(Debug_print_full_dtm ? LOG : DEBUG5,
-				(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
-	}
-
 	if (GetSnapshotDataReuse(snapshot))
 	{
+		/* GP: QD takes a distributed snapshot */
+		if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
+			!snapshot->haveDistribSnapshot && !Debug_disable_distributed_snapshot)
+		{
+			CreateDistributedSnapshot(ds);
+			snapshot->haveDistribSnapshot = true;
+
+			ereport(Debug_print_full_dtm ? LOG : DEBUG5,
+					(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
+		}
+
 		LWLockRelease(ProcArrayLock);
 
 		goto ret;
@@ -3050,6 +3050,16 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 		/* Not that these values are not set atomically. However,
 		 * each of these assignments is itself assumed to be atomic. */
 		MyProc->xmin = TransactionXmin = xmin;
+	}
+
+	/* GP: QD takes a distributed snapshot */
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot)
+	{
+		CreateDistributedSnapshot(ds);
+		snapshot->haveDistribSnapshot = true;
+
+		ereport(Debug_print_full_dtm ? LOG : DEBUG5,
+				(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
 	}
 
 	LWLockRelease(ProcArrayLock);

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2626,11 +2626,15 @@ GetSnapshotDataInitOldSnapshot(Snapshot snapshot)
  * least in the case we already hold a snapshot), but that's for another day.
  */
 static bool
-GetSnapshotDataReuse(Snapshot snapshot)
+GetSnapshotDataReuse(Snapshot snapshot, DtxContext distributedTransactionContext)
 {
 	uint64 curXactCompletionCount;
 
 	Assert(LWLockHeldByMe(ProcArrayLock));
+
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
+		!snapshot->haveDistribSnapshot)
+		return false;
 
 	if (unlikely(snapshot->snapXactCompletionCount == 0))
 		return false;
@@ -2813,21 +2817,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
-	if (GetSnapshotDataReuse(snapshot))
+	if (GetSnapshotDataReuse(snapshot, distributedTransactionContext))
 	{
-		/* GP: QD takes a distributed snapshot */
-		if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
-			!snapshot->haveDistribSnapshot && !Debug_disable_distributed_snapshot)
-		{
-			CreateDistributedSnapshot(ds);
-			snapshot->haveDistribSnapshot = true;
-
-			ereport(Debug_print_full_dtm ? LOG : DEBUG5,
-					(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
-		}
-
 		LWLockRelease(ProcArrayLock);
-
 		goto ret;
 	}
 
@@ -3174,7 +3166,6 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	snapshot->regd_count = 0;
 	snapshot->copied = false;
 
-ret:
 	/*
 	 * Sort the entry {distribXid} to support the QEs doing culls on their
 	 * DisribToLocalXact sorted lists.
@@ -3185,6 +3176,7 @@ ret:
 		qsort(ds->inProgressXidArray, ds->count,
 			  sizeof(DistributedTransactionId), DistributedSnapshotMappedEntry_Compare);
 
+ret:
 	/*
 	 * MPP Addition. If we are the chief then we'll save our local snapshot
 	 * into the shared snapshot. Note: we need to use the shared local

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2670,8 +2670,6 @@ GetSnapshotDataReuse(Snapshot snapshot)
 	snapshot->regd_count = 0;
 	snapshot->copied = false;
 
-	GetSnapshotDataInitOldSnapshot(snapshot);
-
 	return true;
 }
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2626,15 +2626,11 @@ GetSnapshotDataInitOldSnapshot(Snapshot snapshot)
  * least in the case we already hold a snapshot), but that's for another day.
  */
 static bool
-GetSnapshotDataReuse(Snapshot snapshot, DtxContext distributedTransactionContext)
+GetSnapshotDataReuse(Snapshot snapshot)
 {
 	uint64 curXactCompletionCount;
 
 	Assert(LWLockHeldByMe(ProcArrayLock));
-
-	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
-		!snapshot->haveDistribSnapshot)
-		return false;
 
 	if (unlikely(snapshot->snapXactCompletionCount == 0))
 		return false;
@@ -2817,7 +2813,8 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
-	if (GetSnapshotDataReuse(snapshot, distributedTransactionContext))
+	if ((distributedTransactionContext != DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE ||
+		snapshot->haveDistribSnapshot) && GetSnapshotDataReuse(snapshot))
 	{
 		LWLockRelease(ProcArrayLock);
 		goto ret;

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2149,8 +2149,6 @@ SnapshotResetDslm(Snapshot snapshot)
 					(errcode(ERRCODE_OUT_OF_MEMORY),
 					 errmsg("out of memory")));
 	}
-
-	DistributedSnapshot_Reset(&dslm->ds);
 }
 
 static void
@@ -2467,6 +2465,7 @@ CreateDistributedSnapshot(DistributedSnapshot *ds)
 	ProcArrayStruct *arrayP = procArray;
 
 	Assert(LWLockHeldByMe(ProcArrayLock));
+	DistributedSnapshot_Reset(ds);
 	if (*shmNumCommittedGxacts != 0)
 		elog(ERROR, "Create distributed snapshot before DTM recovery finish");
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2814,7 +2814,8 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
 	/* GP: QD takes a distributed snapshot */
-	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot)
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE &&
+		!snapshot->haveDistribSnapshot && !Debug_disable_distributed_snapshot)
 	{
 		CreateDistributedSnapshot(ds);
 		snapshot->haveDistribSnapshot = true;

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2670,19 +2670,6 @@ GetSnapshotDataReuse(Snapshot snapshot, DtxContext distributedTransactionContext
 	snapshot->regd_count = 0;
 	snapshot->copied = false;
 
-	/*
-	 * MPP Addition. If we are the chief then we'll save our local snapshot
-	 * into the shared snapshot. Note: we need to use the shared local
-	 * snapshot for the "Local Implicit using Distributed Snapshot" case, too.
-	 */
-	if (distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
-		distributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER ||
-		distributedTransactionContext == DTX_CONTEXT_QE_AUTO_COMMIT_IMPLICIT)
-	{
-		Assert(SharedLocalSnapshotSlot != NULL);
-		updateSharedLocalSnapshot(&QEDtxContextInfo, distributedTransactionContext, snapshot, "GetSnapshotDataReuse");
-	}
-
 	GetSnapshotDataInitOldSnapshot(snapshot);
 
 	return true;
@@ -2828,10 +2815,21 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
+	/* GP: QD takes a distributed snapshot */
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot)
+	{
+		CreateDistributedSnapshot(ds);
+		snapshot->haveDistribSnapshot = true;
+
+		ereport(Debug_print_full_dtm ? LOG : DEBUG5,
+				(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
+	}
+
 	if (GetSnapshotDataReuse(snapshot, distributedTransactionContext))
 	{
 		LWLockRelease(ProcArrayLock);
-		return snapshot;
+
+		goto ret;
 	}
 
 	latest_completed = ShmemVariableCache->latestCompletedXid;
@@ -3055,16 +3053,6 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 		MyProc->xmin = TransactionXmin = xmin;
 	}
 
-	/* GP: QD takes a distributed snapshot */
-	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot)
-	{
-		CreateDistributedSnapshot(ds);
-		snapshot->haveDistribSnapshot = true;
-
-		ereport(Debug_print_full_dtm ? LOG : DEBUG5,
-				(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
-	}
-
 	LWLockRelease(ProcArrayLock);
 
 	/* maintain state for GlobalVis* */
@@ -3177,6 +3165,7 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	snapshot->regd_count = 0;
 	snapshot->copied = false;
 
+ret:
 	/*
 	 * Sort the entry {distribXid} to support the QEs doing culls on their
 	 * DisribToLocalXact sorted lists.

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2626,7 +2626,7 @@ GetSnapshotDataInitOldSnapshot(Snapshot snapshot)
  * least in the case we already hold a snapshot), but that's for another day.
  */
 static bool
-GetSnapshotDataReuse(Snapshot snapshot, DtxContext distributedTransactionContext)
+GetSnapshotDataReuse(Snapshot snapshot)
 {
 	uint64 curXactCompletionCount;
 
@@ -2825,7 +2825,7 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 				(errmsg("Got distributed snapshot from CreateDistributedSnapshot")));
 	}
 
-	if (GetSnapshotDataReuse(snapshot, distributedTransactionContext))
+	if (GetSnapshotDataReuse(snapshot))
 	{
 		LWLockRelease(ProcArrayLock);
 


### PR DESCRIPTION
Commit 0b5c2c0 incorrectly and incompletely fixed the distributed
snapshot when reusing: first, it didn't create a distributed snapshot,
second, it didn't sort the array in the snapshot, and third, it updated
the local snapshot when a lock was acquired. Don't call the
GetSnapshotDataReuse function if a distributed snapshot is needed but
doesn't exist. Move the DistributedSnapshot_Reset function call from
the SnapshotResetDslm function to the CreateDistributedSnapshot
function.