### PR TITLE
Fix compilation of analyzefuncs.c and cdbmutate.c

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1133,7 +1133,7 @@ makeSegmentFilterExpr(int segid)
 		make_opclause(Int4EqualOperator,
 					  BOOLOID,
 					  false,	/* opretset */
-					  (Expr *) makeFuncExpr(F_MPP_EXECUTION_SEGMENT,
+					  (Expr *) makeFuncExpr(F_GP_EXECUTION_SEGMENT,
 											INT4OID,
 											NIL,	/* args */
 											InvalidOid,

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -342,7 +342,7 @@ gp_acquire_sample_rows_col_type(Oid typid)
 			 */
 			return OIDOID;
 
-		case PGNODETREEOID:
+		case PG_NODE_TREEOID:
 			/*
 			 * Input function of pg_node_tree doesn't allow loading
 			 * back values. Treat it as text.


### PR DESCRIPTION
Commit 8e1f37c changed the generation rule for fmgroids.h macros.
Change in GPDB-specific places.