### PR TITLE
Fix compilation of src/backend/parser/parse_utilcmd.c

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -98,7 +98,9 @@ typedef struct
 	List	   *fkconstraints;	/* FOREIGN KEY constraints */
 	List	   *ixconstraints;	/* index-creating constraints */
 	List	   *inh_indexes;	/* cloned indexes from INCLUDING INDEXES
-								 * GPDB: used by transformDistributedBy */
+								 * GPDB: used by transformDistributedBy
+								 * Note: Attribute numbers in expressions
+								 * might not be correct, only use names */
 	List	   *attr_encodings; /* List of ColumnReferenceStorageDirectives */
 	List	   *extstats;		/* cloned extended statistics */
 	List	   *blist;			/* "before list" of things to do before

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1337,18 +1337,6 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 												 attmap,
 												 NULL);
 
-			/* Copy comment on index, if requested */
-			if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
-			{
-				comment = GetComment(parent_index_oid, RelationRelationId, 0);
-
-				/*
-				 * We make use of IndexStmt's idxcomment option, so as not to
-				 * need to know now what name the index will have.
-				 */
-				index_stmt->idxcomment = comment;
-			}
-
 			/* Save it in the inh_indexes list for the time being */
 			cxt->inh_indexes = lappend(cxt->inh_indexes, index_stmt);
 

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -97,6 +97,8 @@ typedef struct
 	List	   *ckconstraints;	/* CHECK constraints */
 	List	   *fkconstraints;	/* FOREIGN KEY constraints */
 	List	   *ixconstraints;	/* index-creating constraints */
+	List	   *inh_indexes;	/* cloned indexes from INCLUDING INDEXES
+								 * GPDB: used by transformDistributedBy */
 	List	   *attr_encodings; /* List of ColumnReferenceStorageDirectives */
 	List	   *extstats;		/* cloned extended statistics */
 	List	   *blist;			/* "before list" of things to do before
@@ -291,6 +293,7 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString)
 	cxt.ckconstraints = NIL;
 	cxt.fkconstraints = NIL;
 	cxt.ixconstraints = NIL;
+	cxt.inh_indexes = NIL; /* GPDB: used by transformDistributedBy */
 	cxt.extstats = NIL;
 	cxt.attr_encodings = stmt->attr_encodings;
 	cxt.blist = NIL;
@@ -1093,6 +1096,13 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 	tupleDesc = RelationGetDescr(relation);
 
 	/*
+	 * Initialize column number map for map_variable_attnos().  We need this
+	 * since dropped columns in the source table aren't copied, so the new
+	 * table can have different column numbers.
+	 */
+	AttrMap    *attmap = make_attrmap(tupleDesc->natts);
+
+	/*
 	 * Insert the copied attributes into the cxt for the new table definition.
 	 * We must do this now so that they appear in the table in the relative
 	 * position where the LIKE clause is, as required by SQL99.
@@ -1137,6 +1147,7 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 		 * Add to column list
 		 */
 		cxt->columns = lappend(cxt->columns, def);
+		attmap->attnums[parent_attno - 1] = list_length(cxt->columns);
 
 		/*
 		 * Although we don't transfer the column's default/generation
@@ -1297,6 +1308,53 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 		list_free(parent_extstats);
 	}
 
+	/*
+	 * Copy indexes for Greengage choosing distributed-by keys.
+	 * PostgreSQL processes index statements after here in expandTableLikeClause(),
+	 * but we need indexes in transformDistributedBy() which is before expandTableLikeClause(),
+	 * So we both retain the index statements processing here and expandTableLikeClause.
+	 * the process here is just used by transformDistributedBy().
+	 */
+	if ((table_like_clause->options & CREATE_TABLE_LIKE_INDEXES) &&
+		relation->rd_rel->relhasindex)
+	{
+		List	   *parent_indexes;
+		ListCell   *l;
+
+		parent_indexes = RelationGetIndexList(relation);
+
+		foreach(l, parent_indexes)
+		{
+			Oid			parent_index_oid = lfirst_oid(l);
+			Relation	parent_index;
+			IndexStmt  *index_stmt;
+
+			parent_index = index_open(parent_index_oid, AccessShareLock);
+
+			/* Build CREATE INDEX statement to recreate the parent_index */
+			index_stmt = generateClonedIndexStmt(stmt->relation,
+												 parent_index,
+												 attmap,
+												 NULL);
+
+			/* Copy comment on index, if requested */
+			if (table_like_clause->options & CREATE_TABLE_LIKE_COMMENTS)
+			{
+				comment = GetComment(parent_index_oid, RelationRelationId, 0);
+
+				/*
+				 * We make use of IndexStmt's idxcomment option, so as not to
+				 * need to know now what name the index will have.
+				 */
+				index_stmt->idxcomment = comment;
+			}
+
+			/* Save it in the inh_indexes list for the time being */
+			cxt->inh_indexes = lappend(cxt->inh_indexes, index_stmt);
+
+			index_close(parent_index, AccessShareLock);
+		}
+	}
 	/*
 	 * Close the parent rel, but keep our AccessShareLock on it until xact
 	 * commit.  That will prevent someone else from deleting or ALTERing the
@@ -2176,6 +2234,7 @@ transformCreateExternalStmt(CreateExternalStmt *stmt, const char *queryString)
 	cxt.ckconstraints = NIL;
 	cxt.fkconstraints = NIL;
 	cxt.ixconstraints = NIL;
+	cxt.inh_indexes = NIL; /* GPDB: used by transformDistributedBy */
 	cxt.attr_encodings = NIL;
 	cxt.pkey = NULL;
 	cxt.rel = NULL;
@@ -4306,6 +4365,7 @@ transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 	cxt.ckconstraints = NIL;
 	cxt.fkconstraints = NIL;
 	cxt.ixconstraints = NIL;
+	cxt.inh_indexes = NIL; /* GPDB: used by transformDistributedBy */
 	cxt.attr_encodings = NIL;
 	cxt.extstats = NIL;
 	cxt.blist = NIL;


### PR DESCRIPTION
Commit 5028981 in src/backend/parser/parse_utilcmd.c removed the
inh_indexes field from the CreateStmtContext structure, although it was
used in the transformDistributedBy function in the GPDB. Restore it for
the GPDB and add code to populate it in the transformTableLikeClause
function from 7X.