### PR TITLE
Resolve conflicts in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -69,23 +69,15 @@ clean:
 	$(MAKE) -C test $@
 	$(MAKE) -C tutorial NO_PGXS=1 $@
 	$(MAKE) -C test/isolation $@
-<<<<<<< HEAD
-	$(MAKE) -C test/thread $@
 	$(MAKE) -C $(MOCK_DIR) $@
 	$(MAKE) -C $(CMOCKERY_DIR) $@
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 distclean maintainer-clean:
 	$(MAKE) -C test $@
 	$(MAKE) -C tutorial NO_PGXS=1 $@
 	$(MAKE) -C test/isolation $@
-<<<<<<< HEAD
-	$(MAKE) -C test/thread $@
 	$(MAKE) -C $(MOCK_DIR) $@
 	$(MAKE) -C $(CMOCKERY_DIR) $@
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	rm -f Makefile.port Makefile.global
 
 .PHONY: install-local installdirs-local uninstall-local


### PR DESCRIPTION
Commit 8a21211 in the src/Makefile in clean and in distclean
maintainer-clean removed test/thread, while the earlier commit 1c1e362
had already added MOCK_DIR and CMOCKERY_DIR to the same places.