### PR TITLE
Resolve conflicts in pg_backup.h, pg_backup_db.c, and pg_backup_archiver.c

### DIFF
--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -61,7 +61,6 @@ typedef enum _teSection
 	SECTION_POST_DATA			/* stuff to be processed after data */
 } teSection;
 
-<<<<<<< HEAD
 /* We need one enum entry per prepared query in pg_dump */
 enum _dumpPreparedQueries
 {
@@ -79,8 +78,6 @@ enum _dumpPreparedQueries
 	NUM_PREP_QUERIES			/* must be last */
 };
 
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 /* Parameters needed by ConnectDatabase; same for dump and restore */
 typedef struct _connParams
 {
@@ -204,14 +201,11 @@ typedef struct _dumpOptions
 
 	int			sequence_data;	/* dump sequence data even in schema-only mode */
 	int			do_nothing;
-<<<<<<< HEAD
+	int			coll_unknown;
 
 	/* GPDB */
 	bool		dumpGpPolicy;
 	bool		isGPbackend;
-=======
-	int			coll_unknown;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 } DumpOptions;
 
 /*
@@ -294,19 +288,10 @@ typedef void (*SetupWorkerPtrType) (Archive *AH);
  * Main archiver interface.
  */
 
-<<<<<<< HEAD
-extern void ConnectDatabase(Archive *AH,
-							const char *dbname,
-							const char *pghost,
-							const char *pgport,
-							const char *username,
-							trivalue prompt_password,
-							bool binary_upgrade);
-=======
 extern void ConnectDatabase(Archive *AHX,
 							const ConnParams *cparams,
-							bool isReconnect);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+							bool isReconnect,
+							bool binary_upgrade);
 extern void DisconnectDatabase(Archive *AHX);
 extern PGconn *GetConnection(Archive *AHX);
 

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -416,14 +416,7 @@ RestoreArchive(Archive *AHX)
 		AHX->minRemoteVersion = 0;
 		AHX->maxRemoteVersion = 9999999;
 
-<<<<<<< HEAD
-		ConnectDatabase(AHX, ropt->dbname,
-						ropt->pghost, ropt->pgport, ropt->username,
-						ropt->promptPassword,
-						false);
-=======
-		ConnectDatabase(AHX, &ropt->cparams, false);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+		ConnectDatabase(AHX, &ropt->cparams, false, false);
 
 		/*
 		 * If we're talking to the DB directly, don't send comments since they
@@ -4241,14 +4234,7 @@ restore_toc_entries_postfork(ArchiveHandle *AH, TocEntry *pending_list)
 	/*
 	 * Now reconnect the single parent connection.
 	 */
-<<<<<<< HEAD
-	ConnectDatabase((Archive *) AH, ropt->dbname,
-					ropt->pghost, ropt->pgport, ropt->username,
-					ropt->promptPassword,
-					false);
-=======
-	ConnectDatabase((Archive *) AH, &ropt->cparams, true);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+	ConnectDatabase((Archive *) AH, &ropt->cparams, true, false);
 
 	/* re-establish fixed state */
 	_doSetFixedOutputState(AH);
@@ -4913,57 +4899,13 @@ CloneArchive(ArchiveHandle *AH)
 	 * Connect our new clone object to the database, using the same connection
 	 * parameters used for the original connection.
 	 */
-	ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true);
+	ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true,
+					false);
 
 	/* re-establish fixed state */
 	if (AH->mode == archModeRead)
-<<<<<<< HEAD
-	{
-		RestoreOptions *ropt = AH->public.ropt;
-
-		Assert(AH->connection == NULL);
-
-		/* this also sets clone->connection */
-		ConnectDatabase((Archive *) clone, ropt->dbname,
-						ropt->pghost, ropt->pgport, ropt->username,
-						ropt->promptPassword, false);
-
-		/* re-establish fixed state */
-		_doSetFixedOutputState(clone);
-	}
-	else
-	{
-		PQExpBufferData connstr;
-		char	   *pghost;
-		char	   *pgport;
-		char	   *username;
-
-		Assert(AH->connection != NULL);
-
-		/*
-		 * Even though we are technically accessing the parent's database
-		 * object here, these functions are fine to be called like that
-		 * because all just return a pointer and do not actually send/receive
-		 * any data to/from the database.
-		 */
-		initPQExpBuffer(&connstr);
-		appendPQExpBufferStr(&connstr, "dbname=");
-		appendConnStrVal(&connstr, PQdb(AH->connection));
-		pghost = PQhost(AH->connection);
-		pgport = PQport(AH->connection);
-		username = PQuser(AH->connection);
-
-		/* this also sets clone->connection */
-		ConnectDatabase((Archive *) clone, connstr.data,
-						pghost, pgport, username, TRI_NO, false);
-
-		termPQExpBuffer(&connstr);
-		/* setupDumpWorker will fix up connection state */
-	}
-=======
 		_doSetFixedOutputState(clone);
 	/* in write case, setupDumpWorker will fix up connection state */
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 	/* Let the format-specific code have a chance too */
 	clone->ClonePtr(clone);

--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -27,12 +27,7 @@
 #include "pg_backup_utils.h"
 
 static void _check_database_version(ArchiveHandle *AH);
-<<<<<<< HEAD
-static PGconn *_connectDB(ArchiveHandle *AH, const char *newdbname, const char *newUser);
 static void notice_processor(void *arg pg_attribute_unused(), const char *message);
-=======
-static void notice_processor(void *arg, const char *message);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 static void
 _check_database_version(ArchiveHandle *AH)
@@ -117,17 +112,9 @@ ReconnectToServer(ArchiveHandle *AH, const char *dbname)
  */
 void
 ConnectDatabase(Archive *AHX,
-<<<<<<< HEAD
-				const char *dbname,
-				const char *pghost,
-				const char *pgport,
-				const char *username,
-				trivalue prompt_password,
-				bool binary_upgrade)
-=======
 				const ConnParams *cparams,
-				bool isReconnect)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+				bool isReconnect,
+				bool binary_upgrade)
 {
 	ArchiveHandle *AH = (ArchiveHandle *) AHX;
 	trivalue	prompt_password;
@@ -149,28 +136,10 @@ ConnectDatabase(Archive *AHX,
 	 * Start the connection.  Loop until we have a password if requested by
 	 * backend.
 	 */
-	const char *keywords[8];
-	const char *values[8];
+	const char *keywords[9];
+	const char *values[9];
 	do
 	{
-<<<<<<< HEAD
-		keywords[0] = "host";
-		values[0] = pghost;
-		keywords[1] = "port";
-		values[1] = pgport;
-		keywords[2] = "user";
-		values[2] = username;
-		keywords[3] = "password";
-		values[3] = password;
-		keywords[4] = "dbname";
-		values[4] = dbname;
-		keywords[5] = "fallback_application_name";
-		values[5] = progname;
-		keywords[6] = NULL;
-		values[6] = NULL;
-=======
-		const char *keywords[8];
-		const char *values[8];
 		int			i = 0;
 
 		/*
@@ -198,7 +167,6 @@ ConnectDatabase(Archive *AHX,
 		keywords[i] = NULL;
 		values[i++] = NULL;
 		Assert(i <= lengthof(keywords));
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 		new_pass = false;
 		AH->connection = PQconnectdbParams(keywords, values, true);
@@ -259,11 +227,11 @@ ConnectDatabase(Archive *AHX,
 	 */
 	if (binary_upgrade)
 	{
-		keywords[6] = "options";
-		values[6] = AH->public.remoteVersion < GPDB7_MAJOR_PGVERSION ?
+		keywords[7] = "options";
+		values[7] = AH->public.remoteVersion < GPDB7_MAJOR_PGVERSION ?
 								"-c gp_session_role=utility" : "-c gp_role=utility";
-		keywords[7] = NULL;
-		values[7] = NULL;
+		keywords[8] = NULL;
+		values[8] = NULL;
 		AH->connection = PQconnectdbParams(keywords, values, true);
 	}
 	PQsetNoticeProcessor(AH->connection, notice_processor, NULL);

--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -94,7 +94,7 @@ ReconnectToServer(ArchiveHandle *AH, const char *dbname)
 	 */
 	AH->connection = NULL;		/* dodge error check in ConnectDatabase */
 
-	ConnectDatabase((Archive *) AH, &ropt->cparams, true);
+	ConnectDatabase((Archive *) AH, &ropt->cparams, true, false);
 
 	PQfinish(oldConn);
 }


### PR DESCRIPTION
1) Commit a45bc8a in src/bin/pg_dump/pg_backup.h added the definition
of the new ConnParams structure, while earlier commit 3040b44 had
already done the same, adding the definition of the new
_dumpPreparedQueries enumeration above.

2) Commit a45bc8a in src/bin/pg_dump/pg_backup.h changed the arguments
in the ConnectDatabase function definition, while earlier commit
19cd1cf had already added the new bool binary_upgrade argument.

3) Commit 257836a added a new field, coll_unknown, to the DumpOptions
structure in src/bin/pg_dump/pg_backup.h, while an earlier commit,
77cd915, had already added the GPDB-specific fields, dumpGpPolicy and
isGPbackend, in the same location.

4) Commit a45bc8a removed the declaration of the _connectDB function in
src/bin/pg_dump/pg_backup_db.c, while an earlier commit, 8ae22d1,
had already added pg_attribute_unused to the notice_processor function
argument below.

5) Commit a45bc8a in src/bin/pg_dump/pg_backup_db.c refactored the
code, including arguments, in the ConnectDatabase function. However,
the earlier commit 19cd1cf had already added the new bool
binary_upgrade argument and its handling.

6) Commit a45bc8a in src/bin/pg_dump/pg_backup_archiver.c in the
RestoreArchive function changed the call to the ConnectDatabase
function. However, the earlier commit 19cd1cf had already added the new
bool binary_upgrade argument to the ConnectDatabase function.

7) Commit a45bc8a in src/bin/pg_dump/pg_backup_archiver.c changed the
call to the ConnectDatabase function in the
restore_toc_entries_postfork function, while the earlier commit 19cd1cf
had already added a new bool binary_upgrade argument to the
ConnectDatabase function.

8) Commit a45bc8a in src/bin/pg_dump/pg_backup_archiver.c simplified
the code in the CloneArchive function, while the earlier commit 19cd1cf
had already added a new bool binary_upgrade argument to the
ConnectDatabase function.