### PR TITLE
Fix test src/test/regress/expected/misc.out

### DIFF
--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -328,6 +328,7 @@ external_rescan(FileScanDesc scan)
 	scan->fs_pstate->cur_lineno = 0;
 	scan->fs_pstate->cur_attname = NULL;
 	scan->fs_pstate->raw_buf_len = 0;
+	scan->fs_pstate->raw_buf_index = 0;
 }
 
 /* ----------------
@@ -1003,6 +1004,7 @@ externalgettup_custom(FileScanDesc scan)
 						 * to read more data into it.
 						 */
 						pstate->raw_buf_len = 0;
+						pstate->raw_buf_index = 0;
 						justifyDatabuf(&formatter->fmt_databuf);
 						continue;
 

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -906,6 +906,7 @@ externalgettup_custom(FileScanDesc scan)
 			{
 				appendBinaryStringInfo(&formatter->fmt_databuf, pstate->raw_buf, bytesread);
 				pstate->raw_buf_len = bytesread;
+				pstate->raw_buf_index = 0;
 			}
 
 			/* HEADER not yet supported ... */

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -273,7 +273,6 @@ static bool NextCopyFromX(CopyState cstate, ExprContext *econtext,
 static void HandleCopyError(CopyState cstate);
 static void HandleQDErrorFrame(CopyState cstate, char *p, int len);
 
-static void CopyInitDataParser(CopyState cstate);
 static void setEncodingConversionProc(CopyState cstate, int encoding, bool iswritable);
 
 static GpDistributionData *InitDistributionData(CopyState cstate, EState *estate);
@@ -4197,8 +4196,6 @@ CopyFrom(CopyState cstate)
 		}
 	}
 
-	CopyInitDataParser(cstate);
-
 	if (resultRelInfo->ri_RelationDesc->rd_tableam)
 		table_dml_init(resultRelInfo->ri_RelationDesc);
 
@@ -4622,15 +4619,6 @@ CopyFrom(CopyState cstate)
 		}
 	}
 
-	/*
-	 * After processed data from QD, which is empty and just for workflow, now
-	 * to process the data on segment, only one shot if cstate->on_segment &&
-	 * Gp_role == GP_ROLE_DISPATCH
-	 */
-	if (cstate->on_segment && Gp_role == GP_ROLE_EXECUTE)
-	{
-		CopyInitDataParser(cstate);
-	}
 	elog(DEBUG1, "Segment %u, Copied %lu rows.", GpIdentity.segindex, processed);
 	/* Flush any remaining buffered tuples */
 	if (insertMethod != CIM_SINGLE)
@@ -7616,18 +7604,6 @@ CreateCopyDestReceiver(void)
 	self->processed = 0;
 
 	return (DestReceiver *) self;
-}
-
-/*
- * Initialize data loader parsing state
- */
-static void CopyInitDataParser(CopyState cstate)
-{
-	cstate->reached_eof = false;
-	cstate->cur_relname = RelationGetRelationName(cstate->rel);
-	cstate->cur_lineno = 0;
-	cstate->cur_attname = NULL;
-	cstate->null_print_len = strlen(cstate->null_print);
 }
 
 /*

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4817,7 +4817,7 @@ BeginCopyFrom(ParseState *pstate,
 	initStringInfo(&cstate->attribute_buf);
 	cstate->raw_buf = (char *) palloc(RAW_BUF_SIZE + 1);
 	cstate->raw_buf_index = cstate->raw_buf_len = 0;
-	if (!cstate->binary)
+	if (!cstate->binary || cstate->dispatch_mode == COPY_EXECUTOR)
 	{
 		initStringInfo(&cstate->line_buf);
 		cstate->line_buf_converted = false;
@@ -7628,10 +7628,6 @@ static void CopyInitDataParser(CopyState cstate)
 	cstate->cur_lineno = 0;
 	cstate->cur_attname = NULL;
 	cstate->null_print_len = strlen(cstate->null_print);
-
-	/* Set up data buffer to hold a chunk of data */
-	MemSet(cstate->raw_buf, ' ', RAW_BUF_SIZE * sizeof(char));
-	cstate->raw_buf[RAW_BUF_SIZE] = '\0';
 }
 
 /*


### PR DESCRIPTION
1. Commit cd22d3cdb9bd9963c694c01a8c0232bbae3ddcfb disabled initialization
for line_buf for binary COPY, however in GPDB line_buf is used by QEs
in NextCopyFromExecute even in binary COPY. Enable initialization for
executors too.
2. Commit 0a0727ccfc5f4e2926623abe877bdc0b5bfd682e started using raw_buf
for reading binary data, however there was already GPDB-specific
initialization for it in CopyInitDataParser. This accidentally cleared data
already present in the raw_buf at the time when CopyInitDataParser was called.
The whole CopyInitDataParser can be safely removed since nothing relies on it,
and the string in raw_buf is already zero-terminated in CopyLoadRawBuf.
3. Some GPDB-specific code didn't reset raw_buf_index properly, but now it is
needed.