### PR TITLE
Fix tests in src/test/regress/expected/jsonb_jsonpath.out

### DIFF
--- a/src/test/regress/expected/jsonb_jsonpath.out
+++ b/src/test/regress/expected/jsonb_jsonpath.out
@@ -1498,7 +1498,7 @@ select jsonb_path_query('"1.23"', '$.double()');
 select jsonb_path_query('"1.23aaa"', '$.double()');
 ERROR:  string argument of jsonpath item method .double() is not a valid representation of a double precision number
 select jsonb_path_query('1e1000', '$.double()');
-ERROR:  numeric argument of jsonpath item method .double() is out of range for type double precision
+ERROR:  value out of range: overflow
 select jsonb_path_query('"nan"', '$.double()');
 ERROR:  string argument of jsonpath item method .double() is not a valid representation of a double precision number
 select jsonb_path_query('"NaN"', '$.double()');


### PR DESCRIPTION
Commit 0657181 in src/test/regress/expected/jsonb_jsonpath.out added a
new test with error output, while the earlier commit 6b0e52b had
already added another error output using the CHECKFLOATVAL macro in the
float8in_internal_opt_error function.