### PR TITLE
Resolve conflicts in src/backend/optimizer/plan/setrefs.c

### DIFF
--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -184,13 +184,14 @@ static List *fix_hashclauses(PlannerInfo *root,
 							 List *clauses,
 							 indexed_tlist *outer_itlist,
 							 indexed_tlist *inner_itlist,
-							 Index acceptable_rel, int rtoffset);
+							 Index acceptable_rel, int rtoffset,
+							 double num_exec);
 static List *fix_child_hashclauses(PlannerInfo *root,
 								   List *clauses,
 								   indexed_tlist *outer_itlist,
 								   indexed_tlist *inner_itlist,
 								   Index acceptable_rel, int rtoffset,
-								   Index child);
+								   Index child, double num_exec);
 static Node *fix_upper_expr(PlannerInfo *root,
 							Node *node,
 							indexed_tlist *subplan_itlist,
@@ -2321,7 +2322,8 @@ set_join_references(PlannerInfo *root, Join *join, int rtoffset)
 										outer_itlist,
 										inner_itlist,
 										(Index) 0,
-										rtoffset);
+										rtoffset,
+										NUM_EXEC_QUAL((Plan *) join));
 
 		hj->hashqualclauses = fix_join_expr(root,
 											hj->hashqualclauses,
@@ -3058,7 +3060,9 @@ static List *fix_hashclauses(PlannerInfo *root,
                            List *clauses,
                            indexed_tlist *outer_itlist,
                            indexed_tlist *inner_itlist,
-                           Index acceptable_rel, int rtoffset)
+                           Index acceptable_rel,
+						   int rtoffset,
+						   double num_exec)
 {
     Assert(clauses);
     ListCell *lc = NULL;
@@ -3083,7 +3087,8 @@ static List *fix_hashclauses(PlannerInfo *root,
                 inner_itlist,
                 (Index) 0,
                 rtoffset,
-                OUTER_VAR);
+                OUTER_VAR,
+				num_exec);
         /*
          * for inner argument, we cannot refer to target entries
          * in join's outer child target list, otherwise hash table
@@ -3096,7 +3101,8 @@ static List *fix_hashclauses(PlannerInfo *root,
                 inner_itlist,
                 (Index) 0,
                 rtoffset,
-                INNER_VAR);
+                INNER_VAR,
+				num_exec);
         new_args = lappend(new_args, new_outer_arg);
         new_args = lappend(new_args, new_inner_arg);
         /* replace old arguments with the fixed arguments */
@@ -3129,7 +3135,8 @@ fix_child_hashclauses(PlannerInfo *root,
               indexed_tlist *inner_itlist,
               Index acceptable_rel,
               int rtoffset,
-              Index child)
+              Index child,
+			  double num_exec)
 {
     fix_join_expr_context context;
     context.root = root;
@@ -3137,6 +3144,7 @@ fix_child_hashclauses(PlannerInfo *root,
     context.inner_itlist = inner_itlist;
     context.acceptable_rel = acceptable_rel;
     context.rtoffset = rtoffset;
+    context.num_exec = num_exec;
     if (INNER_VAR == child)
     {
     	/* skips using outer target list when matching non-vars */

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -821,11 +821,13 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 				/* adjust for the new range table offset */
 				tplan->scan.scanrelid += rtoffset;
 				tplan->scan.plan.targetlist =
-					fix_scan_list(root, tplan->scan.plan.targetlist, rtoffset);
+					fix_scan_list(root, tplan->scan.plan.targetlist,
+								  rtoffset, NUM_EXEC_TLIST(plan));
 				tplan->scan.plan.qual =
-					fix_scan_list(root, tplan->scan.plan.qual, rtoffset);
+					fix_scan_list(root, tplan->scan.plan.qual,
+								  rtoffset, NUM_EXEC_QUAL(plan));
 				tplan->function = (RangeTblFunction *)
-					fix_scan_expr(root, (Node *) tplan->function, rtoffset);
+					fix_scan_expr(root, (Node *) tplan->function, rtoffset, 1);
 
 				return plan;
 			}
@@ -1014,10 +1016,10 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 
 							pinfo->initial_pruning_steps = (List *)
 								fix_upper_expr(root, (Node *) pinfo->initial_pruning_steps,
-											   childplan_itlist, OUTER_VAR, rtoffset);
+											   childplan_itlist, OUTER_VAR, rtoffset, 1);
 							pinfo->exec_pruning_steps = (List *)
 								fix_upper_expr(root, (Node *) pinfo->exec_pruning_steps,
-											   childplan_itlist, OUTER_VAR, rtoffset);
+											   childplan_itlist, OUTER_VAR, rtoffset, 1);
 						}
 					}
 				}
@@ -1111,7 +1113,7 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 					                                             (Node *)dqaExpr->agg_filter,
 					                                             subplan_itlist,
 					                                             OUTER_VAR,
-					                                             rtoffset);
+					                                             rtoffset, 1);
 
 					lfirst(lc) = dqaExpr;
 				}
@@ -1350,7 +1352,8 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 					build_tlist_index(plan->lefttree->targetlist);
 
 				motion->hashExprs = (List *)
-					fix_upper_expr(root, (Node*) motion->hashExprs, childplan_itlist,  OUTER_VAR, rtoffset);
+					fix_upper_expr(root, (Node*) motion->hashExprs,
+								   childplan_itlist,  OUTER_VAR, rtoffset, 1);
 
 				/* no need to fix targetlist and qual */
 				Assert(plan->qual == NIL);
@@ -2315,15 +2318,15 @@ set_join_references(PlannerInfo *root, Join *join, int rtoffset)
 										outer_itlist,
 										inner_itlist,
 										(Index) 0,
-										rtoffset,
-										NUM_EXEC_QUAL((Plan *) join));
+										rtoffset);
 
 		hj->hashqualclauses = fix_join_expr(root,
 											hj->hashqualclauses,
 											outer_itlist,
 											inner_itlist,
 											(Index) 0,
-											rtoffset);
+											rtoffset,
+											NUM_EXEC_QUAL((Plan *) join));
 		/*
 		 * HashJoin's hashkeys are used to look for matching tuples from its
 		 * outer plan (not the Hash node!) in the hashtable.

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1019,7 +1019,8 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 											   childplan_itlist, OUTER_VAR, rtoffset, 1);
 							pinfo->exec_pruning_steps = (List *)
 								fix_upper_expr(root, (Node *) pinfo->exec_pruning_steps,
-											   childplan_itlist, OUTER_VAR, rtoffset, 1);
+											   childplan_itlist, OUTER_VAR, rtoffset,
+											   NUM_EXEC_TLIST(plan));
 						}
 					}
 				}
@@ -1113,7 +1114,8 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 					                                             (Node *)dqaExpr->agg_filter,
 					                                             subplan_itlist,
 					                                             OUTER_VAR,
-					                                             rtoffset, 1);
+					                                             rtoffset,
+																 NUM_EXEC_TLIST(plan));
 
 					lfirst(lc) = dqaExpr;
 				}
@@ -1353,7 +1355,8 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 
 				motion->hashExprs = (List *)
 					fix_upper_expr(root, (Node*) motion->hashExprs,
-								   childplan_itlist,  OUTER_VAR, rtoffset, 1);
+								   childplan_itlist,  OUTER_VAR, rtoffset,
+								   NUM_EXEC_TLIST(plan));
 
 				/* no need to fix targetlist and qual */
 				Assert(plan->qual == NIL);

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -69,12 +69,9 @@ typedef struct
 	indexed_tlist *inner_itlist;
 	Index		acceptable_rel;
 	int			rtoffset;
-<<<<<<< HEAD
 	bool        use_outer_tlist_for_matching_nonvars;
 	bool        use_inner_tlist_for_matching_nonvars;
-=======
 	double		num_exec;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 } fix_join_expr_context;
 
 typedef struct
@@ -1137,7 +1134,6 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 				 * in GPDB, we allow the ROWS/RANGE expressions to contain
 				 * references to the subplan, so we have to use fix_upper_expr.
 				 */
-<<<<<<< HEAD
 				if (wplan->startOffset || wplan->endOffset)
 				{
 					subplan_itlist =
@@ -1145,18 +1141,12 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 
 					wplan->startOffset =
 						fix_upper_expr(root, wplan->startOffset,
-									   subplan_itlist, OUTER_VAR, rtoffset);
+									   subplan_itlist, OUTER_VAR, rtoffset, 1);
 					wplan->endOffset =
 						fix_upper_expr(root, wplan->endOffset,
-									   subplan_itlist, OUTER_VAR, rtoffset);
+									   subplan_itlist, OUTER_VAR, rtoffset, 1);
 					pfree(subplan_itlist);
 				}
-=======
-				wplan->startOffset =
-					fix_scan_expr(root, wplan->startOffset, rtoffset, 1);
-				wplan->endOffset =
-					fix_scan_expr(root, wplan->endOffset, rtoffset, 1);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 			}
 			break;
 		case T_Result:
@@ -1425,15 +1415,12 @@ set_indexonlyscan_references(PlannerInfo *root,
 					   INDEX_VAR,
 					   rtoffset,
 					   NUM_EXEC_QUAL((Plan *) plan));
-	/* indexqual is already transformed to reference index columns */
-<<<<<<< HEAD
-	plan->indexqual = fix_scan_list(root, plan->indexqual, rtoffset);
 	/* indexqualorig is already transformed to reference index columns */
-	plan->indexqualorig = fix_scan_list(root, plan->indexqualorig, rtoffset);
-=======
+	plan->indexqualorig = fix_scan_list(root, plan->indexqualorig,
+										rtoffset, 1);
+	/* indexqual is already transformed to reference index columns */
 	plan->indexqual = fix_scan_list(root, plan->indexqual,
 									rtoffset, 1);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	/* indexorderby is already transformed to reference index columns */
 	plan->indexorderby = fix_scan_list(root, plan->indexorderby,
 									   rtoffset, 1);
@@ -3047,13 +3034,10 @@ fix_join_expr(PlannerInfo *root,
 	context.inner_itlist = inner_itlist;
 	context.acceptable_rel = acceptable_rel;
 	context.rtoffset = rtoffset;
-<<<<<<< HEAD
 	context.use_outer_tlist_for_matching_nonvars = true;
 	context.use_inner_tlist_for_matching_nonvars = true;
-
-=======
 	context.num_exec = num_exec;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+
 	return (List *) fix_join_expr_mutator((Node *) clauses, &context);
 }
 


### PR DESCRIPTION
1) Commit 41efb83 in src/backend/optimizer/plan/setrefs.c added a new
field, num_exec, to the fix_join_expr_context structure. However, the
earlier commit 6b0e52b had already added the fields,
use_outer_tlist_for_matching_nonvars and
use_inner_tlist_for_matching_nonvars, to the same location.

2) Commit 41efb83 in src/backend/optimizer/plan/setrefs.c added the
num_exec argument to the initialization of the startOffset and
endOffset fields in the fix_scan_expr function call. However, earlier
GPDB-specific commits had already added GPDB-specific code to the same
location.

3) Commit 41efb83 in src/backend/optimizer/plan/setrefs.c added the
num_exec argument to the initialization of the indexqual field in the
set_indexonlyscan_references function when calling the fix_scan_list
macro. However, commit 598f4b0 had already added the initialization of
the indexqualorig field to the same location.

4) Commit 41efb83 in src/backend/optimizer/plan/setrefs.c added the
initialization of the num_exec field to the fix_join_expr function.
However, commit 6b0e52b had already added the initialization of the
use_outer_tlist_for_matching_nonvars and
use_inner_tlist_for_matching_nonvars fields to the same location.

5) Commit 41efb83 added a new num_exec argument to the fix_scan_list
macro in src/backend/optimizer/plan/setrefs.c. Add this in
GPDB-specific locations.

6) Commit 41efb83 added a new double num_exec argument to the
fix_upper_expr and fix_join_expr functions in
src/backend/optimizer/plan/setrefs.c. Add this in GPDB-specific
locations.