### PR TITLE
Resolve conflicts in src/bin/pg_rewind/copy_fetch.c

### DIFF
--- a/src/bin/pg_rewind/copy_fetch.c
+++ b/src/bin/pg_rewind/copy_fetch.c
@@ -221,11 +221,7 @@ copy_executeFileMap(filemap_t *map)
 
 	for (i = 0; i < map->nentries; i++)
 	{
-<<<<<<< HEAD
-		entry = map->array[i];
-=======
 		entry = map->entries[i];
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 		execute_pagemap(&entry->target_pages_to_overwrite, entry->path);
 
 		switch (entry->action)


### PR DESCRIPTION
Commit f81e97d in src/bin/pg_rewind/copy_fetch.c in the
copy_executeFileMap function changed the narray and array fields to
nentries and entries, while the earlier commit 1a770cf had already
changed the pagemap field to target_pages_to_overwrite below.