### PR TITLE
Fix compilation of src/backend/commands/tablecmds.c

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -8852,7 +8852,9 @@ ATExecCookedColumnDefault(Relation rel, AttrNumber attnum,
 	RemoveAttrDefault(RelationGetRelid(rel), attnum, DROP_RESTRICT, false,
 					  true);
 
-	(void) StoreAttrDefault(rel, attnum, newDefault, true, false);
+	(void) StoreAttrDefault(rel, attnum, newDefault,
+							NULL, NULL, NULL, /* missing val stuff */
+							true, false);
 
 	ObjectAddressSubSet(address, RelationRelationId,
 						RelationGetRelid(rel), attnum);


### PR DESCRIPTION
Commit 5028981 added a new function, ATExecCookedColumnDefault, to
src/backend/commands/tablecmds.c, which calls the StoreAttrDefault
function. However, the earlier commit 19cd1cf had already added the new
arguments bool *cookedMissingVal, Datum *missingval_p, and bool
*missingIsNull_p.