### PR TITLE
Resolve conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302605041
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202011041
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+#define CATALOG_VERSION_NO	302605211
 
 #endif


### PR DESCRIPTION
Commit e152506 updated the catalog version after the incompatible
changes, so we should do the same for the current date - the date of
the incompatible changes.