### PR TITLE
Fix tests in src/test/regress/expected/subscription.out

### DIFF
--- a/src/test/regress/expected/subscription.out
+++ b/src/test/regress/expected/subscription.out
@@ -146,10 +146,10 @@ ERROR:  DROP SUBSCRIPTION cannot run inside a transaction block
 COMMIT;
 ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
 \dRs+
-                                                      List of subscriptions
-      Name       |           Owner            | Enabled |     Publication     | Synchronous commit |           Conninfo           
------------------+----------------------------+---------+---------------------+--------------------+------------------------------
- regress_testsub | regress_subscription_user2 | f       | {testpub2,testpub3} | local              | dbname=regress_doesnotexist2
+                                                           List of subscriptions
+      Name       |           Owner            | Enabled |     Publication     | Binary | Synchronous commit |           Conninfo           
+-----------------+----------------------------+---------+---------------------+--------+--------------------+------------------------------
+ regress_testsub | regress_subscription_user2 | f       | {testpub2,testpub3} | f      | local              | dbname=regress_doesnotexist2
 (1 row)
 
 -- now it works


### PR DESCRIPTION
Commit 9de77b5 added the Binary column output to
src/test/regress/expected/subscription.out, while the earlier commit
7b0e0fe already added the output without this column.