### PR TITLE
Resolve conflicts in src/test/regress/expected/create_index.out

### DIFF
--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -260,7 +260,6 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-<<<<<<< HEAD
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -268,18 +267,9 @@ SELECT * FROM fast_emp4000
    ->  Sort
          Sort Key: ((home_base[0])[0])
          ->  Index Only Scan using grect2ind on fast_emp4000
-               Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
+               Index Cond: (home_base <@ '(2000,1000),(200,200)'::box)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                           QUERY PLAN                            
------------------------------------------------------------------
- Sort
-   Sort Key: ((home_base[0])[0])
-   ->  Index Only Scan using grect2ind on fast_emp4000
-         Index Cond: (home_base <@ '(2000,1000),(200,200)'::box)
-(4 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 SELECT * FROM fast_emp4000
     WHERE home_base <@ '(200,200),(2000,1000)'::box
@@ -329,7 +319,6 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
 EXPLAIN (COSTS OFF)
 SELECT * FROM polygon_tbl WHERE f1 @> '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
-<<<<<<< HEAD
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -337,18 +326,9 @@ SELECT * FROM polygon_tbl WHERE f1 @> '((1,1),(2,2),(2,1))'::polygon
    ->  Sort
          Sort Key: ((poly_center(f1))[0])
          ->  Index Scan using gpolygonind on polygon_tbl
-               Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
+               Index Cond: (f1 @> '((1,1),(2,2),(2,1))'::polygon)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                         QUERY PLAN                         
-------------------------------------------------------------
- Sort
-   Sort Key: ((poly_center(f1))[0])
-   ->  Index Scan using gpolygonind on polygon_tbl
-         Index Cond: (f1 @> '((1,1),(2,2),(2,1))'::polygon)
-(4 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 SELECT * FROM polygon_tbl WHERE f1 @> '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
@@ -585,11 +565,6 @@ SELECT * FROM point_tbl WHERE NOT f1 ~= '(1e-300, -1e-300)' ORDER BY f1 <-> '0,1
 SELECT * FROM point_tbl WHERE NOT f1 ~= '(1e-300, -1e-300)' ORDER BY f1 <-> '0,1';
         f1         
 -------------------
-<<<<<<< HEAD
-=======
- (1e-300,-1e-300)
- (0,0)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  (-3,4)
  (-10,0)
  (10,10)
@@ -631,11 +606,6 @@ SELECT * FROM point_tbl WHERE NOT f1 ~= '(1e-300, -1e-300)' AND f1 IS NOT NULL O
 SELECT * FROM point_tbl WHERE NOT f1 ~= '(1e-300, -1e-300)' AND f1 IS NOT NULL ORDER BY f1 <-> '0,1';
         f1         
 -------------------
-<<<<<<< HEAD
-=======
- (1e-300,-1e-300)
- (0,0)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  (-3,4)
  (-10,0)
  (10,10)
@@ -658,17 +628,9 @@ SELECT * FROM point_tbl WHERE NOT f1 ~= '(1e-300, -1e-300)' AND f1 <@ '(-10,-10)
  Optimizer: Postgres query optimizer
 (7 rows)
 
-<<<<<<< HEAD
 SELECT * FROM point_tbl WHERE NOT f1 ~= '(1e-300, -1e-300)' AND f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
    f1    
 ---------
-=======
-SELECT * FROM point_tbl WHERE f1 <@ '(-10,-10),(10,10)':: box ORDER BY f1 <-> '0,1';
-        f1        
-------------------
- (1e-300,-1e-300)
- (0,0)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  (-3,4)
  (-10,0)
  (10,10)
@@ -2275,13 +2237,8 @@ WHERE classid = 'pg_class'::regclass AND
  index concur_reindex_ind2                | collation "default"                                        | n
  index concur_reindex_ind2                | column c2 of table concur_reindex_tab                      | a
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
-<<<<<<< HEAD
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
- index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
-=======
- index concur_reindex_ind3                | table concur_reindex_tab                                   | a
  index concur_reindex_ind4                | collation "default"                                        | n
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
  index concur_reindex_ind4                | column c2 of table concur_reindex_tab                      | a
  materialized view concur_reindex_matview | schema public                                              | n
@@ -2312,13 +2269,8 @@ WHERE classid = 'pg_class'::regclass AND
  index concur_reindex_ind2                | collation "default"                                        | n
  index concur_reindex_ind2                | column c2 of table concur_reindex_tab                      | a
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
-<<<<<<< HEAD
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
- index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
-=======
- index concur_reindex_ind3                | table concur_reindex_tab                                   | a
  index concur_reindex_ind4                | collation "default"                                        | n
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
  index concur_reindex_ind4                | column c2 of table concur_reindex_tab                      | a
  materialized view concur_reindex_matview | schema public                                              | n
@@ -2543,20 +2495,12 @@ SELECT relid, parentrelid, level FROM pg_partition_tree('concur_reindex_part_ind
 REINDEX TABLE concur_reindex_part_index; -- error
 ERROR:  "concur_reindex_part_index" is not a table or materialized view
 REINDEX TABLE CONCURRENTLY concur_reindex_part_index; -- error
-<<<<<<< HEAD
 ERROR:  REINDEX CONCURRENTLY is not supported
-=======
-ERROR:  "concur_reindex_part_index" is not a table or materialized view
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 -- Partitioned index with no leaves
 REINDEX TABLE concur_reindex_part_index_10; -- error
 ERROR:  "concur_reindex_part_index_10" is not a table or materialized view
 REINDEX TABLE CONCURRENTLY concur_reindex_part_index_10; -- error
-<<<<<<< HEAD
 ERROR:  REINDEX CONCURRENTLY is not supported
-=======
-ERROR:  "concur_reindex_part_index_10" is not a table or materialized view
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 -- Cannot run in a transaction block
 BEGIN;
 REINDEX INDEX concur_reindex_part_index;
@@ -2620,22 +2564,14 @@ SELECT create_relfilenode_part('reindex_index_status', 'concur_reindex_part_inde
 (1 row)
 
 REINDEX INDEX CONCURRENTLY concur_reindex_part_index;
-<<<<<<< HEAD
 ERROR:  REINDEX CONCURRENTLY is not supported
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 SELECT * FROM compare_relfilenode_part('reindex_index_status');
             relname            | relkind |          state           
 -------------------------------+---------+--------------------------
  concur_reindex_part_index     | I       | relfilenode is unchanged
  concur_reindex_part_index_0   | I       | relfilenode is unchanged
-<<<<<<< HEAD
  concur_reindex_part_index_0_1 | i       | relfilenode is unchanged
  concur_reindex_part_index_0_2 | i       | relfilenode is unchanged
-=======
- concur_reindex_part_index_0_1 | i       | relfilenode has changed
- concur_reindex_part_index_0_2 | i       | relfilenode has changed
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  concur_reindex_part_index_10  | I       | relfilenode is unchanged
 (5 rows)
 
@@ -2646,20 +2582,12 @@ DROP TABLE reindex_index_status;
 REINDEX INDEX concur_reindex_part; -- error
 ERROR:  "concur_reindex_part" is not an index
 REINDEX INDEX CONCURRENTLY concur_reindex_part; -- error
-<<<<<<< HEAD
 ERROR:  REINDEX CONCURRENTLY is not supported
-=======
-ERROR:  "concur_reindex_part" is not an index
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 -- Partitioned with no leaves
 REINDEX INDEX concur_reindex_part_10; -- error
 ERROR:  "concur_reindex_part_10" is not an index
 REINDEX INDEX CONCURRENTLY concur_reindex_part_10; -- error
-<<<<<<< HEAD
 ERROR:  REINDEX CONCURRENTLY is not supported
-=======
-ERROR:  "concur_reindex_part_10" is not an index
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 -- Cannot run in a transaction block
 BEGIN;
 REINDEX TABLE concur_reindex_part;
@@ -2694,22 +2622,14 @@ SELECT create_relfilenode_part('reindex_index_status', 'concur_reindex_part_inde
 (1 row)
 
 REINDEX TABLE CONCURRENTLY concur_reindex_part;
-<<<<<<< HEAD
 ERROR:  REINDEX CONCURRENTLY is not supported
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 SELECT * FROM compare_relfilenode_part('reindex_index_status');
             relname            | relkind |          state           
 -------------------------------+---------+--------------------------
  concur_reindex_part_index     | I       | relfilenode is unchanged
  concur_reindex_part_index_0   | I       | relfilenode is unchanged
-<<<<<<< HEAD
  concur_reindex_part_index_0_1 | i       | relfilenode is unchanged
  concur_reindex_part_index_0_2 | i       | relfilenode is unchanged
-=======
- concur_reindex_part_index_0_1 | i       | relfilenode has changed
- concur_reindex_part_index_0_2 | i       | relfilenode has changed
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
  concur_reindex_part_index_10  | I       | relfilenode is unchanged
 (5 rows)
 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -78,7 +78,7 @@ SET enable_seqscan = ON;
 SET enable_indexscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT * FROM fast_emp4000
-    WHERE home_base @ '(200,200),(2000,1000)'::box
+    WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
        home_base       
 -----------------------
@@ -98,7 +98,7 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
    278
 (1 row)
 
-SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
+SELECT * FROM polygon_tbl WHERE f1 @> '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
          f1          
 ---------------------
@@ -258,7 +258,7 @@ SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
-    WHERE home_base @ '(200,200),(2000,1000)'::box
+    WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
                                  QUERY PLAN                                 
 ----------------------------------------------------------------------------
@@ -268,13 +268,13 @@ SELECT * FROM fast_emp4000
          ->  Sort
                Sort Key: ((home_base[0])[0])
                ->  Index Scan using grect2ind on fast_emp4000
-                     Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
-                     Filter: (home_base @ '(2000,1000),(200,200)'::box)
+                     Index Cond: (home_base <@ '(2000,1000),(200,200)'::box)
+                     Filter: (home_base <@ '(2000,1000),(200,200)'::box)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (9 rows)
 
 SELECT * FROM fast_emp4000
-    WHERE home_base @ '(200,200),(2000,1000)'::box
+    WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
        home_base       
 -----------------------
@@ -320,7 +320,7 @@ SELECT count(*) FROM fast_emp4000 WHERE home_base IS NULL;
 (1 row)
 
 EXPLAIN (COSTS OFF)
-SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
+SELECT * FROM polygon_tbl WHERE f1 @> '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
                               QUERY PLAN                               
 -----------------------------------------------------------------------
@@ -330,12 +330,12 @@ SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
          ->  Sort
                Sort Key: ((poly_center(f1))[0])
                ->  Index Scan using gpolygonind on polygon_tbl
-                     Index Cond: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
-                     Filter: (f1 ~ '((1,1),(2,2),(2,1))'::polygon)
+                     Index Cond: (f1 @> '((1,1),(2,2),(2,1))'::polygon)
+                     Filter: (f1 @> '((1,1),(2,2),(2,1))'::polygon)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (9 rows)
 
-SELECT * FROM polygon_tbl WHERE f1 ~ '((1,1),(2,2),(2,1))'::polygon
+SELECT * FROM polygon_tbl WHERE f1 @> '((1,1),(2,2),(2,1))'::polygon
     ORDER BY (poly_center(f1))[0];
          f1          
 ---------------------
@@ -2231,15 +2231,16 @@ WHERE classid = 'pg_class'::regclass AND
                    obj                    |                           objref                           | deptype 
 ------------------------------------------+------------------------------------------------------------+---------
  index concur_reindex_ind1                | constraint concur_reindex_ind1 on table concur_reindex_tab | i
+ index concur_reindex_ind2                | collation "default"                                        | n
  index concur_reindex_ind2                | column c2 of table concur_reindex_tab                      | a
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
- index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
+ index concur_reindex_ind4                | collation "default"                                        | n
  index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
  index concur_reindex_ind4                | column c2 of table concur_reindex_tab                      | a
  materialized view concur_reindex_matview | schema public                                              | n
  table concur_reindex_tab                 | schema public                                              | n
-(9 rows)
+(10 rows)
 
 REINDEX INDEX CONCURRENTLY concur_reindex_ind1;
 ERROR:  REINDEX CONCURRENTLY is not supported
@@ -2262,15 +2263,16 @@ WHERE classid = 'pg_class'::regclass AND
                    obj                    |                           objref                           | deptype 
 ------------------------------------------+------------------------------------------------------------+---------
  index concur_reindex_ind1                | constraint concur_reindex_ind1 on table concur_reindex_tab | i
+ index concur_reindex_ind2                | collation "default"                                        | n
  index concur_reindex_ind2                | column c2 of table concur_reindex_tab                      | a
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
  index concur_reindex_ind3                | column c1 of table concur_reindex_tab                      | a
- index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
+ index concur_reindex_ind4                | collation "default"                                        | n
  index concur_reindex_ind4                | column c1 of table concur_reindex_tab                      | a
  index concur_reindex_ind4                | column c2 of table concur_reindex_tab                      | a
  materialized view concur_reindex_matview | schema public                                              | n
  table concur_reindex_tab                 | schema public                                              | n
-(9 rows)
+(10 rows)
 
 -- Check that comments are preserved
 CREATE TABLE testcomment (i int);
@@ -2734,6 +2736,17 @@ CREATE UNIQUE INDEX concur_exprs_index_pred ON concur_exprs_tab (c1)
 CREATE UNIQUE INDEX concur_exprs_index_pred_2
   ON concur_exprs_tab (c1, (1 / c1))
   WHERE ('-H') >= (c2::TEXT) COLLATE "C";
+ANALYZE concur_exprs_tab;
+SELECT starelid::regclass, count(*) FROM pg_statistic WHERE starelid IN (
+  'concur_exprs_index_expr'::regclass,
+  'concur_exprs_index_pred'::regclass,
+  'concur_exprs_index_pred_2'::regclass)
+  GROUP BY starelid ORDER BY starelid::regclass::text;
+        starelid         | count 
+-------------------------+-------
+ concur_exprs_index_expr |     1
+(1 row)
+
 SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
                                                   pg_get_indexdef                                                  
 -------------------------------------------------------------------------------------------------------------------
@@ -2790,6 +2803,17 @@ SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
                                                                pg_get_indexdef                                                                
 ----------------------------------------------------------------------------------------------------------------------------------------------
  CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= (c2 COLLATE "C"))
+(1 row)
+
+-- Statistics should remain intact.
+SELECT starelid::regclass, count(*) FROM pg_statistic WHERE starelid IN (
+  'concur_exprs_index_expr'::regclass,
+  'concur_exprs_index_pred'::regclass,
+  'concur_exprs_index_pred_2'::regclass)
+  GROUP BY starelid ORDER BY starelid::regclass::text;
+        starelid         | count 
+-------------------------+-------
+ concur_exprs_index_expr |     1
 (1 row)
 
 DROP TABLE concur_exprs_tab;


### PR DESCRIPTION
1. Commit 3165426e54df02a6199c0a216546e5095e875a0a replaced operators in
plans, so GPDB-specific plans have to be updated.

2. Commit 16fa9b2b30a357b4aea982bd878ec2e5e002dbcc reordered lines in
output, however those lines are missing in GPDB since merge commit
19cd1cf4b68faff2e29bc2fa884c480e4644cdb4.

3. Commit 257836a75585934cc05ed7a80bccf8190d41e056 added new output lines,
however GPDB has different lines nearby since
8b305092235fa0879589334837513f22bed339b1.

4. Commit a6642b3ae060976b42830b7dc8f29ec190ab05e4 added more tests for
concurrent reindex, however GPDB does not support it. Also, this commit
was already cherry-picked as 67a7c0f06be0da1cd466e24fb0c33b51308dc1e0.