### PR TITLE
Fix compilation of src/backend/optimizer/path/costsize.c

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -5680,7 +5680,8 @@ get_foreign_key_join_selectivity(PlannerInfo *root,
 												(Node *) rinfo,
 												0,
 												jointype,
-												sjinfo);
+												sjinfo,
+												false /* use_damping */);
 						if (s0 > 0)
 							fkselec /= s0;
 					}


### PR DESCRIPTION
Commit ad1c36b added a call to the clause_selectivity function in the
get_foreign_key_join_selectivity function in
src/backend/optimizer/path/costsize.c, although the earlier commit
6b0e52b had already added the bool use_damping argument to this
function.