### PR TITLE
Resolve conflicts in src/backend/postmaster/bgwriter.c

### DIFF
--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -107,11 +107,7 @@ BackgroundWriterMain(void)
 	pqsignal(SIGHUP, SignalHandlerForConfigReload);
 	pqsignal(SIGINT, SIG_IGN);
 	pqsignal(SIGTERM, SignalHandlerForShutdownRequest);
-<<<<<<< HEAD
 	pqsignal(SIGQUIT, bg_quickdie);
-=======
-	/* SIGQUIT handler was already set up by InitPostmasterChild */
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	pqsignal(SIGALRM, SIG_IGN);
 	pqsignal(SIGPIPE, SIG_IGN);
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);


### PR DESCRIPTION
Commit 44fc6e2 in src/backend/postmaster/bgwriter.c in the
BackgroundWriterMain function removed the SIGQUIT signal setting and
added a corresponding comment. However, an earlier commit, 89f85cc, had
already changed this signal setting from SignalHandlerForCrashExit to
bg_quickdie, which is needed for the
fault_in_background_writer_quickdie default injector in the
fts_segment_reset test.