### PR TITLE
Fix NULL pointer free in src/backend/cdb/cdbllize.c

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1177,7 +1177,8 @@ cdbllize_build_slice_table(PlannerInfo *root, Plan *top_plan,
 			 * list, because that would screw up the plan_id numbering of the
 			 * subplans).
 			 */
-			pfree(lfirst(lc));
+			if (lfirst(lc) != NULL)
+				pfree(lfirst(lc));
 			dummy_plan = (Plan *) make_result(NIL,
 											  (Node *) list_make1(makeBoolConst(false, false)),
 											  NULL);


### PR DESCRIPTION
Commit 41efb8340877e8ffd0023bb6b2ef22ffd1ca014d added the possibility of
glob->subplan entries being NULL, when they are deleted. GPDB-specific code
attempted to pfree it. Add a NULL check to cdbllize.c, with an additional
benefit that all the NULL entries will be replaced with dummy plans, which
are handled correctly by the rest of GPDB-specific code.