### PR TITLE
Fix test src/test/regress/expected/object_address.out

### DIFF
--- a/src/test/regress/expected/object_address.out
+++ b/src/test/regress/expected/object_address.out
@@ -617,7 +617,7 @@ ORDER BY objects.classid, objects.objid, objects.objsubid;
 ("(""text search configuration"",,,)")|("(""text search configuration"",,)")|NULL
 ("(""text search template"",,,)")|("(""text search template"",,)")|NULL
 ("(subscription,,,)")|("(subscription,,)")|NULL
-("(publication,,,)")|("(publication,,)")|NULL
 ("(""publication relation"",,,)")|("(""publication relation"",,)")|NULL
+("(publication,,,)")|("(publication,,)")|NULL
 -- restore normal output mode
 \a\t


### PR DESCRIPTION
Commit 2a10fdc4307a667883f7a3369cb93a721ade9680 added new test, however
GPDB-specific commit 1e9ed1ab883412588519ffb01bb7f2819edc7f91 changed OID of
pg_publication, which changes the ordering in the test output.
