### PR TITLE
Fix compilation of src/include/optimizer/cost.h

### DIFF
--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -16,6 +16,8 @@
 #ifndef COST_H
 #define COST_H
 
+#include <math.h>
+
 #include "nodes/pathnodes.h"
 #include "nodes/plannodes.h"
 


### PR DESCRIPTION
Commit 2924b6f in src/include/optimizer/cost.h added a call to the
isnan function in the clamp_row_est function, but forgot to include
math.h.