### PR TITLE
Resolve conflicts in src/backend/replication/syncrep.c

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -160,8 +160,6 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	const char *old_status;
 	int			mode;
 
-<<<<<<< HEAD
-=======
 	/*
 	 * This should be called while holding interrupts during a transaction
 	 * commit to prevent the follow-up shared memory queue cleanups to be
@@ -187,27 +185,17 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 		!((volatile WalSndCtlData *) WalSndCtl)->sync_standbys_defined)
 		return;
 
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	/* Cap the level for anything other than commit to remote flush only. */
 	if (commit)
 		mode = SyncRepWaitMode;
 	else
 		mode = Min(SyncRepWaitMode, SYNC_REP_WAIT_FLUSH);
 
-<<<<<<< HEAD
 	Assert(!am_walsender);
 	elogif(debug_walrepl_syncrep, LOG,
 			"syncrep wait -- This backend's commit LSN for syncrep is %X/%X.",
 		   (uint32) (lsn >> 32), (uint32) lsn);
 
-	/*
-	 * Fast exit if user has not requested sync replication.
-	 */
-	if (!SyncRepRequested())
-		return;
-
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	Assert(SHMQueueIsDetached(&(MyProc->syncRepLinks)));
 	Assert(WalSndCtl != NULL);
 

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -161,13 +161,6 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	int			mode;
 
 	/*
-	 * This should be called while holding interrupts during a transaction
-	 * commit to prevent the follow-up shared memory queue cleanups to be
-	 * influenced by external interruptions.
-	 */
-	Assert(InterruptHoldoffCount > 0);
-
-	/*
 	 * Fast exit if user has not requested sync replication, or there are no
 	 * sync replication standby names defined.
 	 *


### PR DESCRIPTION
Commit be9788e in src/backend/replication/syncrep.c in the
SyncRepWaitForLSN function moved the conditional return higher, adding
additional conditions and a large comment. Commit e174f69 added an
InterruptHoldoffCount assertion before it. However, the earlier commit
6b0e52b had already added a debug log in the same location, and commit
33a6433 added an assertion before it, and commit bdb1ea1 removed
InterruptHoldoffCount assertion.