### PR TITLE
Resolve conflicts in src/bin/pg_rewind/filemap.h

### DIFF
--- a/src/bin/pg_rewind/filemap.h
+++ b/src/bin/pg_rewind/filemap.h
@@ -12,18 +12,6 @@
 #include "storage/block.h"
 #include "storage/relfilenode.h"
 
-<<<<<<< HEAD
-/*
- * For every file found in the local or remote system, we have a file entry
- * that contains information about the file on both systems.  For relation
- * files, there is also a page map that marks pages in the file that were
- * changed in the target after the last common checkpoint.  Each entry also
- * contains an 'action' field, which says what we are going to do with the
- * file.
- */
-
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 /* these enum values are sorted in the order we want actions to be processed */
 typedef enum
 {
@@ -61,13 +49,9 @@ typedef enum
  */
 typedef struct file_entry_t
 {
-<<<<<<< HEAD
-	char	   *path;
-=======
 	uint32		status;			/* hash status */
 
 	const char *path;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	bool		isrelfile;		/* is it a relation data file? */
 
 	/*
@@ -83,7 +67,6 @@ typedef struct file_entry_t
 	 * source.
 	 */
 	datapagemap_t target_pages_to_overwrite;
-<<<<<<< HEAD
 
 	/*
 	 * Status of the file in the source.
@@ -92,28 +75,13 @@ typedef struct file_entry_t
 	file_type_t source_type;
 	size_t		source_size;
 	char	   *source_link_target; /* for a symlink */
+
+	/*
+	 * What will we do to the file?
+	 */
+	file_action_t action;
 
 	bool 		is_gp_tablespace;
-
-	/*
-	 * What will we do to the file?
-	 */
-	file_action_t action;
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
-
-	/*
-	 * Status of the file in the source.
-	 */
-	bool		source_exists;
-	file_type_t source_type;
-	size_t		source_size;
-	char	   *source_link_target; /* for a symlink */
-
-	/*
-	 * What will we do to the file?
-	 */
-	file_action_t action;
 } file_entry_t;
 
 /*
@@ -127,26 +95,8 @@ typedef struct filemap_t
 	uint64		total_size;		/* total size of the source cluster */
 	uint64		fetch_size;		/* number of bytes that needs to be copied */
 
-<<<<<<< HEAD
-	/*
-	 * After processing all the remote files, the entries in the linked list
-	 * are moved to this array. After processing local files, too, all the
-	 * local entries are added to the array by decide_file_actions(), and
-	 * sorted in the final order. After decide_file_actions(), all the entries
-	 * are in the array, and the linked list is empty.
-	 */
-	file_entry_t **array;
-	int			narray;			/* current length of array */
-
-	/*
-	 * Summary information.
-	 */
-	uint64		total_size;		/* total size of the source cluster */
-	uint64		fetch_size;		/* number of bytes that needs to be copied */
-=======
 	int			nentries;		/* size of 'entries' array */
 	file_entry_t *entries[FLEXIBLE_ARRAY_MEMBER];
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 } filemap_t;
 
 /* Functions for populating the filemap */
@@ -155,15 +105,9 @@ extern void process_source_file(const char *path, file_type_t type,
 								size_t size, const char *link_target);
 extern void process_target_file(const char *path, file_type_t type,
 								size_t size, const char *link_target);
-<<<<<<< HEAD
 extern void process_target_wal_aofile_change(RelFileNode rnode,
 											 int segno,
 											 int64 offset);
-extern void process_target_wal_block_change(ForkNumber forknum,
-											RelFileNode rnode,
-											BlockNumber blkno);
-extern void decide_file_actions(void);
-=======
 extern void process_target_wal_block_change(ForkNumber forknum,
 											RelFileNode rnode,
 											BlockNumber blkno);
@@ -171,6 +115,5 @@ extern void process_target_wal_block_change(ForkNumber forknum,
 extern filemap_t *decide_file_actions(void);
 extern void calculate_totals(filemap_t *filemap);
 extern void print_filemap(filemap_t *filemap);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 #endif							/* FILEMAP_H */


### PR DESCRIPTION
1) Commit f81e97d in src/bin/pg_rewind/filemap.h removed the comment at
the beginning, although earlier commits had already changed it.

2) Commit f81e97d in src/bin/pg_rewind/filemap.h added a new field,
"status," to the file_entry_t structure, added the const modifier to
the "path" field, and removed the "next" field, although earlier commit
55c5525 had already added the new field, "is_gp_tablespace," to this
structure.

3) Commit f81e97d in src/bin/pg_rewind/filemap.h renamed the narray and
array fields to nentries and entries in the filemap_t structure, and
removed the first, last, and nlist fields. Earlier commits had already
changed the comments for the fields in this structure.

4) Commit eb00f1d in src/bin/pg_rewind/filemap.h formatted the
arguments in the definition of the process_target_wal_block_change
function and added a definition of the new decide_file_actions
function. Commit f81e97d changed the return type of the
decide_file_actions function from void to filemap_t * and added
definitions of the new calculate_totals and print_filemap functions.
Earlier commit 1a770cf had already partially done the same and added a
definition of the new process_target_wal_aofile_change function.