### PR TITLE
Fix compilation of src/bin/pgbench/pgbench.c

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -3790,9 +3790,7 @@ initCreateTables(PGconn *con)
 			appendPQExpBuffer(&query, " tablespace %s", escape_tablespace);
 			PQfreemem(escape_tablespace);
 		}
-		snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
-				 " distributed by (%s)",
-				 ddl->distributed_col);
+		appendPQExpBuffer(&query, " distributed by (%s)", ddl->distributed_col);
 
 		executeStatement(con, query.data);
 	}


### PR DESCRIPTION
Commit 9796f45 in src/bin/pgbench/pgbench.c in the initCreateTables
function removed the local variable opts, replacing snprintf opts with
appendPQExpBuffer query. Replace in GPDB-specific code.