### PR TITLE
Fix tests in src/test/recovery/t/001_stream_rep.pl

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10230,9 +10230,9 @@ KeepLogSeg(XLogRecPtr recptr, XLogSegNo *logSegNo, XLogRecPtr PriorRedoPtr)
 				segno = 1;
 			else
 				segno = currSegNo - keep_segs;
-		}
 
-		setvalue = true;
+			setvalue = true;
+		}
 	}
 
 	/* don't delete WAL segments newer than the calculated segment */

--- a/src/test/recovery/t/001_stream_rep.pl
+++ b/src/test/recovery/t/001_stream_rep.pl
@@ -12,6 +12,7 @@ my $node_primary = get_new_node('primary');
 $node_primary->init(
 	allows_streaming => 1,
 	auth_extra       => [ '--create-role', 'repl_role' ]);
+$node_primary->append_conf('postgresql.conf', 'wal_keep_size = 0');
 $node_primary->start;
 my $backup_name = 'my_backup';
 
@@ -407,5 +408,8 @@ ok( ($phys_restart_lsn_pre cmp $phys_restart_lsn_post) == 0,
 # Check if the previous segment gets correctly recycled after the
 # server stopped cleanly, causing a shutdown checkpoint to be generated.
 my $primary_data = $node_primary->data_dir;
-ok(!-f "$primary_data/pg_wal/$segment_removed",
+# GPDB never uses restart_lsn as lowest cut-off point. Instead always
+# will use Checkpoint redo location prior to restart_lsn as cut-off
+# point.
+ok(-f "$primary_data/pg_wal/$segment_removed",
 	"WAL segment $segment_removed recycled after physical slot advancing");


### PR DESCRIPTION
1) Commit b48df81 in src/test/recovery/t/001_stream_rep.pl added new
tests that rely on 0 as the default value for the wal_keep_size GUC. In
the GPDB, the default value for this GUC has been changed. Set it
explicitly in the test.

2) Commit b48df81 in src/test/recovery/t/001_stream_rep.pl added new
tests that expect WAL segment 000000010000000000000003 to be recycled.
However, earlier commit 185c7d7 in src/backend/access/transam/xlog.c in
the KeepLogSeg function no longer uses restart_lsn as the lowest cutoff
point, but uses Checkpoint redo location prior to restart_lsn as the
cutoff. Therefore, WAL segment 0000000100000000000000003 is not
recycled.

3) Commit ae181fc in src/backend/access/transam/xlog.c in the
KeepLogSeg function did not resolve conflicts correctly. Move the
expression setvalue = true; into the internal IF, as it was before.