### PR TITLE
Resolve conflicts in src/interfaces/ecpg/test/pg_regress_ecpg.c

### DIFF
--- a/src/interfaces/ecpg/test/pg_regress_ecpg.c
+++ b/src/interfaces/ecpg/test/pg_regress_ecpg.c
@@ -21,10 +21,7 @@
 #include "pg_regress.h"
 #include "common/string.h"
 #include "lib/stringinfo.h"
-<<<<<<< HEAD
-=======
 
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 static void
 ecpg_filter(const char *sourcefile, const char *outfile)
@@ -164,10 +161,7 @@ ecpg_start_test(const char *testname,
 
 	unsetenv("PGAPPNAME");
 	free(appnameenv);
-<<<<<<< HEAD
-=======
 
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 	free(testname_dash.data);
 
 	return pid;


### PR DESCRIPTION
1) Commit 784b1ba in src/interfaces/ecpg/test/pg_regress_ecpg.c removed
the LINEBUFSIZE define. An earlier commit, b4c36a1, had already done
the same but also removed the empty line.

2) Commit 784b1ba in src/interfaces/ecpg/test/pg_regress_ecpg.c in the
ecpg_start_test function replaced free(testname_dash) and three others
below with free(testname_dash.data). An earlier commit, b4c36a1, had
already done the same but also removed the empty line.