### PR TITLE
Resolve conflicts in src/test/isolation/Makefile

### DIFF
--- a/src/test/isolation/Makefile
+++ b/src/test/isolation/Makefile
@@ -18,7 +18,6 @@ OBJS = \
 
 all: isolationtester$(X) pg_isolation_regress$(X)
 
-<<<<<<< HEAD
 gpstringsubs.pl:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/gpstringsubs.pl
 
@@ -34,13 +33,6 @@ atmsort.pm:
 explain.pm:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/regress/explain.pm
 
-# Though we don't install these binaries, build them during installation
-# (including temp-install).  Otherwise, "make -j check-world" and "make -j
-# installcheck-world" would spawn multiple, concurrent builds in this
-# directory.  Later builds would overwrite files while earlier builds are
-# reading them, causing occasional failures.
-install: | all
-=======
 install: all installdirs
 	$(INSTALL_PROGRAM) pg_isolation_regress$(X) '$(DESTDIR)$(pgxsdir)/$(subdir)/pg_isolation_regress$(X)'
 	$(INSTALL_PROGRAM) isolationtester$(X) '$(DESTDIR)$(pgxsdir)/$(subdir)/isolationtester$(X)'
@@ -51,7 +43,6 @@ installdirs:
 uninstall:
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/pg_isolation_regress$(X)'
 	rm -f '$(DESTDIR)$(pgxsdir)/$(subdir)/isolationtester$(X)'
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 submake-regress:
 	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress.o


### PR DESCRIPTION
Commit 2203ede9ae85b6423f850466122606275ea09b17 added new targets to the
Makefile for installing pg_isolation_regress and isolationtester, however
GPDB-specific commits have already added several targets for *.pl and *.pm
files.