### PR TITLE
Fix compilation of src/backend/utils/sort/tuplestore.c

### DIFF
--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1774,7 +1774,7 @@ tuplestore_open_shared(SharedFileSet *fileset, const char *filename)
 	state->writetup = writetup_forbidden;
 	state->readtup = readtup_heap;
 
-	state->myfile = BufFileOpenShared(fileset, filename);
+	state->myfile = BufFileOpenShared(fileset, filename, O_RDONLY);
 	state->readptrs[0].file = 0;
 	state->readptrs[0].offset = 0L;
 	state->status = TSS_READFILE;


### PR DESCRIPTION
Commit 808e13b added a new int mode argument to the BufFileOpenShared
function definition in src/include/storage/buffile.h. Add this in
GPDB-specific places.