### PR TITLE
Resolve conflicts in src/backend/storage/ipc/procarray.c

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4926,14 +4926,10 @@ GlobalVisUpdateApply(ComputeXidHorizonsResult *horizons)
 						  GetDistOldestXmin(horizons->catalog_oldest_nonremovable));
 	GlobalVisDataRels.maybe_needed =
 		FullXidRelativeTo(horizons->latest_completed,
-<<<<<<< HEAD
 						  GetDistOldestXmin(horizons->data_oldest_nonremovable));
-=======
-						  horizons->data_oldest_nonremovable);
 	GlobalVisTempRels.maybe_needed =
 		FullXidRelativeTo(horizons->latest_completed,
-						  horizons->temp_oldest_nonremovable);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+						  GetDistOldestXmin(horizons->temp_oldest_nonremovable));
 
 	/*
 	 * In longer running transactions it's possible that transactions we


### PR DESCRIPTION
Commit 94bc27b in src/backend/storage/ipc/procarray.c added the
maybe_needed field setting to the GlobalVisTempRels variable in the
GlobalVisUpdateApply function. However, an earlier commit, 0a5cc3f, had
already added a call to the GetDistOldestXmin function as an argument
to the FullXidRelativeTo function call above.