### PR TITLE
Resolve conflicts in src/test/regress/expected/create_am.out

### DIFF
--- a/src/test/regress/expected/create_am.out
+++ b/src/test/regress/expected/create_am.out
@@ -46,7 +46,6 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
     WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
-<<<<<<< HEAD
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -54,18 +53,9 @@ SELECT * FROM fast_emp4000
    ->  Sort
          Sort Key: ((home_base[0])[0])
          ->  Index Only Scan using grect2ind2 on fast_emp4000
-               Index Cond: (home_base @ '(2000,1000),(200,200)'::box)
+               Index Cond: (home_base <@ '(2000,1000),(200,200)'::box)
  Optimizer: Postgres query optimizer
 (7 rows)
-=======
-                           QUERY PLAN                            
------------------------------------------------------------------
- Sort
-   Sort Key: ((home_base[0])[0])
-   ->  Index Only Scan using grect2ind2 on fast_emp4000
-         Index Cond: (home_base <@ '(2000,1000),(200,200)'::box)
-(4 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 SELECT * FROM fast_emp4000
     WHERE home_base <@ '(200,200),(2000,1000)'::box

--- a/src/test/regress/expected/create_am_optimizer.out
+++ b/src/test/regress/expected/create_am_optimizer.out
@@ -27,8 +27,6 @@ CREATE OPERATOR CLASS box_ops DEFAULT
 	OPERATOR 10	<<|,
 	OPERATOR 11	|>>,
 	OPERATOR 12	|&>,
-	OPERATOR 13	~,
-	OPERATOR 14	@,
 	FUNCTION 1	gist_box_consistent(internal, box, smallint, oid, internal),
 	FUNCTION 2	gist_box_union(internal, internal),
 	-- don't need compress, decompress, or fetch functions
@@ -46,7 +44,7 @@ SET enable_indexscan = ON;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT * FROM fast_emp4000
-    WHERE home_base @ '(200,200),(2000,1000)'::box
+    WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
                                QUERY PLAN                               
 ------------------------------------------------------------------------
@@ -56,12 +54,12 @@ SELECT * FROM fast_emp4000
          ->  Sort
                Sort Key: ((home_base[0])[0])
                ->  Seq Scan on fast_emp4000
-                     Filter: (home_base @ '(2000,1000),(200,200)'::box)
+                     Filter: (home_base <@ '(2000,1000),(200,200)'::box)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (8 rows)
 
 SELECT * FROM fast_emp4000
-    WHERE home_base @ '(200,200),(2000,1000)'::box
+    WHERE home_base <@ '(200,200),(2000,1000)'::box
     ORDER BY (home_base[0])[0];
        home_base       
 -----------------------
@@ -110,8 +108,13 @@ ERROR:  cannot drop access method gist2 because other objects depend on it
 DETAIL:  index grect2ind2 depends on operator class box_ops for access method gist2
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 -- Drop access method cascade
+-- To prevent a (rare) deadlock against autovacuum,
+-- we must lock the table that owns the index that will be dropped
+BEGIN;
+LOCK TABLE fast_emp4000;
 DROP ACCESS METHOD gist2 CASCADE;
 NOTICE:  drop cascades to index grect2ind2
+COMMIT;
 --
 -- Test table access methods
 --


### PR DESCRIPTION
Commit 3165426e54df02a6199c0a216546e5095e875a0a removed the @ operator,
so GPDB-specific plan has to be updated. Also update ORCA output for it and
also commit d54f99e41541de848a6ca53b3ec060f461e9ab71.