### PR TITLE
Resolve conflicts in src/test/isolation/isolation_schedule

### DIFF
--- a/src/test/isolation/expected/horizons.out
+++ b/src/test/isolation/expected/horizons.out
@@ -18,6 +18,7 @@ step pruner_query_plan:
 QUERY PLAN     
 
 Index Only Scan using horizons_tst_data_key on horizons_tst
+Optimizer: Postgres query optimizer
 step pruner_query: 
     SELECT explain_json($$
         EXPLAIN (FORMAT json, BUFFERS, ANALYZE)
@@ -76,6 +77,7 @@ step pruner_query_plan:
 QUERY PLAN     
 
 Index Only Scan using horizons_tst_data_key on horizons_tst
+Optimizer: Postgres query optimizer
 step pruner_query: 
     SELECT explain_json($$
         EXPLAIN (FORMAT json, BUFFERS, ANALYZE)

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -101,8 +101,8 @@ test: delete-abort-savept
 #test: lock-committed-update
 #test: lock-committed-keyupdate
 test: update-locked-tuple
-<<<<<<< HEAD
 #test: reindex-concurrently
+#test: reindex-schema
 #test: propagate-lock-delete
 #test: tuplelock-conflict
 #test: tuplelock-update
@@ -117,24 +117,6 @@ test: update-locked-tuple
 #test: skip-locked-2
 #test: skip-locked-3
 #test: skip-locked-4
-=======
-test: reindex-concurrently
-test: reindex-schema
-test: propagate-lock-delete
-test: tuplelock-conflict
-test: tuplelock-update
-test: tuplelock-upgrade-no-deadlock
-test: freeze-the-dead
-test: nowait
-test: nowait-2
-test: nowait-3
-test: nowait-4
-test: nowait-5
-test: skip-locked
-test: skip-locked-2
-test: skip-locked-3
-test: skip-locked-4
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 test: drop-index-concurrently-1
 #test: multiple-cic
 test: alter-table-1
@@ -151,10 +133,11 @@ test: timeouts
 test: vacuum-concurrent-drop
 test: vacuum-conflict
 test: vacuum-skip-locked
-<<<<<<< HEAD
+test: horizons
 #test: predicate-hash
 #test: predicate-gist
 #test: predicate-gin
+#test: partition-concurrent-attach
 
 test: partition-drop-index-locking
 
@@ -162,14 +145,6 @@ test: partition-drop-index-locking
 # because it fails when test errors from ExecLockRows. The reason is that
 # GPDB disabled triggers for foreign keys.
 #test: partition-key-update-1
-=======
-test: horizons
-test: predicate-hash
-test: predicate-gist
-test: predicate-gin
-test: partition-concurrent-attach
-test: partition-key-update-1
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 test: partition-key-update-2
 test: partition-key-update-3
 test: partition-key-update-4


### PR DESCRIPTION
1) Commit 1d65416 in src/test/isolation/isolation_schedule added a new
reindex-schema test, while earlier GPDB-specific commits had already
disabled the adjacent tests. Concurrent reindex is not supported in
GPDB.

2) Commits 94bc27b and f481d28 in src/test/isolation/isolation_schedule
added new horizons and partition-concurrent-attach tests, while earlier
GPDB-specific commits had already disabled the adjacent tests.
Concurrent attach partition is not supported in GPDB.