### PR TITLE
Fix remaining PG14 unit-test failures; document unit-test phase

### DIFF
--- a/src/backend/mock.mk
+++ b/src/backend/mock.mk
@@ -20,6 +20,21 @@ override CPPFLAGS+= -I$(top_srcdir)/src/backend/libpq \
 # postgres in src/backend/Makefile doesn't need this and -pthread.
 MOCK_LIBS := -ldl $(filter-out -ledit, $(LIBS)) $(LDAP_LIBS_BE) $(ICU_LIBS) $(ZSTD_LIBS)
 
+# The server variants of libpgcommon/libpgport are already part of $(OBJFILES)
+# (they sit at the end of objfiles.txt), but they are scanned *before* the mock
+# objects in the link line.  A mocked backend file can reference a symbol that
+# lives only in src/common -- e.g. PG14's fd.c references get_dirent_type(),
+# which is defined in common/file_utils.c.  That reference only becomes
+# unresolved once the linker reaches the mock object, i.e. after the server
+# archives have already been scanned, so the symbol would otherwise be resolved
+# by the FRONTEND libpgcommon.a in $(LIBS) -- pulling in fe_memutils.o /
+# file_utils.o and producing "multiple definition" errors against mcxt.o and
+# the mock (palloc, fsync_fname, durable_rename, ...).  Re-list the *server*
+# archives after the mock objects so such late references resolve against the
+# server variant (which omits the FRONTEND-only definitions).
+MOCK_SRV_LIBS := $(top_builddir)/src/common/libpgcommon_srv.a \
+				 $(top_builddir)/src/port/libpgport_srv.a
+
 # These files are not linked into test programs.
 EXCL_OBJS=\
 	src/backend/main/main.o \
@@ -121,7 +136,7 @@ WRAP_FUNCS=$(addprefix $(WRAP_FLAGS), \
 
 # The test target depends on $(OBJFILES) which would update files including mocks.
 %.t: $(OBJFILES) $(CMOCKERY_OBJS) $(MOCK_OBJS) %_test.o
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(call WRAP_FUNCS, $(top_srcdir)/$(subdir)/test/$*_test.c) $(call BACKEND_OBJS, $(top_srcdir)/$(subdir)/$*.o $(patsubst $(MOCK_DIR)/%_mock.o,$(top_builddir)/src/%.o, $^)) $(filter-out %/objfiles.txt, $^) $(MOCK_LIBS) -o $@
+	$(CXX) $(CFLAGS) $(LDFLAGS) $(call WRAP_FUNCS, $(top_srcdir)/$(subdir)/test/$*_test.c) $(call BACKEND_OBJS, $(top_srcdir)/$(subdir)/$*.o $(patsubst $(MOCK_DIR)/%_mock.o,$(top_builddir)/src/%.o, $^)) $(filter-out %/objfiles.txt, $^) $(MOCK_SRV_LIBS) $(MOCK_LIBS) -o $@
 
 # We'd like to call only src/backend, but it seems we should build src/port and
 # src/timezone before src/backend.  This is not the case when main build has finished,


### PR DESCRIPTION
Two genuine PG14 mock-test failures (the rest of the initial -j failures
were build races that pass serially):

- mock.mk: re-list the server libpgcommon_srv.a/libpgport_srv.a after the
  mock objects (MOCK_SRV_LIBS) so PG14 fd.c's get_dirent_type() reference
  resolves against the server common lib instead of pulling in the FRONTEND
  libpgcommon.a -- which dragged in frontend file_utils.o/fe_memutils.o and
  broke cdbappendonlyxlog.t with multiple-definition of fsync_fname/
  durable_rename (vs fd_mock.o) and palloc/pfree/... (vs mcxt.o).
- ftsmessagehandler_test.c: add expect_value for the new two_phase parameter
  of PG14 ReplicationSlotCreate() (test_HandleFtsWalRepPromoteMirror).

- GG_PG_13_14_MERGE_RULES.md: add the previously-undocumented unit-test
  phase. §11 covers errstart->errstart_cold EXPECT_EREPORT, the GUC coverage
  test + the 14 PG14 GUCs added to unsync_guc_name.h, mock linkage (uuid_le,
  get_dirent_type), mock param expectations, and the -j race caveat. §12
  tabulates the other API-shape changes (COPY kept monolithic, ConnParams/
  simple_prompt, ExecReindex, ProcedureCreate, cluster_rel, hex_encode,
  errcontext, nodeModifyTable, ReadNextTransactionId, protocol-v2 removal).

Full `make -s unittest-check` (backend + src/bin) now passes serially:
53/53 mock suites.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
(cherry picked from commit https://github.com/arenadata/gpdb/commit/a8db552f7b2a5e44158a0e7035a0afdb0ef8be99)

Changes from original commit

1) GG_PG_13_14_MERGE_RULES.md removed.
2) Changes in ftsmessagehandler_test removed.

---
!!! REBASE !!!