### PR TITLE
Fix OID dispatching during index inheritance.

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -653,7 +653,6 @@ DefineIndex(Oid relationId,
 		shouldDispatch = false;
 	}
 
-
 	/*
 	 * Also don't dispatch this if it's part of an ALTER TABLE. We will dispatch
 	 * the whole ALTER TABLE command later.

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -654,13 +654,6 @@ DefineIndex(Oid relationId,
 	}
 
 	/*
-	 * Also don't dispatch this if it's part of an ALTER TABLE. We will dispatch
-	 * the whole ALTER TABLE command later.
-	 */
-	if (is_alter_table)
-		shouldDispatch = false;
-
-	/*
 	 * Some callers need us to run with an empty default_tablespace; this is a
 	 * necessary hack to be able to reproduce catalog state accurately when
 	 * recreating indexes after table-rewriting ALTER TABLE.

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -653,6 +653,14 @@ DefineIndex(Oid relationId,
 		shouldDispatch = false;
 	}
 
+
+	/*
+	 * Also don't dispatch this if it's part of an ALTER TABLE. We will dispatch
+	 * the whole ALTER TABLE command later.
+	 */
+	if (is_alter_table)
+		shouldDispatch = false;
+
 	/*
 	 * Some callers need us to run with an empty default_tablespace; this is a
 	 * necessary hack to be able to reproduce catalog state accurately when

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1779,7 +1779,7 @@ ProcessUtilitySlow(ParseState *pstate,
 					IndexStmt  *stmt = (IndexStmt *) parsetree;
 					Oid			relid;
 					LOCKMODE	lockmode;
-					bool		is_alter_table;
+					bool		is_alter_table = false; // see below
 
 					if (stmt->concurrent)
 						PreventInTransactionBlock(isTopLevel,
@@ -1850,6 +1850,29 @@ ProcessUtilitySlow(ParseState *pstate,
 					}
 
 					/*
+					 * Greengage specific behavior:
+					 * Postgres will pass false for is_alter_table for DefineIndex.
+					 * This argument is only used at two places in DefineIndex (in original postgres code):
+					 *   1. the function index_check_primary_key
+					 *   2. print a debug log on what the statement is
+					 *
+					 * In fact when calling DefineIndex here, we can always pass
+					 * false for is_alter_table when it actually comes from expandTableLikeClause:
+					 *   for 1, we are sure relationHasPrimaryKey check will pass because we are
+					 *   building a new relation with index here.
+					 *   for 2, I do not think it will mislead the user if we print it as CreateStmt.
+					 *
+					 * But for Greengage, is_alter_table matters a lot and has to be set false here:
+					 * DefineIndex need to dispatch, and if it is_alter_table is true, Greengage will
+					 * take this as a sub command of AlterTable stmt, thus it will not dispatch and
+					 * lead to errors. Thus, we comment off the following code and pass false for
+					 * is_alter_table for DefineIndex here.
+					 *
+					 * See following discussion for details:
+					 * https://www.postgresql.org/message-id/CANerzActdrdFO1r4RSqK0M2d0Xtwu5t5bH%3DZOoLsAQ%3DHhZrB%3Dg%40mail.gmail.com
+					 */
+#if 0
+					/*
 					 * If the IndexStmt is already transformed, it must have
 					 * come from generateClonedIndexStmt, which in current
 					 * usage means it came from expandTableLikeClause rather
@@ -1859,6 +1882,7 @@ ProcessUtilitySlow(ParseState *pstate,
 					 * worth adding a separate bool field for the purpose.)
 					 */
 					is_alter_table = stmt->transformed;
+#endif
 
 					/* Run parse analysis ... */
 					stmt = transformIndexStmt(relid, stmt, queryString);


### PR DESCRIPTION
Commit 5028981 refactored index inheritance during table creation,
although the earlier commit 19cd1cf had already disabled OID
dispatching during this process.