### PR TITLE
Fix compilation of src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4388,7 +4388,6 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	dml->canSetTag = true;	// FIXME
 	dml->nominalRelation = index;
 	dml->resultRelations = ListMake1Int(index);
-	dml->resultRelIndex = list_length(m_result_rel_list) - 1;
 	dml->rootRelation = md_rel->IsPartitioned() ? index : 0;
 	dml->plans = ListMake1(child_plan);
 


### PR DESCRIPTION
Commit 1375422 in src/include/nodes/plannodes.h removed the
resultRelIndex field from the PlannedStmt structure. Remove this in
GPDB-specific code.