### PR TITLE
Resolve conflicts in dbsize.c and numeric.c

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -879,12 +879,7 @@ numeric_shift_right(Numeric n, unsigned count)
 	Datum		divisor_numeric;
 	Datum		result;
 
-<<<<<<< HEAD
-	divisor_int64 = Int64GetDatum((int64) (1LL << count));
-	divisor_numeric = DirectFunctionCall1(int8_numeric, divisor_int64);
-=======
 	divisor_numeric = NumericGetDatum(int64_to_numeric(((int64) 1) << count));
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	result = DirectFunctionCall2(numeric_div_trunc, d, divisor_numeric);
 	return DatumGetNumeric(result);
 }

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -484,7 +484,6 @@ static void dump_var(const char *str, NumericVar *var);
 		(v)->neg_digits = NULL; 	\
 	} while (0)
 
-<<<<<<< HEAD
 #define quick_init_var(v) \
 	do { \
 		(v)->buf = (v)->ndb;	\
@@ -530,9 +529,6 @@ static void dump_var(const char *str, NumericVar *var);
 		(v)->buf[0] = 0;	\
 		(v)->digits = (v)->buf + 1;	\
 	} while (0)
-=======
-#define init_var(v)		memset(v, 0, sizeof(NumericVar))
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 #define NUMERIC_DIGITS(num) (NUMERIC_HEADER_IS_SHORT(num) ? \
 	(num)->choice.n_short.n_data : (num)->choice.n_long.n_data)
@@ -4526,19 +4522,7 @@ int8_numeric(PG_FUNCTION_ARGS)
 {
 	int64		val = PG_GETARG_INT64(0);
 
-<<<<<<< HEAD
-	quick_init_var(&result);
-
-	int64_to_numericvar(val, &result);
-
-	res = make_result(&result);
-
-	free_var(&result);
-
-	PG_RETURN_NUMERIC(res);
-=======
 	PG_RETURN_NUMERIC(int64_to_numeric(val));
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 }
 
 
@@ -4578,19 +4562,7 @@ int2_numeric(PG_FUNCTION_ARGS)
 {
 	int16		val = PG_GETARG_INT16(0);
 
-<<<<<<< HEAD
-	quick_init_var(&result);
-
-	int64_to_numericvar((int64) val, &result);
-
-	res = make_result(&result);
-
-	free_var(&result);
-
-	PG_RETURN_NUMERIC(res);
-=======
 	PG_RETURN_NUMERIC(int64_to_numeric(val));
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 }
 
 


### PR DESCRIPTION
1) Commit 0aa8f76 in src/backend/utils/adt/dbsize.c in the
numeric_shift_right function replaced DirectFunctionCall1 int8_numeric
with NumericGetDatum int64_to_numeric, while earlier commit 3e39d45 had
already replaced 1 with 1LL above this point.

2) Commit 3438c98 in src/backend/utils/adt/numeric.c in the init_var
macro replaced the call to the MemSetAligned function with memset,
while earlier commit 6b0e52b had already optimized this init_var macro
differently.

3) Commit 0aa8f76 in src/backend/utils/adt/numeric.c in the
int2_numeric function simplified the content, while the earlier commit
6b0e52b had already replaced the init_var macro call with
quick_init_var in the same location.

4) Commit 0aa8f76 in src/backend/utils/adt/numeric.c in the
int8_numeric function simplified the content, while the earlier commit
6b0e52b had already replaced the init_var macro call with
quick_init_var in the same location.