### PR TITLE
Resolve conflicts in src/bin/pg_dump/dumputils.h

### DIFF
--- a/src/bin/pg_dump/dumputils.h
+++ b/src/bin/pg_dump/dumputils.h
@@ -44,12 +44,9 @@ extern bool buildDefaultACLCommands(const char *type, const char *nspname,
 									const char *owner,
 									int remoteVersion,
 									PQExpBuffer sql);
-<<<<<<< HEAD
 
 extern void quoteAclUserName(PQExpBuffer output, const char *input);
 
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 extern void buildShSecLabelQuery(const char *catalog_name,
 								 Oid objectId, PQExpBuffer sql);
 extern void emitShSecLabels(PGconn *conn, PGresult *res,


### PR DESCRIPTION
Commit 8354e7b in src/bin/pg_dump/dumputils.h removed the first
argument, PGconn *conn, from the definition of the buildShSecLabelQuery
function. However, earlier commit 1c56023 had already added the
definition of the new quoteAclUserName function above.