### PR TITLE
Fix compilation of src/backend/commands/indexcmds.c

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -213,16 +213,6 @@ typedef struct ReindexErrorInfo
 } ReindexErrorInfo;
 
 /*
- * callback arguments for reindex_error_callback()
- */
-typedef struct ReindexErrorInfo
-{
-	char	   *relname;
-	char	   *relnamespace;
-	char		relkind;
-} ReindexErrorInfo;
-
-/*
  * CheckIndexCompatible
  *		Determine whether an existing index definition is compatible with a
  *		prospective index definition, such that the existing index storage


### PR DESCRIPTION
Commit a6642b3 added a new ReindexErrorInfo structure to
src/backend/commands/indexcmds.c, while earlier commit 67a7c0f had
already done the same.