### PR TITLE
Resolve conflicts src/include/utils/logtape.h

### DIFF
--- a/src/include/utils/logtape.h
+++ b/src/include/utils/logtape.h
@@ -54,13 +54,9 @@ typedef struct TapeShare
  * prototypes for functions in logtape.c
  */
 
-<<<<<<< HEAD
 extern char * LogicalTapeGetBufFilename(const LogicalTapeSet *lts);
-extern LogicalTapeSet *LogicalTapeSetCreate(int ntapes, TapeShare *shared,
-=======
 extern LogicalTapeSet *LogicalTapeSetCreate(int ntapes, bool preallocate,
 											TapeShare *shared,
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 											SharedFileSet *fileset, int worker);
 extern void LogicalTapeSetClose(LogicalTapeSet *lts);
 extern void LogicalTapeSetForgetFreeSpace(LogicalTapeSet *lts);

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -524,7 +524,7 @@ logicaltape_test(void)
 	int test_tape = 5;
 	int test_entry = 45000;
 
-	LogicalTapeSet *tape_set = LogicalTapeSetCreate(max_tapes, NULL, NULL, -1);
+	LogicalTapeSet *tape_set = LogicalTapeSetCreate(max_tapes, false, NULL, NULL, -1);
 
 	int work_tape = 0;
 	long blocknum = 0;


### PR DESCRIPTION
Commit 07589649639410032df281e98469db88a0b86271 added a new argument to
LogicalTapeSetCreate, however GPDB-specific commit
e2f2312c2295b357bb770666789ddd3ae8ba54a8 added LogicalTapeGetBufFilename
nearby. Also fix GPDB-specific logicaltape_test.