### PR TITLE
Resolve conflicts in src/test/regress/pg_regress.c

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -845,7 +845,6 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 		FILE	   *infile,
 				   *outfile;
 		StringInfoData line;
-<<<<<<< HEAD
 		bool		has_tokens = false;
 		struct stat fst;
 
@@ -873,8 +872,6 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 
 			continue;
 		}
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 		/* reject filenames not finishing in ".source" */
 		if (strlen(*name) < 8)
@@ -909,7 +906,6 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 
 		while (pg_get_line_buf(infile, &line))
 		{
-<<<<<<< HEAD
 			convert_line(&line, &repls);
 			fputs(line.data, outfile);
 
@@ -919,14 +915,6 @@ convert_sourcefiles_in(const char *source_subdir, const char *dest_dir, const ch
 			 */
 			if (!has_tokens && strstr(line.data, "@gp") != NULL)
 				has_tokens = true;
-=======
-			replace_string(&line, "@abs_srcdir@", inputdir);
-			replace_string(&line, "@abs_builddir@", outputdir);
-			replace_string(&line, "@testtablespace@", testtablespace);
-			replace_string(&line, "@libdir@", dlpath);
-			replace_string(&line, "@DLSUFFIX@", DLSUFFIX);
-			fputs(line.data, outfile);
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 		}
 
 		pfree(line.data);


### PR DESCRIPTION
Commit 784b1ba1a2b9306697544bedb2ef9425185dd206 replaced array with
StringInfoData, however it was already cherry-picked earlier as commit
b4c36a1dc37fffb2d7e795d0f77aaaf035ad3e9f.