### PR TITLE
Fix tests in src/test/regress/expected/replication_slots.out

### DIFF
--- a/src/test/regress/expected/replication_slots.out
+++ b/src/test/regress/expected/replication_slots.out
@@ -11,9 +11,9 @@ HINT:  Creating replication slots on a single segment is not advised.  Replicati
 
 -- And I should see that my replication slot exists
 select * from pg_get_replication_slots() where not active;
-       slot_name       | plugin | slot_type | datoid | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn | wal_status | min_safe_lsn 
------------------------+--------+-----------+--------+-----------+--------+------------+------+--------------+-------------+---------------------+------------+--------------
- some_replication_slot |        | physical  |        | f         | f      |            |      |              |             |                     |            | 
+       slot_name       | plugin | slot_type | datoid | temporary | active | active_pid | xmin | catalog_xmin | restart_lsn | confirmed_flush_lsn | wal_status | safe_wal_size 
+-----------------------+--------+-----------+--------+-----------+--------+------------+------+--------------+-------------+---------------------+------------+---------------
+ some_replication_slot |        | physical  |        | f         | f      |            |      |              |             |                     |            |              
 (1 row)
 
 -- Cleanup:


### PR DESCRIPTION
Commit a8aaa0c in the src/backend/catalog/system_views.sql file in the
pg_replication_slots view renamed the min_safe_lsn column to
safe_wal_size. Rename it in the GPDB-specific test.