### PR TITLE
Fix compilation of src/backend/utils/error/assert.c

### DIFF
--- a/src/backend/utils/error/assert.c
+++ b/src/backend/utils/error/assert.c
@@ -43,8 +43,8 @@ ExceptionalCondition(const char *conditionName,
 		|| !PointerIsValid(errorType))
 		ereport(FATAL,
 				errFatalReturn(gp_reraise_signal),
-				errmsg("TRAP: ExceptionalCondition: bad arguments in PID %d")),
-					   (int) getpid();
+				errmsg("TRAP: ExceptionalCondition: bad arguments in PID %d"),
+					   (int) getpid());
 	else
 		ereport(FATAL,
 				errFatalReturn(gp_reraise_signal),


### PR DESCRIPTION
Commit f57cef9 in src/backend/utils/error/assert.c introduced a syntax
error while fixing conflicts.