### PR TITLE
Resolve conflicts in src/bin/pg_upgrade/dump.c

### DIFF
--- a/src/bin/pg_upgrade/dump.c
+++ b/src/bin/pg_upgrade/dump.c
@@ -53,14 +53,9 @@ generate_old_dump(void)
 		snprintf(log_file_name, sizeof(log_file_name), DB_DUMP_LOG_FILE_MASK, old_db->db_oid);
 
 		parallel_exec_prog(log_file_name, NULL,
-<<<<<<< HEAD
 						   "%s \"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
-						   "--binary-upgrade --format=custom %s --file=\"%s\" %s",
-						   PG_OPTIONS_UTILITY_MODE_VERSION(old_cluster.major_version),
-=======
-						   "\"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
 						   "--binary-upgrade --format=custom %s %s --file=\"%s\" %s",
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+						   PG_OPTIONS_UTILITY_MODE_VERSION(old_cluster.major_version),
 						   new_cluster.bindir, cluster_conn_opts(&old_cluster),
 						   log_opts.verbose ? "--verbose" : "",
 						   user_opts.ind_coll_unknown ?


### PR DESCRIPTION
Commit 257836a added new collation options to the generate_old_dump
function in src/bin/pg_upgrade/dump.c, while earlier commit 7d0121c had
already added utility options in the same location.