### PR TITLE
Resolve conflicts in file_ops.c and pg_rewind.c

### DIFF
--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -330,7 +330,7 @@ create_target_tablespace_layout(const char *path, const char *link)
  * in pg_rewind by running single mode postgres if needed and also we do not
  * copy an unsynchronized dababase without sync as the target base.
  */
-static void
+void
 sync_target_dir(filemap_t *filemap)
 {
 	if (!do_sync || dry_run)

--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -345,9 +345,9 @@ sync_target_dir(filemap_t *filemap)
 		exit(1);
 	}
 
-	for (i = 0; i < filemap->narray; i++)
+	for (i = 0; i < filemap->nentries; i++)
 	{
-		entry = filemap->array[i];
+		entry = filemap->entries[i];
 
 		if (entry->target_pages_to_overwrite.bitmapsize > 0)
 			fsync_fname(entry->path, false);

--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -323,14 +323,73 @@ create_target_tablespace_layout(const char *path, const char *link)
  * most dirty buffers to disk.  Additionally fsync_pgdata uses a two-pass
  * approach (only initiating writeback in the first pass), which often reduces
  * the overall amount of IO noticeably.
+ *
+ * gpdb: We assume that all files are synchronized before rewinding and thus we
+ * just need to synchronize those affected files. This is a resonable
+ * assumption for gpdb since we've ensured that the db state is clean shutdown
+ * in pg_rewind by running single mode postgres if needed and also we do not
+ * copy an unsynchronized dababase without sync as the target base.
  */
-void
-sync_target_dir(void)
+static void
+sync_target_dir(filemap_t *filemap)
 {
 	if (!do_sync || dry_run)
 		return;
 
-	fsync_pgdata(datadir_target, PG_VERSION_NUM);
+	file_entry_t *entry;
+	int			  i;
+
+	if (chdir(datadir_target) < 0)
+	{
+		pg_log_error("could not change directory to \"%s\": %m", datadir_target);
+		exit(1);
+	}
+
+	for (i = 0; i < filemap->narray; i++)
+	{
+		entry = filemap->array[i];
+
+		if (entry->target_pages_to_overwrite.bitmapsize > 0)
+			fsync_fname(entry->path, false);
+		else
+		{
+			switch (entry->action)
+			{
+				case FILE_ACTION_COPY:
+				case FILE_ACTION_TRUNCATE:
+				case FILE_ACTION_COPY_TAIL:
+					fsync_fname(entry->path, false);
+					break;
+
+				case FILE_ACTION_CREATE:
+					fsync_fname(entry->path,
+								entry->source_type == FILE_TYPE_DIRECTORY);
+					/* FALLTHROUGH */
+				case FILE_ACTION_REMOVE:
+					/*
+					 * Fsync the parent directory if we either create or delete
+					 * files/directories in the parent directory. The parent
+					 * directory might be missing as expected, so fsync it could
+					 * fail but we ignore that error.
+					 */
+					fsync_parent_path(entry->path);
+					break;
+
+				case FILE_ACTION_NONE:
+					break;
+
+				default:
+					pg_fatal("no action decided for \"%s\"", entry->path);
+					break;
+			}
+		}
+	}
+
+	/* fsync some files that are (possibly) written by pg_rewind. */
+	fsync_fname("global/pg_control", false);
+	fsync_fname("backup_label", false);
+	fsync_fname("postgresql.auto.conf", false);
+	fsync_fname(".", true); /* due to new file backup_label. */
 }
 
 /*

--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -165,14 +165,10 @@ create_target(file_entry_t *entry)
 			break;
 
 		case FILE_TYPE_SYMLINK:
-<<<<<<< HEAD
 			if (entry->is_gp_tablespace)
 				create_target_tablespace_layout(entry->path, entry->source_link_target);
 			else
 				create_target_symlink(entry->path, entry->source_link_target);
-=======
-			create_target_symlink(entry->path, entry->source_link_target);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 			break;
 
 		case FILE_TYPE_REGULAR:
@@ -180,14 +176,11 @@ create_target(file_entry_t *entry)
 			pg_fatal("invalid action (CREATE) for regular file");
 			break;
 
-<<<<<<< HEAD
 		case FILE_TYPE_FIFO:
 			/* Only pgsql_tmp files are FIFO and they are ignored from source target. */
 			pg_fatal("invalid action (CREATE) for fifo file");
 			break;
 
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 		case FILE_TYPE_UNDEFINED:
 			pg_fatal("undefined file type for \"%s\"", entry->path);
 			break;
@@ -296,7 +289,6 @@ remove_target_symlink(const char *path)
 				 dstpath);
 }
 
-<<<<<<< HEAD
 /* Create symlink for tablespace, create tablespace target dir */
 static void
 create_target_tablespace_layout(const char *path, const char *link)
@@ -322,7 +314,7 @@ create_target_tablespace_layout(const char *path, const char *link)
 
 	pfree(newlink);
 }
-=======
+
 /*
  * Sync target data directory to ensure that modifications are safely on disk.
  *
@@ -340,8 +332,6 @@ sync_target_dir(void)
 
 	fsync_pgdata(datadir_target, PG_VERSION_NUM);
 }
-
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 /*
  * Read a file into memory. The file to be read is <datadir>/<path>.

--- a/src/bin/pg_rewind/file_ops.h
+++ b/src/bin/pg_rewind/file_ops.h
@@ -19,7 +19,7 @@ extern void remove_target_file(const char *path, bool missing_ok);
 extern void truncate_target_file(const char *path, off_t newsize);
 extern void create_target(file_entry_t *t);
 extern void remove_target(file_entry_t *t);
-extern void sync_target_dir(void);
+extern void sync_target_dir(filemap_t *filemap);
 
 extern char *slurpFile(const char *datadir, const char *path, size_t *filesize);
 

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -133,11 +133,8 @@ main(int argc, char **argv)
 	TimeLineID	endtli;
 	ControlFileData ControlFile_new;
 	bool		writerecoveryconf = false;
-<<<<<<< HEAD
-	char		*replication_slot = NULL;
-=======
+	char	   *replication_slot = NULL;
 	filemap_t  *filemap;
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 	pg_logging_init(argv[0]);
 	set_pglocale_pgservice(argv[0], PG_TEXTDOMAIN("pg_rewind"));
@@ -428,11 +425,7 @@ main(int argc, char **argv)
 	 * We have collected all information we need from both systems. Decide
 	 * what to do with each file.
 	 */
-<<<<<<< HEAD
-	decide_file_actions();
-=======
 	filemap = decide_file_actions();
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	if (showprogress)
 		calculate_totals(filemap);
 
@@ -498,7 +491,7 @@ main(int argc, char **argv)
 
 	if (showprogress)
 		pg_log_info("syncing target data directory");
-	sync_target_dir();
+	sync_target_dir(filemap);
 
 	if (writerecoveryconf && !dry_run)
 		WriteRecoveryConfig(conn, datadir_target,
@@ -846,84 +839,6 @@ digestControlFile(ControlFileData *ControlFile, char *src, size_t size)
 	checkControlFile(ControlFile);
 }
 
-/*
-<<<<<<< HEAD
- * Sync target data directory to ensure that modifications are safely on disk.
- *
- * We do this once, for the whole data directory, for performance reasons.  At
- * the end of pg_rewind's run, the kernel is likely to already have flushed
- * most dirty buffers to disk.  Additionally fsync_pgdata uses a two-pass
- * approach (only initiating writeback in the first pass), which often reduces
- * the overall amount of IO noticeably.
- *
- * gpdb: We assume that all files are synchronized before rewinding and thus we
- * just need to synchronize those affected files. This is a resonable
- * assumption for gpdb since we've ensured that the db state is clean shutdown
- * in pg_rewind by running single mode postgres if needed and also we do not
- * copy an unsynchronized dababase without sync as the target base.
- */
-static void
-syncTargetDirectory(void)
-{
-	if (!do_sync || dry_run)
-		return;
-
-	file_entry_t *entry;
-	int			  i;
-
-	if (chdir(datadir_target) < 0)
-	{
-		pg_log_error("could not change directory to \"%s\": %m", datadir_target);
-		exit(1);
-	}
-
-	for (i = 0; i < filemap->narray; i++)
-	{
-		entry = filemap->array[i];
-
-		if (entry->target_pages_to_overwrite.bitmapsize > 0)
-			fsync_fname(entry->path, false);
-		else
-		{
-			switch (entry->action)
-			{
-				case FILE_ACTION_COPY:
-				case FILE_ACTION_TRUNCATE:
-				case FILE_ACTION_COPY_TAIL:
-					fsync_fname(entry->path, false);
-					break;
-
-				case FILE_ACTION_CREATE:
-					fsync_fname(entry->path,
-								entry->source_type == FILE_TYPE_DIRECTORY);
-					/* FALLTHROUGH */
-				case FILE_ACTION_REMOVE:
-					/*
-					 * Fsync the parent directory if we either create or delete
-					 * files/directories in the parent directory. The parent
-					 * directory might be missing as expected, so fsync it could
-					 * fail but we ignore that error.
-					 */
-					fsync_parent_path(entry->path);
-					break;
-
-				case FILE_ACTION_NONE:
-					break;
-
-				default:
-					pg_fatal("no action decided for \"%s\"", entry->path);
-					break;
-			}
-		}
-	}
-
-	/* fsync some files that are (possibly) written by pg_rewind. */
-	fsync_fname("global/pg_control", false);
-	fsync_fname("backup_label", false);
-	fsync_fname("postgresql.auto.conf", false);
-	fsync_fname(".", true); /* due to new file backup_label. */
-}
-
 static int32
 get_target_dbid(const char *argv0)
 {
@@ -983,8 +898,6 @@ get_target_dbid(const char *argv0)
 }
 
 /*
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  * Get value of GUC parameter restore_command from the target cluster.
  *
  * This uses a logic based on "postgres -C" to get the value from the


### PR DESCRIPTION
1) Commit ffb4e27 in src/bin/pg_rewind/file_ops.c in the create_target
function replaced the link_target field with source_link_target, while
earlier commit 1a770cf had already done the same and also added a
condition for is_gp_tablespace.

2) Commit ffb4e27 in src/bin/pg_rewind/file_ops.c in the create_target
function added handling for the FILE_TYPE_UNDEFINED case, while earlier
commit c122be1 had already added handling for the FILE_TYPE_FIFO case
in the same location.

3) Commit ffb4e27 added a new function sync_target_dir to
src/bin/pg_rewind/file_ops.c, while earlier commit 55c5525 had already
added the create_target_tablespace_layout function in the same place.

4) Commit f81e97d in src/bin/pg_rewind/pg_rewind.c added a new local
variable filemap and its usage in the main function. However, earlier
commit 1a770cf had already added a call to the decide_file_actions
function, and commit 19cd1cf had already added a new local variable
replication_slot in these same locations.

5) Commit ffb4e27 in src/bin/pg_rewind/pg_rewind.c removed the
syncTargetDirectory function, moving its contents to the
sync_target_dir function in src/bin/pg_rewind/file_ops.c. Earlier
commits had already significantly changed its contents.