### PR TITLE
Resolve conflicts in src/bin/pg_upgrade/option.c

### DIFF
--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -324,13 +324,10 @@ usage(void)
 	printf(_("  -v, --verbose                 enable verbose internal logging\n"));
 	printf(_("  -V, --version                 display version information, then exit\n"));
 	printf(_("  --clone                       clone instead of copying files to new cluster\n"));
-<<<<<<< HEAD
 	printf(_("  --continue-check-on-fatal     goes through all pg_upgrade checks; should be used with -c\n"));
 	printf(_("  --skip-target-check           skip all checks and comparisons of new cluster; should be used with -c\n"));
-=======
 	printf(_("  --index-collation-versions-unknown\n"));
 	printf(_("                                mark text indexes as needing to be rebuilt\n"));
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	printf(_("  -?, --help                    show this help, then exit\n"));
 	printf(_("\n"
 			 "Before running pg_upgrade you must:\n"


### PR DESCRIPTION
Commit 257836a added new index-collation-versions-unknown options to
the generate_old_dump function in src/bin/pg_upgrade/option.c. Earlier
commits 9e89719 and e99317c had already added continue-check-on-fatal
and skip-target-check options in the same location.