### PR TITLE
Resolve conflicts in src/backend/optimizer/path/costsize.c

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -112,14 +112,6 @@
  */
 #define APPEND_CPU_COST_MULTIPLIER 0.5
 
-/*
- * Maximum value for row estimates.  We cap row estimates to this to help
- * ensure that costs based on these estimates remain within the range of what
- * double can represent.  add_path() wouldn't act sanely given infinite or NaN
- * cost values.
- */
-#define MAXIMUM_ROWCOUNT 1e100
-
 double		seq_page_cost = DEFAULT_SEQ_PAGE_COST;
 double		random_page_cost = DEFAULT_RANDOM_PAGE_COST;
 double		cpu_tuple_cost = DEFAULT_CPU_TUPLE_COST;

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -234,26 +234,11 @@ static Selectivity adjust_selectivity_for_nulltest(Selectivity selec,
  */
 typedef struct
 {
-<<<<<<< HEAD
 	/* Values copied from RelOptInfo as is, for convenience */
 	Index		relid;
 	RTEKind		rtekind;		/* RELATION, SUBQUERY, or FUNCTION */
 	Oid			reltablespace;	/* containing tablespace */
 	double		allvisfrac;
-=======
-	/*
-	 * Avoid infinite and NaN row estimates.  Costs derived from such values
-	 * are going to be useless.  Also force the estimate to be at least one
-	 * row, to make explain output look better and to avoid possible
-	 * divide-by-zero when interpolating costs.  Make it an integer, too.
-	 */
-	if (nrows > MAXIMUM_ROWCOUNT || isnan(nrows))
-		nrows = MAXIMUM_ROWCOUNT;
-	else if (nrows <= 1.0)
-		nrows = 1.0;
-	else
-		nrows = rint(nrows);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 	/* Values adjusted from RelOptInfo, by dividing by numsegments */
 	double		rows;
@@ -3035,15 +3020,12 @@ final_cost_nestloop(PlannerInfo *root, NestPath *path,
 		outer_path_rows = 1;
 	if (inner_path_rows <= 0)
 		inner_path_rows = 1;
-<<<<<<< HEAD
 
 	if (CdbPathLocus_IsPartitioned(path->path.locus))
 		numsegments = CdbPathLocus_NumSegments(path->path.locus);
 	else
 		numsegments = 1;
 
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	/* Mark the path with the correct row estimate */
 	if (path->path.param_info)
 		path->path.rows = path->path.param_info->ppi_rows;

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -33,6 +33,14 @@
 
 #define DEFAULT_EFFECTIVE_CACHE_SIZE  524288	/* measured in pages */
 
+/*
+ * Maximum value for row estimates.  We cap row estimates to this to help
+ * ensure that costs based on these estimates remain within the range of what
+ * double can represent.  add_path() wouldn't act sanely given infinite or NaN
+ * cost values.
+ */
+#define MAXIMUM_ROWCOUNT 1e100
+
 typedef enum
 {
 	CONSTRAINT_EXCLUSION_OFF,	/* do not use c_e */
@@ -53,7 +61,12 @@ clamp_row_est(double nrows)
 	 * better and to avoid possible divide-by-zero when interpolating costs.
      * CDB: Don't round to integer.
 	 */
-    return (nrows < 1.0) ? 1.0 : nrows;
+	if (nrows > MAXIMUM_ROWCOUNT || isnan(nrows))
+		nrows = MAXIMUM_ROWCOUNT;
+	else if (nrows < 1.0)
+		nrows = 1.0;
+
+	return nrows;
 }
 
 

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -57,8 +57,10 @@ static inline double
 clamp_row_est(double nrows)
 {
 	/*
-	 * Force estimate to be at least one row, to make explain output look
-	 * better and to avoid possible divide-by-zero when interpolating costs.
+	 * Avoid infinite and NaN row estimates.  Costs derived from such values
+	 * are going to be useless.  Also force the estimate to be at least one
+	 * row, to make explain output look better and to avoid possible
+	 * divide-by-zero when interpolating costs.
      * CDB: Don't round to integer.
 	 */
 	if (nrows > MAXIMUM_ROWCOUNT || isnan(nrows))


### PR DESCRIPTION
1) Commit a90c950 in src/backend/optimizer/path/costsize.c changed the
comment and calculation of nrows in the clamp_row_est function, while
earlier commit 6b0e52b had already moved the clamp_row_est function to
src/include/optimizer/cost.h.

2) Commit a90c950 in src/backend/optimizer/path/costsize.c in the
final_cost_nestloop function removed isnan(outer_path_rows) from the
conditions, while earlier commit c5f6dbb had already added the
conditional setting of numsegments to the same location.