### PR TITLE
Resolve conflicts in src/backend/commands/explain.c

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -717,16 +717,12 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 	/* Create textual dump of plan tree */
 	ExplainPrintPlan(es, queryDesc);
 
-<<<<<<< HEAD
 	if (cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE)
 		ExplainParallelRetrieveCursor(es, queryDesc);
 
-	if (es->summary && (planduration || bufusage))
-=======
 	/* Show buffer usage in planning */
 	if (bufusage)
 	{
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 		ExplainOpenGroup("Planning", "Planning", true, es);
 		show_buffer_usage(es, bufusage, true);
 		ExplainCloseGroup("Planning", "Planning", true, es);
@@ -739,26 +735,10 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 		ExplainPropertyFloat("Planning Time", "ms", 1000.0 * plantime, 3, es);
 	}
 
-<<<<<<< HEAD
 	/* Print slice table */
 	if (es->slicetable)
 		ExplainPrintSliceTable(es, queryDesc);
 
-	/* Show buffer usage */
-	if (es->summary && bufusage)
-	{
-		if (es->format == EXPLAIN_FORMAT_TEXT)
-			es->indent++;
-		show_buffer_usage(es, bufusage);
-		if (es->format == EXPLAIN_FORMAT_TEXT)
-			es->indent--;
-	}
-
-	if (es->summary && (planduration || bufusage))
-		ExplainCloseGroup("Planning", "Planning", true, es);
-
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	/* Print info about runtime of triggers */
 	if (es->analyze)
 		ExplainPrintTriggers(es, queryDesc);


### PR DESCRIPTION
1) Commit 9d701e6 in src/backend/commands/explain.c in the
ExplainOnePlan function replaced the es->summary && (planning ||
bufusage) condition with the bufusage condition. However, the earlier
commit 7a1ce37 had already added a conditional call to the
ExplainParallelRetrieveCursor function in the same location.

2) Commit 9d701e6 in src/backend/commands/explain.c in the
ExplainOnePlan function removed the es->summary && bufusage and
es->summary && (planation || bufusage) conditions along with the code,
while the earlier commit 08d8dba had already added a conditional call
to the ExplainPrintSliceTable function in the same place.