### PR TITLE
Fix compilation of aocs_compaction.c and appendonly_compaction.c

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -191,7 +191,7 @@ AOCSMoveTuple(TupleTableSlot *slot,
 	/* insert index' tuples if needed */
 	if (resultRelInfo->ri_NumIndices > 0)
 	{
-		ExecInsertIndexTuples(slot, estate, false, false, NIL);
+		ExecInsertIndexTuples(resultRelInfo, slot, estate, false, false, NIL);
 		ResetPerTupleExprContext(estate);
 	}
 
@@ -263,7 +263,10 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 	resultRelInfo->ri_RelationDesc = aorel;
 	resultRelInfo->ri_TrigDesc = NULL;	/* we don't fire triggers */
 	ExecOpenIndices(resultRelInfo, false);
-	estate->es_result_relations = resultRelInfo;
+	if (estate->es_result_relations == NULL)
+		estate->es_result_relations = (ResultRelInfo **)
+			palloc0(estate->es_range_table_size * sizeof(ResultRelInfo *));
+	estate->es_result_relations[resultRelInfo->ri_RangeTableIndex - 1] = resultRelInfo;
 
 	/*
 	 * We don't want uniqueness checks to be performed while "insert"ing tuples

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -301,7 +301,8 @@ AppendOnlyMoveTuple(TupleTableSlot *slot,
 	/* insert index' tuples if needed */
 	if (resultRelInfo->ri_NumIndices > 0)
 	{
-		ExecInsertIndexTuples(slot,
+		ExecInsertIndexTuples(resultRelInfo,
+							  slot,
 							  estate,
 							  false, /* noDupError */
 							  NULL, /* specConflict */
@@ -444,7 +445,10 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	resultRelInfo->ri_RelationDesc = aorel;
 	resultRelInfo->ri_TrigDesc = NULL;	/* we don't fire triggers */
 	ExecOpenIndices(resultRelInfo, false);
-	estate->es_result_relations = resultRelInfo;
+	if (estate->es_result_relations == NULL)
+		estate->es_result_relations = (ResultRelInfo **)
+			palloc0(estate->es_range_table_size * sizeof(ResultRelInfo *));
+	estate->es_result_relations[resultRelInfo->ri_RangeTableIndex - 1] = resultRelInfo;
 
 	/*
 	 * We don't want uniqueness checks to be performed while "insert"ing tuples


### PR DESCRIPTION
1) Commit a04daa9 in src/include/executor/executor.h added a new
argument, ResultRelInfo *resultRelInfo, to the definition of the
ExecInsertIndexTuples function. Add this in GPDB-specific places.

2) Commit 1375422 in src/include/nodes/execnodes.h changed the type of
the es_result_relations field in the EState structure from
ResultRelInfo * to ResultRelInfo **. Change this in GPDB-specific
places.