### PR TITLE
Resolve conflicts in src/backend/access/transam/multixact.c and xlog.c

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -837,22 +837,6 @@ DistributedLog_Startup(TransactionId oldestActiveXid,
 }
 
 /*
- * This must be called ONCE during postmaster or standalone-backend shutdown
- */
-void
-DistributedLog_Shutdown(void)
-{
-	if (IS_QUERY_DISPATCHER())
-		return;
-
-	elog((Debug_print_full_dtm ? LOG : DEBUG5),
-		 "DistributedLog_Shutdown");
-
-	/* Flush dirty DistributedLog pages to disk */
-	SimpleLruFlush(DistributedLogCtl, false);
-}
-
-/*
  * Perform a checkpoint --- either during shutdown, or on-the-fly
  */
 void
@@ -864,8 +848,8 @@ DistributedLog_CheckPoint(void)
 	elog((Debug_print_full_dtm ? LOG : DEBUG5),
 		 "DistributedLog_CheckPoint");
 
-	/* Flush dirty DistributedLog pages to disk */
-	SimpleLruFlush(DistributedLogCtl, true);
+	/* Write dirty DistributedLog pages to disk */
+	SimpleLruWriteAll(DistributedLogCtl, true);
 }
 
 

--- a/src/backend/access/transam/multixact.c
+++ b/src/backend/access/transam/multixact.c
@@ -2121,23 +2121,6 @@ TrimMultiXact(void)
 }
 
 /*
-<<<<<<< HEAD
- * This must be called ONCE during postmaster or standalone-backend shutdown
- */
-void
-ShutdownMultiXact(void)
-{
-	/* Flush dirty MultiXact pages to disk */
-	TRACE_POSTGRESQL_MULTIXACT_CHECKPOINT_START(false);
-	SimpleLruFlush(MultiXactOffsetCtl, false);
-	SimpleLruFlush(MultiXactMemberCtl, false);
-
-	TRACE_POSTGRESQL_MULTIXACT_CHECKPOINT_DONE(false);
-}
-
-/*
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  * Get the MultiXact data to save in a checkpoint record
  */
 void

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8965,14 +8965,6 @@ ShutdownXLOG(int code pg_attribute_unused() , Datum arg pg_attribute_unused() )
 
 		CreateCheckPoint(CHECKPOINT_IS_SHUTDOWN | CHECKPOINT_IMMEDIATE);
 	}
-<<<<<<< HEAD
-	ShutdownCLOG();
-	ShutdownCommitTs();
-	ShutdownSUBTRANS();
-	ShutdownMultiXact();
-	DistributedLog_Shutdown();
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 }
 
 /*

--- a/src/include/access/distributedlog.h
+++ b/src/include/access/distributedlog.h
@@ -61,7 +61,6 @@ extern void DistributedLog_BootStrap(void);
 extern void DistributedLog_Startup(
 					   TransactionId oldestActiveXid,
 					   TransactionId nextXid);
-extern void DistributedLog_Shutdown(void);
 extern void DistributedLog_CheckPoint(void);
 extern void DistributedLog_Extend(TransactionId newestXid);
 extern bool DistributedLog_GetLowWaterXid(


### PR DESCRIPTION
Commit dee663f7843902535a15ae366cede8b4089f1144 removed ShutdownMultiXact
which had an extra empty line in GPDB code. It also removed several other
Shutdown* functions, and replaced SimpleLruFlush with SimpleLruWriteAll.
Apply the same changes to DistributedLog functions as well: remove Shutdown
and replace the use of SimpleLruFlush.