### PR TITLE
Fix compilation in src/backend/catalog/heap.c

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1653,7 +1653,7 @@ heap_create_with_catalog(const char *relname,
 		  relkind == RELKIND_AOVISIMAP) &&
 		  relnamespace != PG_BITMAPINDEX_NAMESPACE)
 	{
-		Oid			new_array_oid;
+		Oid			new_array_oid = InvalidOid;
 		ObjectAddress new_type_addr;
 		char	   *relarrayname = NULL;
 


### PR DESCRIPTION
Commit 90301d7 in src/backend/catalog/heap.c forgot to initialize the
local variable new_array_oid in the heap_create_with_catalog function.