### PR TITLE
Resolve conflicts in src/backend/storage/sync/sync.c and sync.h

### DIFF
--- a/src/backend/storage/sync/sync.c
+++ b/src/backend/storage/sync/sync.c
@@ -105,13 +105,12 @@ static const SyncOps syncsw[] = {
 		.sync_unlinkfiletag = mdunlinkfiletag,
 		.sync_filetagmatches = mdfiletagmatches
 	},
-<<<<<<< HEAD
 	/* append-optimized storage */
-	{
+	[SYNC_HANDLER_AO] = {
 		.sync_syncfiletag = aosyncfiletag,
 		.sync_unlinkfiletag = mdunlinkfiletag,
 		.sync_filetagmatches = mdfiletagmatches
-=======
+	},
 	/* pg_xact */
 	[SYNC_HANDLER_CLOG] = {
 		.sync_syncfiletag = clogsyncfiletag
@@ -127,7 +126,6 @@ static const SyncOps syncsw[] = {
 	/* pg_multixact/members */
 	[SYNC_HANDLER_MULTIXACT_MEMBER] = {
 		.sync_syncfiletag = multixactmemberssyncfiletag
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	}
 };
 

--- a/src/include/storage/sync.h
+++ b/src/include/storage/sync.h
@@ -34,17 +34,13 @@ typedef enum SyncRequestType
  */
 typedef enum SyncRequestHandler
 {
-<<<<<<< HEAD
 	SYNC_HANDLER_MD = 0,			/* md smgr */
-	SYNC_HANDLER_AO = 1
-=======
-	SYNC_HANDLER_MD = 0,
+	SYNC_HANDLER_AO = 1,
 	SYNC_HANDLER_CLOG,
 	SYNC_HANDLER_COMMIT_TS,
 	SYNC_HANDLER_MULTIXACT_OFFSET,
 	SYNC_HANDLER_MULTIXACT_MEMBER,
 	SYNC_HANDLER_NONE
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 } SyncRequestHandler;
 
 /*


### PR DESCRIPTION
Commit dee663f7843902535a15ae366cede8b4089f1144 added new SyncRequestHandler
values, however there was already GPDB-specific value SYNC_HANDLER_AO = 1.
Preserve both changes.