### PR TITLE
Fix compilation of src/interfaces/libpq/fe-connect.c

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -22,6 +22,7 @@
  * which only defines FRONTEND besides including "c.h"
  */
 #include "c.h"
+#include "common/fe_memutils.h"
 
 #ifndef WIN32
 #include <poll.h>


### PR DESCRIPTION
Commit c0cb87f added a call to the pfree function in the
parseServiceFile function in src/interfaces/libpq/fe-connect.c, while
the earlier commit 7e46c18 replaced the postgres_fe.h include with c.h.
Add the missing common/fe_memutils.h include.