### PR TITLE
Resolve conflicts in src/include/catalog/index.h

### DIFF
--- a/src/include/catalog/index.h
+++ b/src/include/catalog/index.h
@@ -127,13 +127,11 @@ extern void FormIndexDatum(IndexInfo *indexInfo,
 						   Datum *values,
 						   bool *isnull);
 
-<<<<<<< HEAD
 extern Oid setNewRelfilenodeToOid(Relation relation, TransactionId freezeXid,
 					   Oid newrelfilenode);
-=======
+
 extern void index_check_collation_versions(Oid relid);
 extern void index_update_collation_versions(Oid relid, Oid coll);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 extern void index_build(Relation heapRelation,
 						Relation indexRelation,


### PR DESCRIPTION
Commit 257836a in src/include/catalog/index.h added new function
declarations index_check_collation_versions and
index_update_collation_versions, while an earlier commit a453004 had
already added a function declaration setNewRelfilenodeToOid in the same
place.