### PR TITLE
Fix segfault in src/backend/executor/nodeModifyTable.c

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1758,13 +1758,8 @@ ExecSplitUpdate_Insert(ModifyTableState *mtstate,
 		 * into the root.
 		 */
 		Assert(mtstate->rootResultRelInfo != NULL);
-		ResultRelInfo *partRelInfo;
-		slot = ExecPrepareTupleRouting(mtstate, estate, proute,
-									   mtstate->rootResultRelInfo, slot,
-									   &partRelInfo);
-		resultRelInfo = partRelInfo;
 
-		slot = ExecInsert(mtstate, resultRelInfo, slot, planSlot,
+		slot = ExecInsert(mtstate, mtstate->rootResultRelInfo, slot, planSlot,
 						  estate, mtstate->canSetTag,
 						  true /* splitUpdate */);
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2263,7 +2263,7 @@ ExecModifyTable(PlanState *pstate)
 			node->mt_whichplan++;
 			if (node->mt_whichplan < node->mt_nplans)
 			{
-				resultRelInfo = estate->es_result_relations[node->mt_whichplan];
+				resultRelInfo = &node->resultRelInfo[node->mt_whichplan];
 				subplanstate = node->mt_plans[node->mt_whichplan];
 				junkfilter = resultRelInfo->ri_junkFilter;
 				action_attno = resultRelInfo->ri_action_attno;


### PR DESCRIPTION
1. Commit 4a157578a121a7f642cdf138c8ecca459bff0a70 incorrectly fixed
nodeModifyTable.c, retaining the use of estate->es_result_relations. However
commit 1375422c7826a2bf387be29895e961614f69de4b changed ExecInitModifyTable to
use a newly allocated buffer in mtstate->resultRelInfo instead of a reference
to estate->es_result_relations. As a result, junkfilter is filled correctly
only in mtstate->resultRelInfo, and it should be used instead.
2. Commit a04daa97a4339c38e304cd6164d37da540d665a8 added
ExecPrepareTupleRouting() call to ExecInsert(), undoing the target relation
change in ExecSplitUpdate_Insert() and causing tuples to be inserted into a
wrong partition. As a solution, remove ExecPrepareTupleRouting() from
ExecSplitUpdate_Insert() and rely on the one on ExecInsert() instead.