### PR TITLE
Fix tests in src/test/regress/expected/plancache.out

### DIFF
--- a/src/test/regress/expected/plancache.out
+++ b/src/test/regress/expected/plancache.out
@@ -381,7 +381,7 @@ select name, generic_plans, custom_plans from pg_prepared_statements
   where  name = 'test_mode_pp';
      name     | generic_plans | custom_plans 
 --------------+---------------+--------------
- test_mode_pp |             2 |            5
+ test_mode_pp |             1 |            6
 (1 row)
 
 -- we should now get a really bad plan
@@ -411,7 +411,7 @@ select name, generic_plans, custom_plans from pg_prepared_statements
   where  name = 'test_mode_pp';
      name     | generic_plans | custom_plans 
 --------------+---------------+--------------
- test_mode_pp |             3 |            6
+ test_mode_pp |             1 |            8
 (1 row)
 
 drop table test_mode;

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -292,7 +292,15 @@ insert into test_mode select 1 from generate_series(1,10000) union all select 2;
 create index on test_mode (a);
 analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
+select name, generic_plans, custom_plans from pg_prepared_statements
+  where  name = 'test_mode_pp';
+     name     | generic_plans | custom_plans 
+--------------+---------------+--------------
+ test_mode_pp |             0 |            0
+(1 row)
+
 -- up to 5 executions, custom plan is used
+set plan_cache_mode to auto;
 explain (costs off) execute test_mode_pp(2);
                         QUERY PLAN                        
 ----------------------------------------------------------
@@ -302,6 +310,13 @@ explain (costs off) execute test_mode_pp(2);
                Index Cond: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
 (5 rows)
+
+select name, generic_plans, custom_plans from pg_prepared_statements
+  where  name = 'test_mode_pp';
+     name     | generic_plans | custom_plans 
+--------------+---------------+--------------
+ test_mode_pp |             0 |            1
+(1 row)
 
 -- force generic plan
 set plan_cache_mode to force_generic_plan;
@@ -315,6 +330,13 @@ explain (costs off) execute test_mode_pp(2);
                      Filter: (a = $1)
  Optimizer: Postgres query optimizer
 (6 rows)
+
+select name, generic_plans, custom_plans from pg_prepared_statements
+  where  name = 'test_mode_pp';
+     name     | generic_plans | custom_plans 
+--------------+---------------+--------------
+ test_mode_pp |             1 |            1
+(1 row)
 
 -- get to generic plan by 5 executions
 set plan_cache_mode to auto;
@@ -342,10 +364,24 @@ execute test_mode_pp(1); -- 4x
  10000
 (1 row)
 
+select name, generic_plans, custom_plans from pg_prepared_statements
+  where  name = 'test_mode_pp';
+     name     | generic_plans | custom_plans 
+--------------+---------------+--------------
+ test_mode_pp |             1 |            5
+(1 row)
+
 execute test_mode_pp(1); -- 5x
  count 
 -------
  10000
+(1 row)
+
+select name, generic_plans, custom_plans from pg_prepared_statements
+  where  name = 'test_mode_pp';
+     name     | generic_plans | custom_plans 
+--------------+---------------+--------------
+ test_mode_pp |             1 |            6
 (1 row)
 
 -- we should now get a really bad plan
@@ -370,6 +406,13 @@ explain (costs off) execute test_mode_pp(2);
                Index Cond: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
 (5 rows)
+
+select name, generic_plans, custom_plans from pg_prepared_statements
+  where  name = 'test_mode_pp';
+     name     | generic_plans | custom_plans 
+--------------+---------------+--------------
+ test_mode_pp |             1 |            8
+(1 row)
 
 drop table test_mode;
 --


### PR DESCRIPTION
Commit d05b172 in the file src/test/regress/sql/plancache.sql added new
tests with the output of new fields generic_plans and custom_plans in
pg_prepared_statements. Adapt them for GPDB and add them to ORCA.