### PR TITLE
Resolve conflicts in doc/src/sgml/ref/pg_rewind.sgml

### DIFF
--- a/doc/src/sgml/ref/pg_rewind.sgml
+++ b/doc/src/sgml/ref/pg_rewind.sgml
@@ -43,13 +43,8 @@ PostgreSQL documentation
   <para>
    <application>pg_rewind</application> is a tool for synchronizing a PostgreSQL cluster
    with another copy of the same cluster, after the clusters' timelines have
-<<<<<<< HEAD
-   diverged. A typical scenario is to bring an old coordinator server back online
-   after failover as a standby that follows the new coordinator.
-=======
    diverged. A typical scenario is to bring an old primary server back online
    after failover as a standby that follows the new primary.
->>>>>>> d259afa7365165760004c2fdbe2520a94ddf2600
   </para>
 
   <para>


### PR DESCRIPTION
Commit 9e101cf in doc/src/sgml/ref/pg_rewind.sgml changed the keyword
"master" to "primary." The documentation will be in a separate
repository in the GPDB.