### PR TITLE
Resolve conflicts in src/backend/parser/parse_utilcmd.c

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -97,11 +97,7 @@ typedef struct
 	List	   *ckconstraints;	/* CHECK constraints */
 	List	   *fkconstraints;	/* FOREIGN KEY constraints */
 	List	   *ixconstraints;	/* index-creating constraints */
-<<<<<<< HEAD
 	List	   *attr_encodings; /* List of ColumnReferenceStorageDirectives */
-	List	   *inh_indexes;	/* cloned indexes from INCLUDING INDEXES */
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	List	   *extstats;		/* cloned extended statistics */
 	List	   *blist;			/* "before list" of things to do before
 								 * creating the table */
@@ -451,11 +447,8 @@ generateSerialExtraStmts(CreateStmtContext *cxt, ColumnDef *column,
 	CreateSeqStmt *seqstmt;
 	AlterSeqStmt *altseqstmt;
 	List	   *attnamelist;
-<<<<<<< HEAD
 	bool		has_cache_option = false;
-=======
 	int			nameEl_idx = -1;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 	/*
 	 * Determine namespace and name to use for the sequence.
@@ -1027,18 +1020,13 @@ transformTableConstraint(CreateStmtContext *cxt, Constraint *constraint)
  * transformTableLikeClause
  *
  * Change the LIKE <srctable> portion of a CREATE TABLE statement into
-<<<<<<< HEAD
- * column definitions which recreate the user defined column portions of
- * <srctable>.
- *
- * GPDB: if forceBareCol is true we disallow inheriting any indexes/constr/defaults.
-=======
  * column definitions that recreate the user defined column portions of
  * <srctable>.  Also, if there are any LIKE options that we can't fully
  * process at this point, add the TableLikeClause to cxt->alist, which
  * will cause utility.c to call expandTableLikeClause() after the new
  * table has been created.
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+ *
+ * GPDB: if forceBareCol is true we disallow inheriting any indexes/constr/defaults.
  */
 static void
 transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_clause,
@@ -1219,51 +1207,6 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 		cxt->alist = lappend(cxt->alist, table_like_clause);
 
 	/*
-<<<<<<< HEAD
-	 * Likewise, copy indexes if requested
-	 */
-	if ((table_like_clause->options & CREATE_TABLE_LIKE_INDEXES) &&
-		relation->rd_rel->relhasindex)
-	{
-		List	   *parent_indexes;
-		ListCell   *l;
-
-		parent_indexes = RelationGetIndexList(relation);
-
-		foreach(l, parent_indexes)
-		{
-			Oid			parent_index_oid = lfirst_oid(l);
-			Relation	parent_index;
-			IndexStmt  *index_stmt;
-
-			parent_index = index_open(parent_index_oid, AccessShareLock);
-
-			/* Build CREATE INDEX statement to recreate the parent_index */
-			index_stmt = generateClonedIndexStmt(cxt->relation,
-												 parent_index,
-												 attmap,
-												 NULL);
-
-			/* Copy comment on index, if requested */
-			if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
-			{
-				comment = GetComment(parent_index_oid, RelationRelationId, 0);
-
-				/*
-				 * We make use of IndexStmt's idxcomment option, so as not to
-				 * need to know now what name the index will have.
-				 */
-				index_stmt->idxcomment = comment;
-			}
-
-			/* Save it in the inh_indexes list for the time being */
-			cxt->inh_indexes = lappend(cxt->inh_indexes, index_stmt);
-
-			index_close(parent_index, AccessShareLock);
-		}
-	}
-
-	/*
 	 * GPDB_12_MERGE_FIXME:
 	 * 		This is wrong and creates unspecified behaviour when multiple like
 	 * 		clauses are present in the statement.
@@ -1317,11 +1260,8 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 	}
 
 	/*
-	 * Likewise, copy extended statistics if requested
-=======
 	 * We may copy extended statistics if requested, since the representation
 	 * of CreateStatsStmt doesn't depend on column numbers.
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	 */
 	if (table_like_clause->options & CREATE_TABLE_LIKE_STATISTICS)
 	{
@@ -4366,11 +4306,7 @@ transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 	cxt.ckconstraints = NIL;
 	cxt.fkconstraints = NIL;
 	cxt.ixconstraints = NIL;
-<<<<<<< HEAD
-	cxt.inh_indexes = NIL;
 	cxt.attr_encodings = NIL;
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	cxt.extstats = NIL;
 	cxt.blist = NIL;
 	cxt.alist = NIL;


### PR DESCRIPTION
1) Commit 5028981 in src/backend/parser/parse_utilcmd.c removed the
inh_indexes field in the CreateStmtContext structure, while earlier
commit 391b78e had already added the attr_encodings field in the same
location.

2) Commit e7c2b95 in src/backend/parser/parse_utilcmd.c added a new
local variable, nameEl_idx, in the generateSerialExtraStmts function,
while earlier commit 19cd1cf had added the local variable,
has_cache_option, in the same location.

3) Commit 5028981 in src/backend/parser/parse_utilcmd.c changed the
comment before the transformTableLikeClause function, while earlier
commit 598f4b0 had already added a GPDB-specific comment at this
location.

4) Commit 5028981 in src/backend/parser/parse_utilcmd.c moved some code
in the transformTableLikeClause function to the new
expandTableLikeClause function, while earlier GPDB-specific commits had
already added handling for the CREATE_TABLE_LIKE_STORAGE option. A
further modification to the CREATE_TABLE_LIKE_STORAGE option will be
made in commit 2e7e4d6.

5) Commit 5028981 in src/backend/parser/parse_utilcmd.c in the
transformAlterTableStmt function removed the initialization of the
inh_indexes field, while the earlier commit 391b78e had already added
the initialization of the attr_encodings field in the same place.