### PR TITLE
Resolve conflicts in src/include/common/string.h

### DIFF
--- a/src/include/common/string.h
+++ b/src/include/common/string.h
@@ -12,10 +12,7 @@
 
 struct StringInfoData;			/* avoid including stringinfo.h here */
 
-<<<<<<< HEAD
-=======
 /* functions in src/common/string.c */
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 extern bool pg_str_endswith(const char *str, const char *end);
 extern int	strtoint(const char *pg_restrict str, char **pg_restrict endptr,
 					 int base);
@@ -23,11 +20,6 @@ extern void pg_clean_ascii(char *str);
 extern int	pg_strip_crlf(char *str);
 
 /* functions in src/common/pg_get_line.c */
-<<<<<<< HEAD
-extern bool pg_get_line_buf(FILE *stream, struct StringInfoData *buf);
-extern bool pg_get_line_append(FILE *stream, struct StringInfoData *buf);
-
-=======
 extern char *pg_get_line(FILE *stream);
 extern bool pg_get_line_buf(FILE *stream, struct StringInfoData *buf);
 extern bool pg_get_line_append(FILE *stream, struct StringInfoData *buf);
@@ -35,5 +27,4 @@ extern bool pg_get_line_append(FILE *stream, struct StringInfoData *buf);
 /* functions in src/common/sprompt.c */
 extern char *simple_prompt(const char *prompt, bool echo);
 
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 #endif							/* COMMON_STRING_H */


### PR DESCRIPTION
Commits 67a472d71c98c3d2fa322a1b4013080b20720b98,
8e3c58e6e459b285d37edb6129e412ed25cd90c1 and
931487018c409a3102452f965ccaa48367244a41 have added new definitions,
however GPDB has previously cherry-picked commit
b4c36a1dc37fffb2d7e795d0f77aaaf035ad3e9f, so some of the changes were already
present.
