### PR TITLE
Fix tests in src/test/isolation2/expected/distributed_snapshot.out

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2816,6 +2816,21 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 		snapshot->haveDistribSnapshot) && GetSnapshotDataReuse(snapshot))
 	{
 		LWLockRelease(ProcArrayLock);
+
+#ifdef FAULT_INJECTOR
+		if (!IS_QUERY_DISPATCHER() && snapshot->haveDistribSnapshot)
+		{
+			const char *dbname = NULL;
+
+			if (MyProcPort)
+				dbname = MyProcPort->database_name;
+
+			FaultInjector_InjectFaultIfSet("distributedlog_advance_oldest_xmin",
+										   DDLNotSpecified, dbname ? dbname: "",
+										   "");
+		}
+#endif
+
 		goto ret;
 	}
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2812,25 +2812,22 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 
+#ifdef FAULT_INJECTOR
+	if (!IS_QUERY_DISPATCHER() && snapshot->haveDistribSnapshot &&
+		FaultInjector_InjectFaultIfSet("distributedlog_advance_oldest_xmin_check",
+										DDLNotSpecified,
+										MyProcPort ? MyProcPort->database_name: "",
+										"") == FaultInjectorTypeSkip)
+	{
+		/* Skip snapshot data reuse */
+	}
+	else
+#endif
+
 	if ((distributedTransactionContext != DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE ||
 		snapshot->haveDistribSnapshot) && GetSnapshotDataReuse(snapshot))
 	{
 		LWLockRelease(ProcArrayLock);
-
-#ifdef FAULT_INJECTOR
-		if (!IS_QUERY_DISPATCHER() && snapshot->haveDistribSnapshot)
-		{
-			const char *dbname = NULL;
-
-			if (MyProcPort)
-				dbname = MyProcPort->database_name;
-
-			FaultInjector_InjectFaultIfSet("distributedlog_advance_oldest_xmin",
-										   DDLNotSpecified, dbname ? dbname: "",
-										   "");
-		}
-#endif
-
 		goto ret;
 	}
 

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2814,7 +2814,7 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 
 #ifdef FAULT_INJECTOR
 	if (!IS_QUERY_DISPATCHER() && snapshot->haveDistribSnapshot &&
-		FaultInjector_InjectFaultIfSet("distributedlog_advance_oldest_xmin_check",
+		FaultInjector_InjectFaultIfSet("distributed_snapshot_skip_data_reuse",
 										DDLNotSpecified,
 										MyProcPort ? MyProcPort->database_name: "",
 										"") == FaultInjectorTypeSkip)

--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -32,7 +32,7 @@ INSERT 1
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'skip', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: SELECT gp_inject_fault('distributed_snapshot_skip_data_reuse', 'skip', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
@@ -60,7 +60,7 @@ INSERT 1
 -----------------
  Success:        
 (1 row)
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+1: SELECT gp_inject_fault('distributed_snapshot_skip_data_reuse', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/expected/distributed_snapshot.out
+++ b/src/test/isolation2/expected/distributed_snapshot.out
@@ -32,6 +32,11 @@ INSERT 1
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'skip', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
@@ -51,6 +56,11 @@ COMMIT
 INSERT 1
 -- let session 3 now move forward to compute distributed oldest xmin
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/sql/distributed_snapshot.sql
+++ b/src/test/isolation2/sql/distributed_snapshot.sql
@@ -23,6 +23,9 @@ CREATE TABLE distributed_snapshot_test1 (a int);
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'skip',
+   '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration
+   where content = 0 and role = 'p';
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend',
    '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration
    where content = 0 and role = 'p';
@@ -35,6 +38,8 @@ CREATE TABLE distributed_snapshot_test1 (a int);
 1: INSERT INTO distributed_snapshot_test1 values(1);
 -- let session 3 now move forward to compute distributed oldest xmin
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid)
+   from gp_segment_configuration where content = 0 and role = 'p';
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'reset', dbid)
    from gp_segment_configuration where content = 0 and role = 'p';
 3<:
 

--- a/src/test/isolation2/sql/distributed_snapshot.sql
+++ b/src/test/isolation2/sql/distributed_snapshot.sql
@@ -23,7 +23,7 @@ CREATE TABLE distributed_snapshot_test1 (a int);
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'skip',
+1: SELECT gp_inject_fault('distributed_snapshot_skip_data_reuse', 'skip',
    '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration
    where content = 0 and role = 'p';
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend',
@@ -39,7 +39,7 @@ CREATE TABLE distributed_snapshot_test1 (a int);
 -- let session 3 now move forward to compute distributed oldest xmin
 1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid)
    from gp_segment_configuration where content = 0 and role = 'p';
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin_check', 'reset', dbid)
+1: SELECT gp_inject_fault('distributed_snapshot_skip_data_reuse', 'reset', dbid)
    from gp_segment_configuration where content = 0 and role = 'p';
 3<:
 


### PR DESCRIPTION
Commit 623a9ba in src/backend/storage/ipc/procarray.c in the
GetSnapshotData function enables snapshot reuse. This omits the call to
the DistributedLog_AdvanceOldestXmin function below, which sets the
distributedlog_advance_oldest_xmin fault injector used in the
src/test/isolation2/sql/distributed_snapshot.sql test. Skip snapshot
data reuse for this test.