### PR TITLE
Fix flaky idle_gang_cleaner case (#15228)

### DIFF
--- a/src/test/isolation2/input/idle_gang_cleaner.source
+++ b/src/test/isolation2/input/idle_gang_cleaner.source
@@ -4,9 +4,6 @@
 -- clean up the idle writer gangs after the timeout, 
 -- no snapshot collision error should occur.
 
-CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
-AS '@abs_builddir@/../regress/regress.so', 'cleanupAllGangs' LANGUAGE C;
-
 create or replace language plpython3u;
 create extension if not exists gp_inject_fault;
 
@@ -30,7 +27,6 @@ create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
 insert into target_session_id_t values(current_setting('gp_session_id')::int);
 
 create table idle_gang_cleaner_t (c1 int, c2 int);
-select cleanupAllGangs();
 
 0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
 
@@ -47,7 +43,6 @@ select count(*) from idle_gang_cleaner_t a
 0U: select gp_inject_fault('proc_kill', 'reset', 2, target_session_id) from target_session_id_t;
 
 -- Release idle Reader gangs in transaction or transaction block
-select cleanupAllGangs();
 0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
 
 begin;

--- a/src/test/isolation2/output/idle_gang_cleaner.source
+++ b/src/test/isolation2/output/idle_gang_cleaner.source
@@ -4,9 +4,6 @@
 -- clean up the idle writer gangs after the timeout,
 -- no snapshot collision error should occur.
 
-CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
-CREATE
-
 create or replace language plpython3u;
 CREATE
 create extension if not exists gp_inject_fault;
@@ -29,11 +26,6 @@ INSERT 1
 
 create table idle_gang_cleaner_t (c1 int, c2 int);
 CREATE
-select cleanupAllGangs();
- cleanupallgangs 
------------------
- t               
-(1 row)
 
 0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
  gp_inject_fault 
@@ -66,11 +58,6 @@ select count(*) from idle_gang_cleaner_t a join idle_gang_cleaner_t b using (c2)
 (1 row)
 
 -- Release idle Reader gangs in transaction or transaction block
-select cleanupAllGangs();
- cleanupallgangs 
------------------
- t               
-(1 row)
 0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
  gp_inject_fault 
 -----------------


### PR DESCRIPTION
After calling `cleanupAllGangs()`, there is a chance of encountering
the FATAL "writer segworker group shared snapshot collision" error
when executing a query. The reason is that if the writer gang cannot
exit before a new command starts, it will find the same session id
in the shared snapshot and collision will happen. Additionally, since
the session only has the writer gangs before executing the target
query, there is no need to call `cleanupAllGangs()` before executing
the query.

(cherry picked from commit 1f51faf)