### PR TITLE
Resolve conflicts in src/test/perl/PostgresNode.pm

### DIFF
--- a/src/test/perl/PostgresNode.pm
+++ b/src/test/perl/PostgresNode.pm
@@ -510,27 +510,17 @@ sub init
 		{
 			print $conf "wal_level = replica\n";
 		}
-<<<<<<< HEAD
-		print $conf "max_wal_senders = 5\n";
-		print $conf "max_replication_slots = 5\n";
-		# PG sets this to 128MB but that makes checkpoint too frequent for GPDB. 
-		# 512MB corresponds to the ratio of GPDB seg size (64) over PG seg size (16).
-		print $conf "max_wal_size = 512MB\n";
-		print $conf "shared_buffers = 1MB\n";
-		print $conf "wal_log_hints = on\n";
-		print $conf "hot_standby = on\n";
-		print $conf "max_connections = 20\n";
-=======
 		print $conf "max_wal_senders = 10\n";
 		print $conf "max_replication_slots = 10\n";
 		print $conf "wal_log_hints = on\n";
 		print $conf "hot_standby = on\n";
 		# conservative settings to ensure we can run multiple postmasters:
 		print $conf "shared_buffers = 1MB\n";
-		print $conf "max_connections = 10\n";
+		print $conf "max_connections = 20\n";
 		# limit disk space consumption, too:
-		print $conf "max_wal_size = 128MB\n";
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+		# PG sets this to 128MB but that makes checkpoint too frequent for GPDB. 
+		# 512MB corresponds to the ratio of GPDB seg size (64) over PG seg size (16).
+		print $conf "max_wal_size = 512MB\n";
 	}
 	else
 	{
@@ -621,15 +611,10 @@ sub backup
 	my $name        = $self->name;
 
 	print "# Taking pg_basebackup $backup_name from node \"$name\"\n";
-<<<<<<< HEAD
-	TestLib::system_or_bail('pg_basebackup', '-D', $backup_path, '-h',
-		$self->host, '-p', $self->port, '--no-sync', '--target-gp-dbid', 99);
-=======
 	TestLib::system_or_bail(
 		'pg_basebackup', '-D', $backup_path, '-h',
 		$self->host,     '-p', $self->port,  '--checkpoint',
-		'fast',          '--no-sync');
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+		'fast',          '--no-sync', '--target-gp-dbid', 99);
 	print "# Backup finished\n";
 	return;
 }


### PR DESCRIPTION
1) Commit 151c0c5 in the file src/test/perl/PostgresNode.pm in the init
function removed the explicit setting of replication values, and commit
4964253 returned them back, but in a different order and with different
values, while the earlier commit 39c159b had already increased the
max_wal_size parameter from 128 to 512, and commit 19cd1cf had already
increased max_connections parameter from 10 to 20.

2) Commit 831611b in the file src/test/perl/PostgresNode.pm added a
fast checkpoint to the backup function, while the earlier commit
19cd1cf already added target-gp-dbid in the same place.