### PR TITLE
Resolve conflicts in table.h and index.c

### DIFF
--- a/src/backend/access/table/table.c
+++ b/src/backend/access/table/table.c
@@ -71,11 +71,11 @@ table_open(Oid relationId, LOCKMODE lockmode)
  * ----------------
  */
 Relation
-try_table_open(Oid relationId, LOCKMODE lockmode)
+try_table_open(Oid relationId, LOCKMODE lockmode, bool noWait)
 {
 	Relation	r;
 
-	r = try_relation_open(relationId, lockmode);
+	r = try_relation_open(relationId, lockmode, noWait);
 
 	/* leave if table does not exist */
 	if (!r)
@@ -155,36 +155,6 @@ table_openrv_extended(const RangeVar *relation, LOCKMODE lockmode,
 					 errmsg("\"%s\" is a composite type",
 							RelationGetRelationName(r))));
 	}
-
-	return r;
-}
-
-/* ----------------
- *		try_table_open - open a heap relation by relation OID
- *
- *		As above, but relation return NULL for relation-not-found
- * ----------------
- */
-Relation
-try_table_open(Oid relationId, LOCKMODE lockmode, bool noWait)
-{
-	Relation	r;
-
-	r = try_relation_open(relationId, lockmode, noWait);
-
-	if (!RelationIsValid(r))
-		return NULL;
-
-	if (r->rd_rel->relkind == RELKIND_INDEX)
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("\"%s\" is an index",
-						RelationGetRelationName(r))));
-	else if (r->rd_rel->relkind == RELKIND_COMPOSITE_TYPE)
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("\"%s\" is a composite type",
-						RelationGetRelationName(r))));
 
 	return r;
 }

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -3714,7 +3714,7 @@ reindex_index(Oid indexId, bool skip_constraint_checks, char persistence,
 		return;
 
 	if ((options & REINDEXOPT_MISSING_OK) != 0)
-		heapRelation = try_table_open(heapId, ShareLock);
+		heapRelation = try_table_open(heapId, ShareLock, false);
 	else
 		heapRelation = table_open(heapId, ShareLock);
 
@@ -4015,7 +4015,7 @@ reindex_relation(Oid relid, int flags, int options)
 	 * should match ReindexTable().
 	 */
 	if ((options & REINDEXOPT_MISSING_OK) != 0)
-		rel = try_table_open(relid, ShareLock);
+		rel = try_table_open(relid, ShareLock, false);
 	else
 		rel = table_open(relid, ShareLock);
 
@@ -4031,11 +4031,8 @@ reindex_relation(Oid relid, int flags, int options)
 		elog(ERROR, "cannot reindex partitioned table \"%s.%s\"",
 			 get_namespace_name(RelationGetNamespace(rel)),
 			 RelationGetRelationName(rel));
-<<<<<<< HEAD
 
 	relIsAO = RelationIsAppendOptimized(rel);
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 	toast_relid = rel->rd_rel->reltoastrelid;
 

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -3618,7 +3618,8 @@ ReindexRelationConcurrently(Oid relationOid, int options)
 				if ((options & REINDEXOPT_MISSING_OK) != 0)
 				{
 					heapRelation = try_table_open(relationOid,
-												  ShareUpdateExclusiveLock);
+												  ShareUpdateExclusiveLock,
+												  false);
 					/* leave if relation does not exist */
 					if (!heapRelation)
 						break;
@@ -3742,7 +3743,8 @@ ReindexRelationConcurrently(Oid relationOid, int options)
 				if ((options & REINDEXOPT_MISSING_OK) != 0)
 				{
 					heapRelation = try_table_open(heapId,
-												  ShareUpdateExclusiveLock);
+												  ShareUpdateExclusiveLock,
+												  false);
 					/* leave if relation does not exist */
 					if (!heapRelation)
 						break;

--- a/src/backend/replication/logical/relation.c
+++ b/src/backend/replication/logical/relation.c
@@ -302,7 +302,7 @@ logicalrep_rel_open(LogicalRepRelId remoteid, LOCKMODE lockmode)
 	 */
 	if (entry->localrelvalid)
 	{
-		entry->localrel = try_table_open(entry->localreloid, lockmode);
+		entry->localrel = try_table_open(entry->localreloid, lockmode, false);
 		if (!entry->localrel)
 		{
 			/* Table was renamed or dropped. */

--- a/src/include/access/table.h
+++ b/src/include/access/table.h
@@ -22,11 +22,7 @@ extern Relation table_open(Oid relationId, LOCKMODE lockmode);
 extern Relation table_openrv(const RangeVar *relation, LOCKMODE lockmode);
 extern Relation table_openrv_extended(const RangeVar *relation,
 									  LOCKMODE lockmode, bool missing_ok);
-<<<<<<< HEAD
 extern Relation try_table_open(Oid relationId, LOCKMODE lockmode, bool noWait);
-=======
-extern Relation try_table_open(Oid relationId, LOCKMODE lockmode);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 extern void table_close(Relation relation, LOCKMODE lockmode);
 
 /* CDB */


### PR DESCRIPTION
1) Commit 1d65416 in the file src/include/access/table.h added a
declaration of a new function try_table_open with two arguments, while
the earlier commit 19cd1cf already added it but with three arguments.

2) Commit a6642b3 in the file src/backend/catalog/index.c in the
reindex_relation function changed the warning to an error, while
earlier commits 25a9039 and 958a672 had already added GPDB-specific
code to the same place.