### PR TITLE
Resolve conflicts in src/backend/parser/gram.y

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -18871,6 +18871,7 @@ bare_label_keyword:
 			| ABSOLUTE_P
 			| ACCESS
 			| ACTION
+			| ACTIVE
 			| ADD_P
 			| ADMIN
 			| AFTER
@@ -18925,17 +18926,22 @@ bare_label_keyword:
 			| COMMENTS
 			| COMMIT
 			| COMMITTED
+			| CONCURRENCY
 			| CONCURRENTLY
 			| CONFIGURATION
 			| CONFLICT
 			| CONNECTION
 			| CONSTRAINT
 			| CONSTRAINTS
+			| CONTAINS
 			| CONTENT_P
 			| CONTINUE_P
 			| CONVERSION_P
 			| COPY
 			| COST
+			| CPUSET
+			| CPU_RATE_LIMIT
+			| CREATEEXTTABLE
 			| CROSS
 			| CSV
 			| CUBE
@@ -18981,9 +18987,12 @@ bare_label_keyword:
 			| ENCODING
 			| ENCRYPTED
 			| END_P
+			| ENDPOINT
 			| ENUM_P
+			| ERRORS
 			| ESCAPE
 			| EVENT
+			| EXCHANGE
 			| EXCLUDE
 			| EXCLUDING
 			| EXCLUSIVE
@@ -18996,6 +19005,8 @@ bare_label_keyword:
 			| EXTRACT
 			| FALSE_P
 			| FAMILY
+			| FIELDS
+			| FILL
 			| FIRST_P
 			| FLOAT_P
 			| FOLLOWING
@@ -19014,8 +19025,10 @@ bare_label_keyword:
 			| GROUPING
 			| GROUPS
 			| HANDLER
+			| HASH
 			| HEADER_P
 			| HOLD
+			| HOST
 			| IDENTITY_P
 			| IF_P
 			| ILIKE
@@ -19026,6 +19039,7 @@ bare_label_keyword:
 			| IN_P
 			| INCLUDE
 			| INCLUDING
+			| INCLUSIVE
 			| INCREMENT
 			| INDEX
 			| INDEXES
@@ -19058,6 +19072,7 @@ bare_label_keyword:
 			| LEFT
 			| LEVEL
 			| LIKE
+			| LIST
 			| LISTEN
 			| LOAD
 			| LOCAL
@@ -19066,14 +19081,22 @@ bare_label_keyword:
 			| LOCATION
 			| LOCK_P
 			| LOCKED
+			| LOG_P
 			| LOGGED
 			| MAPPING
+			| MASTER
 			| MATCH
 			| MATERIALIZED
 			| MAXVALUE
+			| MEDIAN
+			| MEMORY_LIMIT
+			| MEMORY_SHARED_QUOTA
+			| MEMORY_SPILL_RATIO
 			| METHOD
 			| MINVALUE
+			| MISSING
 			| MODE
+			| MODIFIES
 			| MOVE
 			| NAME_P
 			| NAMES
@@ -19081,13 +19104,16 @@ bare_label_keyword:
 			| NATURAL
 			| NCHAR
 			| NEW
+			| NEWLINE
 			| NEXT
 			| NFC
 			| NFD
 			| NFKC
 			| NFKD
 			| NO
+			| NOCREATEEXTTABLE
 			| NONE
+			| NOOVERCOMMIT
 			| NORMALIZE
 			| NORMALIZED
 			| NOT
@@ -19112,6 +19138,7 @@ bare_label_keyword:
 			| OTHERS
 			| OUT_P
 			| OUTER_P
+			| OVERCOMMIT
 			| OVERLAY
 			| OVERRIDING
 			| OWNED
@@ -19122,6 +19149,8 @@ bare_label_keyword:
 			| PARTITIONS
 			| PASSING
 			| PASSWORD
+			| PERCENT
+			| PERSISTENTLY
 			| PLACING
 			| PLANS
 			| POLICY
@@ -19137,10 +19166,15 @@ bare_label_keyword:
 			| PROCEDURE
 			| PROCEDURES
 			| PROGRAM
+			| PROTOCOL
 			| PUBLICATION
+			| QUEUE
 			| QUOTE
+			| RANDOMLY
 			| RANGE
 			| READ
+			| READABLE
+			| READS
 			| REAL
 			| REASSIGN
 			| RECHECK
@@ -19150,6 +19184,7 @@ bare_label_keyword:
 			| REFERENCING
 			| REFRESH
 			| REINDEX
+			| REJECT_P
 			| RELATIVE_P
 			| RELEASE
 			| RENAME
@@ -19157,8 +19192,10 @@ bare_label_keyword:
 			| REPLACE
 			| REPLICA
 			| RESET
+			| RESOURCE
 			| RESTART
 			| RESTRICT
+			| RETRIEVE
 			| RETURNS
 			| REVOKE
 			| RIGHT
@@ -19176,6 +19213,8 @@ bare_label_keyword:
 			| SCROLL
 			| SEARCH
 			| SECURITY
+			| SEGMENT
+			| SEGMENTS
 			| SELECT
 			| SEQUENCE
 			| SEQUENCES
@@ -19194,6 +19233,7 @@ bare_label_keyword:
 			| SMALLINT
 			| SNAPSHOT
 			| SOME
+			| SPLIT
 			| SQL_P
 			| STABLE
 			| STANDALONE_P
@@ -19206,6 +19246,7 @@ bare_label_keyword:
 			| STORED
 			| STRICT_P
 			| STRIP_P
+			| SUBPARTITION
 			| SUBSCRIPTION
 			| SUBSTRING
 			| SUPPORT
@@ -19221,6 +19262,7 @@ bare_label_keyword:
 			| TEMPORARY
 			| TEXT_P
 			| THEN
+			| THRESHOLD
 			| TIES
 			| TIME
 			| TIMESTAMP
@@ -19250,6 +19292,7 @@ bare_label_keyword:
 			| VACUUM
 			| VALID
 			| VALIDATE
+			| VALIDATION
 			| VALIDATOR
 			| VALUE_P
 			| VALUES
@@ -19260,10 +19303,12 @@ bare_label_keyword:
 			| VIEW
 			| VIEWS
 			| VOLATILE
+			| WEB
 			| WHEN
 			| WHITESPACE_P
 			| WORK
 			| WRAPPER
+			| WRITABLE
 			| WRITE
 			| XML_P
 			| XMLATTRIBUTES

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -17609,12 +17609,6 @@ target_el:	a_expr AS ColLabel
 			 * expression and a column label?  We prefer to resolve this
 			 * as an infix expression, which we accomplish by assigning
 			 * IDENT a precedence higher than POSTFIXOP.
-			 *
-			 * In GPDB, we extend this to allow most unreserved_keywords by
-			 * also assigning them a precedence.  There are certain keywords
-			 * that can't work without the as: reserved_keywords, the date
-			 * modifier suffixes (DAY, MONTH, YEAR, etc) and a few other
-			 * obscure cases.
 			 */
 			| a_expr BareColLabel
 				{

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -601,13 +601,9 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 %type <str>		RoleId opt_boolean_or_string
 %type <str>		QueueId
 %type <list>	var_list
-<<<<<<< HEAD
-%type <str>		ColId ColLabel ColLabelNoAs var_name type_function_name param_name
+%type <str>		ColId ColLabel ColLabelNoAs BareColLabel
 %type <keyword> PartitionIdentKeyword	
 %type <str>		PartitionColId
-=======
-%type <str>		ColId ColLabel BareColLabel
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 %type <str>		NonReservedWord NonReservedWord_or_Sconst
 %type <str>		var_name type_function_name param_name
 %type <str>		createdb_opt_name
@@ -616,11 +612,8 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 
 %type <keyword> unreserved_keyword type_func_name_keyword
 %type <keyword> col_name_keyword reserved_keyword
-<<<<<<< HEAD
 %type <keyword> keywords_ok_in_alias_no_as
-=======
 %type <keyword> bare_label_keyword
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 %type <node>	TableConstraint TableLikeClause
 %type <ival>	TableLikeOptionList TableLikeOption
@@ -917,9 +910,8 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
  * rather than reducing a conflicting rule that takes CUBE as a function name.
  * Using the same precedence as IDENT seems right for the reasons given above.
  */
-<<<<<<< HEAD
-%nonassoc	UNBOUNDED		/* ideally should have same precedence as IDENT */
-%nonassoc	IDENT GENERATED NULL_P PARTITION RANGE ROWS GROUPS PRECEDING FOLLOWING CUBE ROLLUP
+%nonassoc	UNBOUNDED		/* ideally would have same precedence as IDENT */
+%nonassoc	IDENT PARTITION RANGE ROWS GROUPS PRECEDING FOLLOWING CUBE ROLLUP
 
 /*
  * This is a bit ugly... To allow these to be column aliases without
@@ -1227,10 +1219,6 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc UNKNOWN
 			%nonassoc ZONE
 
-=======
-%nonassoc	UNBOUNDED		/* ideally would have same precedence as IDENT */
-%nonassoc	IDENT PARTITION RANGE ROWS GROUPS PRECEDING FOLLOWING CUBE ROLLUP
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 %left		Op OPERATOR		/* multi-character ops and user-defined operators */
 %left		'+' '-'
 %left		'*' '/' '%'
@@ -10825,17 +10813,12 @@ ReindexStmt:
 					n->relation = $4;
 					n->name = NULL;
 					n->options = 0;
-<<<<<<< HEAD
 
-					if (n->concurrent)
+					if ($3)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("REINDEX CONCURRENTLY is not supported")));
 
-=======
-					if ($3)
-						n->options |= REINDEXOPT_CONCURRENTLY;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 					$$ = (Node *)n;
 				}
 			| REINDEX reindex_target_multitable opt_concurrently name
@@ -10845,17 +10828,12 @@ ReindexStmt:
 					n->name = $4;
 					n->relation = NULL;
 					n->options = 0;
-<<<<<<< HEAD
 
-					if (n->concurrent)
+					if ($3)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("REINDEX CONCURRENTLY is not supported")));
 
-=======
-					if ($3)
-						n->options |= REINDEXOPT_CONCURRENTLY;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 					$$ = (Node *)n;
 				}
 			| REINDEX '(' reindex_option_list ')' reindex_target_type opt_concurrently qualified_name
@@ -10865,17 +10843,12 @@ ReindexStmt:
 					n->relation = $7;
 					n->name = NULL;
 					n->options = $3;
-<<<<<<< HEAD
 
-					if (n->concurrent)
+					if ($6)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("REINDEX CONCURRENTLY is not supported")));
 
-=======
-					if ($6)
-						n->options |= REINDEXOPT_CONCURRENTLY;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 					$$ = (Node *)n;
 				}
 			| REINDEX '(' reindex_option_list ')' reindex_target_multitable opt_concurrently name
@@ -10885,17 +10858,12 @@ ReindexStmt:
 					n->name = $7;
 					n->relation = NULL;
 					n->options = $3;
-<<<<<<< HEAD
 
-					if (n->concurrent)
+					if ($6)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("REINDEX CONCURRENTLY is not supported")));
 
-=======
-					if ($6)
-						n->options |= REINDEXOPT_CONCURRENTLY;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 					$$ = (Node *)n;
 				}
 		;
@@ -17635,7 +17603,6 @@ target_el:	a_expr AS ColLabel
 					$$->val = (Node *)$1;
 					$$->location = @1;
 				}
-<<<<<<< HEAD
 			/*
 			 * Postgres supports omitting AS only for column labels that aren't
 			 * any known keyword.  There is an ambiguity against postfix
@@ -17650,10 +17617,7 @@ target_el:	a_expr AS ColLabel
 			 * modifier suffixes (DAY, MONTH, YEAR, etc) and a few other
 			 * obscure cases.
 			 */
-			| a_expr IDENT
-=======
 			| a_expr BareColLabel
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 				{
 					$$ = makeNode(ResTarget);
 					$$->name = $2;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -601,7 +601,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 %type <str>		RoleId opt_boolean_or_string
 %type <str>		QueueId
 %type <list>	var_list
-%type <str>		ColId ColLabel ColLabelNoAs BareColLabel
+%type <str>		ColId ColLabel BareColLabel
 %type <keyword> PartitionIdentKeyword	
 %type <str>		PartitionColId
 %type <str>		NonReservedWord NonReservedWord_or_Sconst
@@ -612,7 +612,6 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 
 %type <keyword> unreserved_keyword type_func_name_keyword
 %type <keyword> col_name_keyword reserved_keyword
-%type <keyword> keywords_ok_in_alias_no_as
 %type <keyword> bare_label_keyword
 
 %type <node>	TableConstraint TableLikeClause
@@ -17625,14 +17624,6 @@ target_el:	a_expr AS ColLabel
 					$$->val = (Node *)$1;
 					$$->location = @1;
 				}
-			| a_expr ColLabelNoAs
-				{
-					$$ = makeNode(ResTarget);
-					$$->name = $2;
-					$$->indirection = NIL;
-					$$->val = (Node *)$1;
-					$$->location = @1;
-				}
 			| a_expr
 				{
 					$$ = makeNode(ResTarget);
@@ -18384,16 +18375,6 @@ unreserved_keyword:
  * the grammar.
  */
 
-ColLabelNoAs:   keywords_ok_in_alias_no_as   { $$=pstrdup($1); }
-				;
-
-keywords_ok_in_alias_no_as: PartitionIdentKeyword
-			| TABLESPACE
-			| ADD_P
-			| ALTER
-			| AT
-			;
-
 PartitionColId: PartitionIdentKeyword { $$ = pstrdup($1); }
 			| IDENT { $$ = pstrdup($1); }
 			;
@@ -19020,6 +19001,7 @@ bare_label_keyword:
 			| FOLLOWING
 			| FORCE
 			| FOREIGN
+			| FORMAT
 			| FORWARD
 			| FREEZE
 			| FULL
@@ -19137,7 +19119,7 @@ bare_label_keyword:
 			| PARALLEL
 			| PARSER
 			| PARTIAL
-			| PARTITION
+			| PARTITIONS
 			| PASSING
 			| PASSWORD
 			| PLACING


### PR DESCRIPTION
1) Commit 06a7c31 in the file src/backend/parser/gram.y replaced
var_name type_function_name param_name with BareColLabel, while the
earlier commit 9b88bed had already added ColLabelNoAs in the same
place.

2) Commit 06a7c31 in the file src/backend/parser/gram.y added a new
definition of bare_label_keyword, while the earlier commit 6b0e52b
already added the definition of keywords_ok_in_alias_no_as in the same
place.

3) Commit 28a61fc in the file src/backend/parser/gram.y replaced the
comment in the UNBOUNDED definition and removed GENERATED NULL_P from
the IDENT definition, while the earlier commit 6b0e52b had already
added many GPDB-specific definitions below in the same place.

4) Commit 844c05a in the file src/backend/parser/gram.y replaced the
initialization of the concurrent field with the conditional setting of
the REINDEXOPT_CONCURRENTLY option, while the early commit 19cd1cf
already began to generate an error about the non-support of this
functionality in the GPDB.

5) Commit 06a7c31 in the file src/backend/parser/gram.y replaced a_expr
IDENT with a_expr BareColLabel, while the earlier commit 6b0e52b had
already added a large comment before this place.

6) Remove GPDB-specific ColLabelNoAs and keywords_ok_in_alias_no_as.