### PR TITLE
Resolve conflicts in src/backend/nodes/equalfuncs.c

### DIFF
--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2310,11 +2310,7 @@ _equalReindexStmt(const ReindexStmt *a, const ReindexStmt *b)
 	COMPARE_NODE_FIELD(relation);
 	COMPARE_STRING_FIELD(name);
 	COMPARE_SCALAR_FIELD(options);
-<<<<<<< HEAD
-	COMPARE_SCALAR_FIELD(concurrent);
 	COMPARE_SCALAR_FIELD(relid);
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 	return true;
 }


### PR DESCRIPTION
Commit 844c05a in src/backend/nodes/equalfuncs.c removed the use of the
concurrent field before the _equalReindexStmt function, while an
earlier commit, 6b0e52b, already used the relid field in the same
place.