### PR TITLE
Resolve conflicts in src/backend/utils/init/miscinit.c

### DIFF
--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -37,11 +37,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "postmaster/autovacuum.h"
-<<<<<<< HEAD
-#include "postmaster/fts.h"
-=======
 #include "postmaster/interrupt.h"
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 #include "postmaster/postmaster.h"
 #include "postmaster/startup.h"
 #include "replication/walsender.h"
@@ -53,8 +49,6 @@
 #include "storage/proc.h"
 #include "storage/procarray.h"
 #include "utils/builtins.h"
-#include "utils/faultinjector.h"
-#include "utils/gdd.h"
 #include "utils/guc.h"
 #include "utils/inval.h"
 #include "utils/memutils.h"
@@ -63,6 +57,9 @@
 #include "utils/varlena.h"
 
 #include "cdb/cdbvars.h"
+#include "postmaster/fts.h"
+#include "utils/faultinjector.h"
+#include "utils/gdd.h"
 #include "utils/resgroup.h"
 #include "utils/resource_manager.h"
 #include "utils/resscheduler.h"


### PR DESCRIPTION
Commit 44fc6e2 added a new include postmaster/interrupt.h to
src/backend/utils/init/miscinit.c, while earlier commit 4d9c789 had
already added a GPDB-specific include postmaster/fts.h in the same
location. Move the GPDB-specific includes below separately.