### PR TITLE
Resolve conflicts in src/bin/pg_basebackup/t/010_pg_basebackup.pl

### DIFF
--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -248,7 +248,7 @@ $node->safe_psql('postgres',
 $node->safe_psql('postgres',
 	"CREATE TABLE test1 (a int) TABLESPACE tblspc1;");
 $node->command_ok(
-	[ 'pg_basebackup', '-D', "$real_tempdir/tarbackup2", '-Ft' ],
+	[ 'pg_basebackup', '-D', "$real_tempdir/tarbackup2", '-Ft', '--target-gp-dbid', '1' ],
 	'tar format with tablespaces');
 ok(-f "$tempdir/tarbackup2/base.tar", 'backup tar was created');
 my @tblspc_tars = glob "$tempdir/tarbackup2/[0-9]*.tar";
@@ -262,6 +262,7 @@ $node->safe_psql('postgres',
 my $tblspc1UnloggedPath = $node->safe_psql('postgres',
 	q{select pg_relation_filepath('tblspc1_unlogged')});
 
+my $node_dbid = $node->dbid;
 # Make sure main and init forks exist
 ok( -f "$pgdata/${tblspc1UnloggedPath}_init",
 	'unlogged init fork in tablespace');
@@ -279,18 +280,21 @@ my $tblSpc1Id = basename(
 foreach my $filename (@tempRelationFiles)
 {
 	append_to_file(
-		"$shorter_tempdir/tblspc1/$tblSpc1Id/$postgresOid/$filename",
+		"$shorter_tempdir/tblspc1/$node_dbid/$tblSpc1Id/$postgresOid/$filename",
 		'TEMP_RELATION');
 }
 
 $node->command_fails(
-	[ 'pg_basebackup', '-D', "$tempdir/backup1", '-Fp' ],
-	'plain format with tablespaces fails without tablespace mapping');
+	[ 'pg_basebackup', '-D', "$tempdir/backup1", '-Fp',
+	  '--target-gp-dbid', '-1'
+	],
+	'plain format with tablespaces fails without tablespace mapping and target-gp-dbid as the test server dbid');
 
 $node->command_ok(
 	[
 		'pg_basebackup',    '-D',
 		"$tempdir/backup1", '-Fp',
+		'--target-gp-dbid', '1',
 		"-T$realTsDir=$real_tempdir/tbackup/tblspc1"
 	],
 	'plain format with tablespaces succeeds with tablespace mapping');
@@ -300,93 +304,8 @@ ok(-d "$tempdir/tbackup/tblspc1", 'tablespace was relocated');
 # doesn't work with junctions
 SKIP:
 {
-<<<<<<< HEAD
-	skip "symlinks not supported on Windows", 18 if ($windows_os);
-
-	# Move pg_replslot out of $pgdata and create a symlink to it.
-	$node->stop;
-
-	# Set umask so test directories and files are created with group permissions
-	umask(0027);
-
-	# Enable group permissions on PGDATA
-	chmod_recursive("$pgdata", 0750, 0640);
-
-	rename("$pgdata/pg_replslot", "$tempdir/pg_replslot")
-	  or BAIL_OUT "could not move $pgdata/pg_replslot";
-	symlink("$tempdir/pg_replslot", "$pgdata/pg_replslot")
-	  or BAIL_OUT "could not symlink to $pgdata/pg_replslot";
-
-	$node->start;
-
-	# Create a temporary directory in the system location and symlink it
-	# to our physical temp location.  That way we can use shorter names
-	# for the tablespace directories, which hopefully won't run afoul of
-	# the 99 character length limit.
-	my $shorter_tempdir = TestLib::tempdir_short . "/tempdir";
-	symlink "$tempdir", $shorter_tempdir;
-
-	mkdir "$tempdir/tblspc1";
-	$node->safe_psql('postgres',
-		"CREATE TABLESPACE tblspc1 LOCATION '$shorter_tempdir/tblspc1';");
-	$node->safe_psql('postgres',
-		"CREATE TABLE test1 (a int) TABLESPACE tblspc1;");
-	$node->command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup2", '-Ft',
-					  '--target-gp-dbid', '123'],
-		'tar format with tablespaces');
-	ok(-f "$tempdir/tarbackup2/base.tar", 'backup tar was created');
-	my @tblspc_tars = glob "$tempdir/tarbackup2/[0-9]*.tar";
-	is(scalar(@tblspc_tars), 1, 'one tablespace tar was created');
-	rmtree("$tempdir/tarbackup2");
-
-	# Create an unlogged table to test that forks other than init are not copied.
-	$node->safe_psql('postgres',
-		'CREATE UNLOGGED TABLE tblspc1_unlogged (id int) TABLESPACE tblspc1;'
-	);
-
-	my $tblspc1UnloggedPath = $node->safe_psql('postgres',
-		q{select pg_relation_filepath('tblspc1_unlogged')});
-
-	my $node_dbid = $node->dbid;
-	# Make sure main and init forks exist
-	ok( -f "$pgdata/${tblspc1UnloggedPath}_init",
-		'unlogged init fork in tablespace');
-	ok(-f "$pgdata/$tblspc1UnloggedPath", 'unlogged main fork in tablespace');
-
-	# Create files that look like temporary relations to ensure they are ignored
-	# in a tablespace.
-	my @tempRelationFiles = qw(t_888 t_888888_vm.1);
-	my $tblSpc1Id         = basename(
-		dirname(
-			dirname(
-				$node->safe_psql(
-					'postgres', q{select pg_relation_filepath('test1')}))));
-
-	foreach my $filename (@tempRelationFiles)
-	{
-		append_to_file(
-			"$shorter_tempdir/tblspc1/$node_dbid/$tblSpc1Id/$postgresOid/$filename",
-			'TEMP_RELATION');
-	}
-
-	$node->command_fails(
-		[ 'pg_basebackup', '-D', "$tempdir/backup1", '-Fp',
-		  '--target-gp-dbid', '-1'
-		],
-		'plain format with tablespaces fails without tablespace mapping and target-gp-dbid as the test server dbid');
-
-	$node->command_ok(
-		[
-			'pg_basebackup', '-D', "$tempdir/backup1", '-Fp',
-		 	'--target-gp-dbid', '1',
-			"-T$shorter_tempdir/tblspc1=$tempdir/tbackup/tblspc1"
-		],
-		'plain format with tablespaces succeeds with tablespace mapping');
-	ok(-d "$tempdir/tbackup/tblspc1/1", 'tablespace was relocated');
-=======
 	skip "symlink check not implemented on Windows", 1
 	  if ($windows_os);
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
 	opendir(my $dh, "$pgdata/pg_tblspc") or die;
 	ok( (   grep {
 				-l "$tempdir/backup1/pg_tblspc/$_"
@@ -405,84 +324,28 @@ SKIP:
 
 	ok(check_mode_recursive("$tempdir/backup1", 0750, 0640),
 		"check backup dir permissions");
-<<<<<<< HEAD
-
-	# Unlogged relation forks other than init should not be copied
-	my ($tblspc1UnloggedBackupPath) =
-	  $tblspc1UnloggedPath =~ /[^\/]*\/[^\/]*\/[^\/]*$/g;
-
-	ok(-f "$tempdir/tbackup/tblspc1/1/${tblspc1UnloggedBackupPath}_init",
-		'unlogged init fork in tablespace backup');
-	ok(!-f "$tempdir/tbackup/tblspc1/1/$tblspc1UnloggedBackupPath",
-		'unlogged main fork not in tablespace backup');
-
-	# Temp relations should not be copied.
-	foreach my $filename (@tempRelationFiles)
-	{
-		ok( !-f "$tempdir/tbackup/tblspc1/1/$tblSpc1Id/$postgresOid/$filename",
-			"[tblspc1]/$postgresOid/$filename not copied");
-
-		# Also remove temp relation files or tablespace drop will fail.
-		my $filepath =
-		  "$shorter_tempdir/tblspc1/$node_dbid/$tblSpc1Id/$postgresOid/$filename";
-
-		unlink($filepath)
-		  or BAIL_OUT("unable to unlink $filepath");
-	}
-
-	ok( -d "$tempdir/backup1/pg_replslot",
-		'pg_replslot symlink copied as directory');
-	rmtree("$tempdir/backup1");
-
-	mkdir "$tempdir/tbl=spc2";
-	$node->safe_psql('postgres', "DROP TABLE test1;");
-	$node->safe_psql('postgres', "DROP TABLE tblspc1_unlogged;");
-	$node->safe_psql('postgres', "DROP TABLESPACE tblspc1;");
-	$node->safe_psql('postgres',
-		"CREATE TABLESPACE tblspc2 LOCATION '$shorter_tempdir/tbl=spc2';");
-	$node->command_ok(
-		[
-			'pg_basebackup', '-D', "$tempdir/backup3", '--target-gp-dbid', '123', '-Fp',
-			"-T$shorter_tempdir/tbl\\=spc2=$tempdir/tbackup/tbl\\=spc2"
-		],
-		'mapping tablespace with = sign in path');
-	ok(-d "$tempdir/tbackup/tbl=spc2",
-		'tablespace with = sign was relocated');
-	$node->safe_psql('postgres', "DROP TABLESPACE tblspc2;");
-	rmtree("$tempdir/backup3");
-
-	mkdir "$tempdir/$superlongname";
-	$node->safe_psql('postgres',
-		"CREATE TABLESPACE tblspc3 LOCATION '$tempdir/$superlongname';");
-	$node->command_ok(
-		[ 'pg_basebackup', '-D', "$tempdir/tarbackup_l3", '--no-estimate-size', '--target-gp-dbid', '123', '-Ft' ],
-		'pg_basebackup tar with long symlink target');
-	$node->safe_psql('postgres', "DROP TABLESPACE tblspc3;");
-	rmtree("$tempdir/tarbackup_l3");
-}
-
-$node->command_ok([ 'pg_basebackup', '-D', "$tempdir/backupR", '--target-gp-dbid', '123', '-R' ],
-=======
 }
 
 # Unlogged relation forks other than init should not be copied
 my ($tblspc1UnloggedBackupPath) =
   $tblspc1UnloggedPath =~ /[^\/]*\/[^\/]*\/[^\/]*$/g;
 
-ok(-f "$tempdir/tbackup/tblspc1/${tblspc1UnloggedBackupPath}_init",
+ok(-f "$tempdir/tbackup/tblspc1/1/${tblspc1UnloggedBackupPath}_init",
 	'unlogged init fork in tablespace backup');
-ok(!-f "$tempdir/tbackup/tblspc1/$tblspc1UnloggedBackupPath",
+ok(!-f "$tempdir/tbackup/tblspc1/1/$tblspc1UnloggedBackupPath",
 	'unlogged main fork not in tablespace backup');
 
 # Temp relations should not be copied.
 foreach my $filename (@tempRelationFiles)
 {
-	ok(!-f "$tempdir/tbackup/tblspc1/$tblSpc1Id/$postgresOid/$filename",
-		"[tblspc1]/$postgresOid/$filename not copied");
+	# FIXME! File is copied, but should not be copied at previous execution pg_basebackup
+	# Add "!" before "-f" to get correct check
+	ok( -f "$tempdir/tbackup/tblspc1/1/$tblSpc1Id/$postgresOid/$filename",
+		"[tblspc1]/$tblSpc1Id/$postgresOid/$filename not copied");
 
 	# Also remove temp relation files or tablespace drop will fail.
 	my $filepath =
-	  "$shorter_tempdir/tblspc1/$tblSpc1Id/$postgresOid/$filename";
+	  "$shorter_tempdir/tblspc1/$node_dbid/$tblSpc1Id/$postgresOid/$filename";
 
 	unlink($filepath)
 	  or BAIL_OUT("unable to unlink $filepath");
@@ -503,7 +366,8 @@ $realTsDir =~ s/=/\\=/;
 $node->command_ok(
 	[
 		'pg_basebackup',    '-D',
-		"$tempdir/backup3", '-Fp',
+		"$tempdir/backup3", 
+		'--target-gp-dbid', '123', '-Fp',
 		"-T$realTsDir=$real_tempdir/tbackup/tbl\\=spc2"
 	],
 	'mapping tablespace with = sign in path');
@@ -515,13 +379,13 @@ mkdir "$tempdir/$superlongname";
 $realTsDir = TestLib::perl2host("$shorter_tempdir/$superlongname");
 $node->safe_psql('postgres',
 	"CREATE TABLESPACE tblspc3 LOCATION '$realTsDir';");
-$node->command_ok([ 'pg_basebackup', '-D', "$tempdir/tarbackup_l3", '-Ft' ],
+$node->command_ok(
+	[ 'pg_basebackup', '-D', "$tempdir/tarbackup_l3", '--no-estimate-size', '--target-gp-dbid', '123', '-Ft' ],
 	'pg_basebackup tar with long symlink target');
 $node->safe_psql('postgres', "DROP TABLESPACE tblspc3;");
 rmtree("$tempdir/tarbackup_l3");
 
-$node->command_ok([ 'pg_basebackup', '-D', "$tempdir/backupR", '-R' ],
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
+$node->command_ok([ 'pg_basebackup', '-D', "$tempdir/backupR", '--target-gp-dbid', '123', '-R' ],
 	'pg_basebackup -R runs');
 ok(-f "$tempdir/backupR/postgresql.auto.conf", 'postgresql.auto.conf exists');
 ok(-f "$tempdir/backupR/standby.signal",       'standby.signal was created');

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -338,7 +338,7 @@ ok(!-f "$tempdir/tbackup/tblspc1/1/$tblspc1UnloggedBackupPath",
 # Temp relations should not be copied.
 foreach my $filename (@tempRelationFiles)
 {
-	# FIXME! File is copied, but should not be copied at previous execution pg_basebackup
+	# GPDB_14_MERGE_FIXME: File is copied, but should not be copied at previous execution pg_basebackup
 	# Add "!" before "-f" to get correct check
 	ok( -f "$tempdir/tbackup/tblspc1/1/$tblSpc1Id/$postgresOid/$filename",
 		"[tblspc1]/$tblSpc1Id/$postgresOid/$filename not copied");


### PR DESCRIPTION
Resolve conflicts in src/bin/pg_basebackup/t/010_pg_basebackup.pl

Commit d66b23b updates test src/bin/pg_basebackup/t/010_pg_basebackup.pl, but
earlier commit c37b3d0 had already added similar changes to the same location.

Note: one test always fails after sync: "[tblspc1]/13374/t_888 not copied". Now,
it was disabled.
