### PR TITLE
Resolve conflicts in insert_conflict.out and updatable_views.out

### DIFF
--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -53,22 +53,12 @@ explain (costs off) insert into insertconflicttest values(0, 'Crowberry') on con
    Conflict Filter: (SubPlan 1)
    ->  Result
    SubPlan 1
-<<<<<<< HEAD
      ->  Result
            Filter: (ii.key = excluded.key)
            ->  Materialize
                  ->  Broadcast Motion 3:1  (slice1; segments: 3)
                        ->  Seq Scan on insertconflicttest ii
-   SubPlan 2
-     ->  Broadcast Motion 3:1  (slice2; segments: 3)
-           ->  Seq Scan on insertconflicttest ii_1
- Optimizer: Postgres query optimizer
-(15 rows)
-=======
-     ->  Index Only Scan using both_index_expr_key on insertconflicttest ii
-           Index Cond: (key = excluded.key)
 (8 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
 
 -- Neither collation nor operator class specifications are required --
 -- supplying them merely *limits* matches to indexes with matching opclasses

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -889,14 +889,18 @@ rollback;  -- to get rid of the bogus operator
 explain (costs off)
 select count(*) from tenk1 t
 where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0);
-                          QUERY PLAN                          
---------------------------------------------------------------
- Aggregate
-   ->  Seq Scan on tenk1 t
-         Filter: ((hashed SubPlan 2) OR (ten < 0))
-         SubPlan 2
-           ->  Index Only Scan using tenk1_unique1 on tenk1 k
-(5 rows)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Seq Scan on tenk1 t
+                     Filter: ((hashed SubPlan 2) OR (ten < 0))
+                     SubPlan 2
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Seq Scan on tenk1 k
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 select count(*) from tenk1 t
 where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0);
@@ -909,18 +913,24 @@ explain (costs off)
 select count(*) from tenk1 t
 where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)
   and thousand = 1;
-                          QUERY PLAN                          
---------------------------------------------------------------
- Aggregate
-   ->  Bitmap Heap Scan on tenk1 t
-         Recheck Cond: (thousand = 1)
-         Filter: ((SubPlan 1) OR (ten < 0))
-         ->  Bitmap Index Scan on tenk1_thous_tenthous
-               Index Cond: (thousand = 1)
-         SubPlan 1
-           ->  Index Only Scan using tenk1_unique1 on tenk1 k
-                 Index Cond: (unique1 = t.unique2)
-(9 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on tenk1 t
+                     Recheck Cond: (thousand = 1)
+                     Filter: ((SubPlan 1) OR (ten < 0))
+                     ->  Bitmap Index Scan on tenk1_thous_tenthous
+                           Index Cond: (thousand = 1)
+                     SubPlan 1
+                       ->  Result
+                             Filter: (k.unique1 = t.unique2)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on tenk1 k
+ Optimizer: Postgres query optimizer
+(15 rows)
 
 select count(*) from tenk1 t
 where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -927,6 +927,71 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
 
 rollback;  -- to get rid of the bogus operator
 --
+-- Test resolution of hashed vs non-hashed implementation of EXISTS subplan
+--
+explain (costs off)
+select count(*) from tenk1 t
+where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0);
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  HashAggregate
+                     Group Key: tenk1.unique1, tenk1.unique2, tenk1.ten, tenk1.ctid, tenk1.gp_segment_id, (true)
+                     ->  Result
+                           Filter: (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END OR (tenk1.ten < 0))
+                           ->  Hash Left Join
+                                 Hash Cond: (tenk1.unique2 = tenk1_1.unique1)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: tenk1.unique2
+                                       ->  Seq Scan on tenk1
+                                 ->  Hash
+                                       ->  Seq Scan on tenk1 tenk1_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select count(*) from tenk1 t
+where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0);
+ count 
+-------
+ 10000
+(1 row)
+
+explain (costs off)
+select count(*) from tenk1 t
+where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)
+  and thousand = 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  GroupAggregate
+               Group Key: tenk1_1.unique1, tenk1_1.unique2, tenk1_1.ten, tenk1_1.thousand, tenk1_1.ctid, tenk1_1.gp_segment_id, (true)
+               ->  Sort
+                     Sort Key: tenk1_1.unique1, tenk1_1.unique2, tenk1_1.ten, tenk1_1.thousand, tenk1_1.ctid, tenk1_1.gp_segment_id, (true)
+                     ->  Result
+                           Filter: (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END OR (tenk1_1.ten < 0))
+                           ->  Hash Right Join
+                                 Hash Cond: (tenk1.unique1 = tenk1_1.unique2)
+                                 ->  Seq Scan on tenk1
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                             Hash Key: tenk1_1.unique2
+                                             ->  Index Scan using tenk1_thous_tenthous on tenk1 tenk1_1
+                                                   Index Cond: (thousand = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+select count(*) from tenk1 t
+where (exists(select 1 from tenk1 k where k.unique1 = t.unique2) or ten < 0)
+  and thousand = 1;
+ count 
+-------
+    10
+(1 row)
+
+--
 -- Test case for planner bug with nested EXISTS handling
 --
 -- GPDB_92_MERGE_FIXME: ORCA cannot decorrelate this query, and generates

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -1915,22 +1915,13 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
  Insert on base_tbl b
    ->  Result
    SubPlan 1
-<<<<<<< HEAD
      ->  Result
            Filter: (r.a = b.a)
            ->  Materialize
                  ->  Broadcast Motion 3:1  (slice1; segments: 3)
                        ->  Seq Scan on ref_tbl r
-   SubPlan 2
-     ->  Broadcast Motion 3:1  (slice2; segments: 3)
-           ->  Seq Scan on ref_tbl r_1
  Optimizer: Postgres query optimizer
-(12 rows)
-=======
-     ->  Index Only Scan using ref_tbl_pkey on ref_tbl r
-           Index Cond: (a = b.a)
-(5 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+(9 rows)
 
 ANALYZE base_tbl;
 EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
@@ -1944,22 +1935,13 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
                      ->  Seq Scan on base_tbl b
                      ->  Seq Scan on ref_tbl r
    SubPlan 1
-<<<<<<< HEAD
      ->  Result
            Filter: (r_1.a = b.a)
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice2; segments: 3)
                        ->  Seq Scan on ref_tbl r_1
-   SubPlan 2
-     ->  Broadcast Motion 3:3  (slice3; segments: 3)
-           ->  Seq Scan on ref_tbl r_2
  Optimizer: Postgres query optimizer
-(17 rows)
-=======
-     ->  Index Only Scan using ref_tbl_pkey on ref_tbl r_1
-           Index Cond: (a = b.a)
-(9 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+(14 rows)
 
 DROP TABLE base_tbl, ref_tbl CASCADE;
 NOTICE:  drop cascades to view rw_view1
@@ -2397,26 +2379,20 @@ SELECT * FROM v1 WHERE a=8;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
-<<<<<<< HEAD
-                                                                                         QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-=======
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1
    Update on public.t1
    Update on public.t11 t1_1
    Update on public.t12 t1_2
    Update on public.t111 t1_3
-<<<<<<< HEAD
    ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
          Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id, (DMLAction)
          ->  Split
                Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t1
                      Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id
-                     Filter: ((t1.a > 5) AND (t1.a < 7) AND (t1.a <> 6) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
+                     Filter: ((t1.a > 5) AND (t1.a < 7) AND (t1.a <> 6) AND (SubPlan 1 (copy 11)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
                              Filter: (t12_1.a = t1.a)
@@ -2429,123 +2405,66 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                                                      Output: t12_1.a
                                                ->  Seq Scan on public.t111 t12_2
                                                      Output: t12_2.a
-                     SubPlan 2 (copy 12)
-                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                             Output: t12_4.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_4
-                                         Output: t12_4.a
-                                   ->  Seq Scan on public.t111 t12_5
-                                         Output: t12_5.a
-   ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
          Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
                Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t11 t1_1
                      Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id
-                     Filter: ((t1_1.a > 5) AND (t1_1.a < 7) AND (t1_1.a <> 6) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
+                     Filter: ((t1_1.a > 5) AND (t1_1.a < 7) AND (t1_1.a <> 6) AND (SubPlan 1 (copy 13)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_7.a = t1_1.a)
+                             Filter: (t12_4.a = t1_1.a)
+                             ->  Materialize
+                                   Output: t12_4.a
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                         Output: t12_4.a
+                                         ->  Append
+                                               ->  Seq Scan on public.t12 t12_4
+                                                     Output: t12_4.a
+                                               ->  Seq Scan on public.t111 t12_5
+                                                     Output: t12_5.a
+   ->  Explicit Redistribute Motion 3:3  (slice5; segments: 3)
+         Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
+         ->  Split
+               Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t12 t1_2
+                     Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
+                     Filter: ((t1_2.a > 5) AND (t1_2.a < 7) AND (t1_2.a <> 6) AND (SubPlan 1 (copy 15)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
+                     SubPlan 1 (copy 15)
+                       ->  Result
+                             Filter: (t12_7.a = t1_2.a)
                              ->  Materialize
                                    Output: t12_7.a
-                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                   ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                          Output: t12_7.a
                                          ->  Append
                                                ->  Seq Scan on public.t12 t12_7
                                                      Output: t12_7.a
                                                ->  Seq Scan on public.t111 t12_8
                                                      Output: t12_8.a
-                     SubPlan 2 (copy 14)
-                       ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                             Output: t12_10.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
-         Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
-         ->  Split
-               Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
-               ->  Seq Scan on public.t12 t1_2
-                     Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
-                     Filter: ((t1_2.a > 5) AND (t1_2.a < 7) AND (t1_2.a <> 6) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-                     SubPlan 1 (copy 15)
-                       ->  Result
-                             Filter: (t12_13.a = t1_2.a)
-                             ->  Materialize
-                                   Output: t12_13.a
-                                   ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                                         Output: t12_13.a
-                                         ->  Append
-                                               ->  Seq Scan on public.t12 t12_13
-                                                     Output: t12_13.a
-                                               ->  Seq Scan on public.t111 t12_14
-                                                     Output: t12_14.a
-                     SubPlan 2 (copy 16)
-                       ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                             Output: t12_16.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_16
-                                         Output: t12_16.a
-                                   ->  Seq Scan on public.t111 t12_17
-                                         Output: t12_17.a
-   ->  Explicit Redistribute Motion 3:3  (slice10; segments: 3)
          Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
                Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, DMLAction
                ->  Seq Scan on public.t111 t1_3
                      Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id
-                     Filter: ((t1_3.a > 5) AND (t1_3.a < 7) AND (t1_3.a <> 6) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
+                     Filter: ((t1_3.a > 5) AND (t1_3.a < 7) AND (t1_3.a <> 6) AND (SubPlan 1 (copy 17)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_19.a = t1_3.a)
+                             Filter: (t12_10.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_19.a
-                                   ->  Broadcast Motion 3:3  (slice11; segments: 3)
-                                         Output: t12_19.a
+                                   Output: t12_10.a
+                                   ->  Broadcast Motion 3:3  (slice8; segments: 3)
+                                         Output: t12_10.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_19
-                                                     Output: t12_19.a
-                                               ->  Seq Scan on public.t111 t12_20
-                                                     Output: t12_20.a
-                     SubPlan 2 (copy 18)
-                       ->  Broadcast Motion 3:3  (slice12; segments: 3)
-                             Output: t12_22.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_22
-                                         Output: t12_22.a
-                                   ->  Seq Scan on public.t111 t12_23
-                                         Output: t12_23.a
+                                               ->  Seq Scan on public.t12 t12_10
+                                                     Output: t12_10.a
+                                               ->  Seq Scan on public.t111 t12_11
+                                                     Output: t12_11.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on', optimizer = 'off'
-(115 rows)
-=======
-   ->  Index Scan using t1_a_idx on public.t1
-         Output: 100, t1.b, t1.c, t1.ctid
-         Index Cond: ((t1.a > 5) AND (t1.a < 7))
-         Filter: ((t1.a <> 6) AND (SubPlan 1) AND snoop(t1.a) AND leakproof(t1.a))
-         SubPlan 1
-           ->  Append
-                 ->  Seq Scan on public.t12 t12_1
-                       Filter: (t12_1.a = t1.a)
-                 ->  Seq Scan on public.t111 t12_2
-                       Filter: (t12_2.a = t1.a)
-   ->  Index Scan using t11_a_idx on public.t11 t1_1
-         Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid
-         Index Cond: ((t1_1.a > 5) AND (t1_1.a < 7))
-         Filter: ((t1_1.a <> 6) AND (SubPlan 1) AND snoop(t1_1.a) AND leakproof(t1_1.a))
-   ->  Index Scan using t12_a_idx on public.t12 t1_2
-         Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid
-         Index Cond: ((t1_2.a > 5) AND (t1_2.a < 7))
-         Filter: ((t1_2.a <> 6) AND (SubPlan 1) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-   ->  Index Scan using t111_a_idx on public.t111 t1_3
-         Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid
-         Index Cond: ((t1_3.a > 5) AND (t1_3.a < 7))
-         Filter: ((t1_3.a <> 6) AND (SubPlan 1) AND snoop(t1_3.a) AND leakproof(t1_3.a))
-(27 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+(83 rows)
 
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
 SELECT * FROM v1 WHERE a=100; -- Nothing should have been changed to 100
@@ -2560,26 +2479,20 @@ SELECT * FROM t1 WHERE a=100; -- Nothing should have been changed to 100
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
-<<<<<<< HEAD
-                                                                                QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-=======
-                               QUERY PLAN                                
--------------------------------------------------------------------------
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1
    Update on public.t1
    Update on public.t11 t1_1
    Update on public.t12 t1_2
    Update on public.t111 t1_3
-<<<<<<< HEAD
    ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)
          Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, (DMLAction)
          ->  Split
                Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t1
                      Output: (t1.a + 1), t1.b, t1.c, t1.ctid, t1.gp_segment_id
-                     Filter: ((t1.a > 5) AND (t1.a = 8) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
+                     Filter: ((t1.a > 5) AND (t1.a = 8) AND (SubPlan 1 (copy 11)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
                              Filter: (t12_1.a = t1.a)
@@ -2592,123 +2505,66 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                                      Output: t12_1.a
                                                ->  Seq Scan on public.t111 t12_2
                                                      Output: t12_2.a
-                     SubPlan 2 (copy 12)
-                       ->  Broadcast Motion 3:1  (slice3; segments: 3)
-                             Output: t12_4.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_4
-                                         Output: t12_4.a
-                                   ->  Seq Scan on public.t111 t12_5
-                                         Output: t12_5.a
-   ->  Explicit Redistribute Motion 1:3  (slice4; segments: 1)
+   ->  Explicit Redistribute Motion 1:3  (slice3; segments: 1)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
                Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t11 t1_1
                      Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id
-                     Filter: ((t1_1.a > 5) AND (t1_1.a = 8) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
+                     Filter: ((t1_1.a > 5) AND (t1_1.a = 8) AND (SubPlan 1 (copy 13)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_7.a = t1_1.a)
+                             Filter: (t12_4.a = t1_1.a)
+                             ->  Materialize
+                                   Output: t12_4.a
+                                   ->  Broadcast Motion 3:1  (slice4; segments: 3)
+                                         Output: t12_4.a
+                                         ->  Append
+                                               ->  Seq Scan on public.t12 t12_4
+                                                     Output: t12_4.a
+                                               ->  Seq Scan on public.t111 t12_5
+                                                     Output: t12_5.a
+   ->  Explicit Redistribute Motion 1:3  (slice5; segments: 1)
+         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
+         ->  Split
+               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t12 t1_2
+                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
+                     Filter: ((t1_2.a > 5) AND (t1_2.a = 8) AND (SubPlan 1 (copy 15)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
+                     SubPlan 1 (copy 15)
+                       ->  Result
+                             Filter: (t12_7.a = t1_2.a)
                              ->  Materialize
                                    Output: t12_7.a
-                                   ->  Broadcast Motion 3:1  (slice5; segments: 3)
+                                   ->  Broadcast Motion 3:1  (slice6; segments: 3)
                                          Output: t12_7.a
                                          ->  Append
                                                ->  Seq Scan on public.t12 t12_7
                                                      Output: t12_7.a
                                                ->  Seq Scan on public.t111 t12_8
                                                      Output: t12_8.a
-                     SubPlan 2 (copy 14)
-                       ->  Broadcast Motion 3:1  (slice6; segments: 3)
-                             Output: t12_10.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 1:3  (slice7; segments: 1)
-         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
-         ->  Split
-               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
-               ->  Seq Scan on public.t12 t1_2
-                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
-                     Filter: ((t1_2.a > 5) AND (t1_2.a = 8) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-                     SubPlan 1 (copy 15)
-                       ->  Result
-                             Filter: (t12_13.a = t1_2.a)
-                             ->  Materialize
-                                   Output: t12_13.a
-                                   ->  Broadcast Motion 3:1  (slice8; segments: 3)
-                                         Output: t12_13.a
-                                         ->  Append
-                                               ->  Seq Scan on public.t12 t12_13
-                                                     Output: t12_13.a
-                                               ->  Seq Scan on public.t111 t12_14
-                                                     Output: t12_14.a
-                     SubPlan 2 (copy 16)
-                       ->  Broadcast Motion 3:1  (slice9; segments: 3)
-                             Output: t12_16.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_16
-                                         Output: t12_16.a
-                                   ->  Seq Scan on public.t111 t12_17
-                                         Output: t12_17.a
-   ->  Explicit Redistribute Motion 1:3  (slice10; segments: 1)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
                Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, DMLAction
                ->  Seq Scan on public.t111 t1_3
                      Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id
-                     Filter: ((t1_3.a > 5) AND (t1_3.a = 8) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
+                     Filter: ((t1_3.a > 5) AND (t1_3.a = 8) AND (SubPlan 1 (copy 17)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_19.a = t1_3.a)
+                             Filter: (t12_10.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_19.a
-                                   ->  Broadcast Motion 3:1  (slice11; segments: 3)
-                                         Output: t12_19.a
+                                   Output: t12_10.a
+                                   ->  Broadcast Motion 3:1  (slice8; segments: 3)
+                                         Output: t12_10.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_19
-                                                     Output: t12_19.a
-                                               ->  Seq Scan on public.t111 t12_20
-                                                     Output: t12_20.a
-                     SubPlan 2 (copy 18)
-                       ->  Broadcast Motion 3:1  (slice12; segments: 3)
-                             Output: t12_22.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_22
-                                         Output: t12_22.a
-                                   ->  Seq Scan on public.t111 t12_23
-                                         Output: t12_23.a
+                                               ->  Seq Scan on public.t12 t12_10
+                                                     Output: t12_10.a
+                                               ->  Seq Scan on public.t111 t12_11
+                                                     Output: t12_11.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on', optimizer = 'off'
-(115 rows)
-=======
-   ->  Index Scan using t1_a_idx on public.t1
-         Output: (t1.a + 1), t1.b, t1.c, t1.ctid
-         Index Cond: ((t1.a > 5) AND (t1.a = 8))
-         Filter: ((SubPlan 1) AND snoop(t1.a) AND leakproof(t1.a))
-         SubPlan 1
-           ->  Append
-                 ->  Seq Scan on public.t12 t12_1
-                       Filter: (t12_1.a = t1.a)
-                 ->  Seq Scan on public.t111 t12_2
-                       Filter: (t12_2.a = t1.a)
-   ->  Index Scan using t11_a_idx on public.t11 t1_1
-         Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid
-         Index Cond: ((t1_1.a > 5) AND (t1_1.a = 8))
-         Filter: ((SubPlan 1) AND snoop(t1_1.a) AND leakproof(t1_1.a))
-   ->  Index Scan using t12_a_idx on public.t12 t1_2
-         Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid
-         Index Cond: ((t1_2.a > 5) AND (t1_2.a = 8))
-         Filter: ((SubPlan 1) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-   ->  Index Scan using t111_a_idx on public.t111 t1_3
-         Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid
-         Index Cond: ((t1_3.a > 5) AND (t1_3.a = 8))
-         Filter: ((SubPlan 1) AND snoop(t1_3.a) AND leakproof(t1_3.a))
-(27 rows)
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d
+(83 rows)
 
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
 NOTICE:  snooped value: 8  (seg0 slice4 127.0.0.1:40000 pid=26920)

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -1483,6 +1483,41 @@ NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to view rw_view1
 drop cascades to view rw_view2
 drop cascades to view rw_view3
+-- view on table with GENERATED columns
+CREATE TABLE base_tbl (id int, idplus1 int GENERATED ALWAYS AS (id + 1) STORED);
+CREATE VIEW rw_view1 AS SELECT * FROM base_tbl;
+INSERT INTO base_tbl (id) VALUES (1);
+INSERT INTO rw_view1 (id) VALUES (2);
+INSERT INTO base_tbl (id, idplus1) VALUES (3, DEFAULT);
+INSERT INTO rw_view1 (id, idplus1) VALUES (4, DEFAULT);
+INSERT INTO base_tbl (id, idplus1) VALUES (5, 6);  -- error
+ERROR:  cannot insert into column "idplus1"
+DETAIL:  Column "idplus1" is a generated column.
+INSERT INTO rw_view1 (id, idplus1) VALUES (6, 7);  -- error
+ERROR:  cannot insert into column "idplus1"
+DETAIL:  Column "idplus1" is a generated column.
+SELECT * FROM base_tbl;
+ id | idplus1 
+----+---------
+  1 |       2
+  2 |       3
+  3 |       4
+  4 |       5
+(4 rows)
+
+UPDATE base_tbl SET id = 2000 WHERE id = 2;
+UPDATE rw_view1 SET id = 3000 WHERE id = 3;
+SELECT * FROM base_tbl;
+  id  | idplus1 
+------+---------
+    4 |       5
+ 2000 |    2001
+    1 |       2
+ 3000 |    3001
+(4 rows)
+
+DROP TABLE base_tbl CASCADE;
+NOTICE:  drop cascades to view rw_view1
 -- inheritance tests
 CREATE TABLE base_tbl_parent (a int);
 CREATE TABLE base_tbl_child (CHECK (a > 0)) INHERITS (base_tbl_parent);
@@ -1895,9 +1930,6 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (5);
            ->  Materialize
                  ->  Broadcast Motion 3:1  (slice1; segments: 3)
                        ->  Seq Scan on ref_tbl r
-   SubPlan 2
-     ->  Broadcast Motion 3:1  (slice2; segments: 3)
-           ->  Seq Scan on ref_tbl r_1
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -1918,9 +1950,6 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a = a + 5;
            ->  Materialize
                  ->  Broadcast Motion 3:3  (slice2; segments: 3)
                        ->  Seq Scan on ref_tbl r_1
-   SubPlan 2
-     ->  Broadcast Motion 3:3  (slice3; segments: 3)
-           ->  Seq Scan on ref_tbl r_2
  Optimizer: Postgres query optimizer
 (18 rows)
 
@@ -2376,8 +2405,8 @@ SELECT * FROM v1 WHERE a=8;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
-                                                                                         QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1
    Update on public.t1
    Update on public.t11 t1_1
@@ -2389,7 +2418,7 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t1
                      Output: 100, t1.b, t1.c, t1.ctid, t1.gp_segment_id
-                     Filter: ((t1.a > 5) AND (t1.a < 7) AND (t1.a <> 6) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
+                     Filter: ((t1.a > 5) AND (t1.a < 7) AND (t1.a <> 6) AND (SubPlan 1 (copy 11)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
                              Filter: (t12_1.a = t1.a)
@@ -2402,98 +2431,66 @@ UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
                                                      Output: t12_1.a
                                                ->  Seq Scan on public.t111 t12_2
                                                      Output: t12_2.a
-                     SubPlan 2 (copy 12)
-                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                             Output: t12_4.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_4
-                                         Output: t12_4.a
-                                   ->  Seq Scan on public.t111 t12_5
-                                         Output: t12_5.a
-   ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)
          Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
                Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t11 t1_1
                      Output: 100, t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id
-                     Filter: ((t1_1.a > 5) AND (t1_1.a < 7) AND (t1_1.a <> 6) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
+                     Filter: ((t1_1.a > 5) AND (t1_1.a < 7) AND (t1_1.a <> 6) AND (SubPlan 1 (copy 13)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_7.a = t1_1.a)
+                             Filter: (t12_4.a = t1_1.a)
+                             ->  Materialize
+                                   Output: t12_4.a
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                         Output: t12_4.a
+                                         ->  Append
+                                               ->  Seq Scan on public.t12 t12_4
+                                                     Output: t12_4.a
+                                               ->  Seq Scan on public.t111 t12_5
+                                                     Output: t12_5.a
+   ->  Explicit Redistribute Motion 3:3  (slice5; segments: 3)
+         Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
+         ->  Split
+               Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t12 t1_2
+                     Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
+                     Filter: ((t1_2.a > 5) AND (t1_2.a < 7) AND (t1_2.a <> 6) AND (SubPlan 1 (copy 15)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
+                     SubPlan 1 (copy 15)
+                       ->  Result
+                             Filter: (t12_7.a = t1_2.a)
                              ->  Materialize
                                    Output: t12_7.a
-                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                   ->  Broadcast Motion 3:3  (slice6; segments: 3)
                                          Output: t12_7.a
                                          ->  Append
                                                ->  Seq Scan on public.t12 t12_7
                                                      Output: t12_7.a
                                                ->  Seq Scan on public.t111 t12_8
                                                      Output: t12_8.a
-                     SubPlan 2 (copy 14)
-                       ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                             Output: t12_10.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 3:3  (slice7; segments: 3)
-         Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
-         ->  Split
-               Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
-               ->  Seq Scan on public.t12 t1_2
-                     Output: 100, t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
-                     Filter: ((t1_2.a > 5) AND (t1_2.a < 7) AND (t1_2.a <> 6) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-                     SubPlan 1 (copy 15)
-                       ->  Result
-                             Filter: (t12_13.a = t1_2.a)
-                             ->  Materialize
-                                   Output: t12_13.a
-                                   ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                                         Output: t12_13.a
-                                         ->  Append
-                                               ->  Seq Scan on public.t12 t12_13
-                                                     Output: t12_13.a
-                                               ->  Seq Scan on public.t111 t12_14
-                                                     Output: t12_14.a
-                     SubPlan 2 (copy 16)
-                       ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                             Output: t12_16.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_16
-                                         Output: t12_16.a
-                                   ->  Seq Scan on public.t111 t12_17
-                                         Output: t12_17.a
-   ->  Explicit Redistribute Motion 3:3  (slice10; segments: 3)
          Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
                Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, DMLAction
                ->  Seq Scan on public.t111 t1_3
                      Output: 100, t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id
-                     Filter: ((t1_3.a > 5) AND (t1_3.a < 7) AND (t1_3.a <> 6) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
+                     Filter: ((t1_3.a > 5) AND (t1_3.a < 7) AND (t1_3.a <> 6) AND (SubPlan 1 (copy 17)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_19.a = t1_3.a)
+                             Filter: (t12_10.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_19.a
-                                   ->  Broadcast Motion 3:3  (slice11; segments: 3)
-                                         Output: t12_19.a
+                                   Output: t12_10.a
+                                   ->  Broadcast Motion 3:3  (slice8; segments: 3)
+                                         Output: t12_10.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_19
-                                                     Output: t12_19.a
-                                               ->  Seq Scan on public.t111 t12_20
-                                                     Output: t12_20.a
-                     SubPlan 2 (copy 18)
-                       ->  Broadcast Motion 3:3  (slice12; segments: 3)
-                             Output: t12_22.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_22
-                                         Output: t12_22.a
-                                   ->  Seq Scan on public.t111 t12_23
-                                         Output: t12_23.a
+                                               ->  Seq Scan on public.t12 t12_10
+                                                     Output: t12_10.a
+                                               ->  Seq Scan on public.t111 t12_11
+                                                     Output: t12_11.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on'
-(115 rows)
+(83 rows)
 
 UPDATE v1 SET a=100 WHERE snoop(a) AND leakproof(a) AND a < 7 AND a != 6;
 SELECT * FROM v1 WHERE a=100; -- Nothing should have been changed to 100
@@ -2508,8 +2505,8 @@ SELECT * FROM t1 WHERE a=100; -- Nothing should have been changed to 100
 
 EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
-                                                                                QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Update on public.t1
    Update on public.t1
    Update on public.t11 t1_1
@@ -2521,7 +2518,7 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                Output: ((t1.a + 1)), t1.b, t1.c, t1.ctid, t1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t1
                      Output: (t1.a + 1), t1.b, t1.c, t1.ctid, t1.gp_segment_id
-                     Filter: ((t1.a > 5) AND (t1.a = 8) AND (alternatives: SubPlan 1 (copy 11) or hashed SubPlan 2 (copy 12)) AND snoop(t1.a) AND leakproof(t1.a))
+                     Filter: ((t1.a > 5) AND (t1.a = 8) AND (SubPlan 1 (copy 11)) AND snoop(t1.a) AND leakproof(t1.a))
                      SubPlan 1 (copy 11)
                        ->  Result
                              Filter: (t12_1.a = t1.a)
@@ -2534,98 +2531,66 @@ UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
                                                      Output: t12_1.a
                                                ->  Seq Scan on public.t111 t12_2
                                                      Output: t12_2.a
-                     SubPlan 2 (copy 12)
-                       ->  Broadcast Motion 3:1  (slice3; segments: 3)
-                             Output: t12_4.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_4
-                                         Output: t12_4.a
-                                   ->  Seq Scan on public.t111 t12_5
-                                         Output: t12_5.a
-   ->  Explicit Redistribute Motion 1:3  (slice4; segments: 1)
+   ->  Explicit Redistribute Motion 1:3  (slice3; segments: 1)
          Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, (DMLAction)
          ->  Split
                Output: ((t1_1.a + 1)), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id, DMLAction
                ->  Seq Scan on public.t11 t1_1
                      Output: (t1_1.a + 1), t1_1.b, t1_1.c, t1_1.d, t1_1.ctid, t1_1.gp_segment_id
-                     Filter: ((t1_1.a > 5) AND (t1_1.a = 8) AND (alternatives: SubPlan 1 (copy 13) or hashed SubPlan 2 (copy 14)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
+                     Filter: ((t1_1.a > 5) AND (t1_1.a = 8) AND (SubPlan 1 (copy 13)) AND snoop(t1_1.a) AND leakproof(t1_1.a))
                      SubPlan 1 (copy 13)
                        ->  Result
-                             Filter: (t12_7.a = t1_1.a)
+                             Filter: (t12_4.a = t1_1.a)
+                             ->  Materialize
+                                   Output: t12_4.a
+                                   ->  Broadcast Motion 3:1  (slice4; segments: 3)
+                                         Output: t12_4.a
+                                         ->  Append
+                                               ->  Seq Scan on public.t12 t12_4
+                                                     Output: t12_4.a
+                                               ->  Seq Scan on public.t111 t12_5
+                                                     Output: t12_5.a
+   ->  Explicit Redistribute Motion 1:3  (slice5; segments: 1)
+         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
+         ->  Split
+               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t12 t1_2
+                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
+                     Filter: ((t1_2.a > 5) AND (t1_2.a = 8) AND (SubPlan 1 (copy 15)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
+                     SubPlan 1 (copy 15)
+                       ->  Result
+                             Filter: (t12_7.a = t1_2.a)
                              ->  Materialize
                                    Output: t12_7.a
-                                   ->  Broadcast Motion 3:1  (slice5; segments: 3)
+                                   ->  Broadcast Motion 3:1  (slice6; segments: 3)
                                          Output: t12_7.a
                                          ->  Append
                                                ->  Seq Scan on public.t12 t12_7
                                                      Output: t12_7.a
                                                ->  Seq Scan on public.t111 t12_8
                                                      Output: t12_8.a
-                     SubPlan 2 (copy 14)
-                       ->  Broadcast Motion 3:1  (slice6; segments: 3)
-                             Output: t12_10.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_10
-                                         Output: t12_10.a
-                                   ->  Seq Scan on public.t111 t12_11
-                                         Output: t12_11.a
    ->  Explicit Redistribute Motion 1:3  (slice7; segments: 1)
-         Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, (DMLAction)
-         ->  Split
-               Output: ((t1_2.a + 1)), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id, DMLAction
-               ->  Seq Scan on public.t12 t1_2
-                     Output: (t1_2.a + 1), t1_2.b, t1_2.c, t1_2.e, t1_2.ctid, t1_2.gp_segment_id
-                     Filter: ((t1_2.a > 5) AND (t1_2.a = 8) AND (alternatives: SubPlan 1 (copy 15) or hashed SubPlan 2 (copy 16)) AND snoop(t1_2.a) AND leakproof(t1_2.a))
-                     SubPlan 1 (copy 15)
-                       ->  Result
-                             Filter: (t12_13.a = t1_2.a)
-                             ->  Materialize
-                                   Output: t12_13.a
-                                   ->  Broadcast Motion 3:1  (slice8; segments: 3)
-                                         Output: t12_13.a
-                                         ->  Append
-                                               ->  Seq Scan on public.t12 t12_13
-                                                     Output: t12_13.a
-                                               ->  Seq Scan on public.t111 t12_14
-                                                     Output: t12_14.a
-                     SubPlan 2 (copy 16)
-                       ->  Broadcast Motion 3:1  (slice9; segments: 3)
-                             Output: t12_16.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_16
-                                         Output: t12_16.a
-                                   ->  Seq Scan on public.t111 t12_17
-                                         Output: t12_17.a
-   ->  Explicit Redistribute Motion 1:3  (slice10; segments: 1)
          Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, (DMLAction)
          ->  Split
                Output: ((t1_3.a + 1)), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id, DMLAction
                ->  Seq Scan on public.t111 t1_3
                      Output: (t1_3.a + 1), t1_3.b, t1_3.c, t1_3.d, t1_3.e, t1_3.ctid, t1_3.gp_segment_id
-                     Filter: ((t1_3.a > 5) AND (t1_3.a = 8) AND (alternatives: SubPlan 1 (copy 17) or hashed SubPlan 2 (copy 18)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
+                     Filter: ((t1_3.a > 5) AND (t1_3.a = 8) AND (SubPlan 1 (copy 17)) AND snoop(t1_3.a) AND leakproof(t1_3.a))
                      SubPlan 1 (copy 17)
                        ->  Result
-                             Filter: (t12_19.a = t1_3.a)
+                             Filter: (t12_10.a = t1_3.a)
                              ->  Materialize
-                                   Output: t12_19.a
-                                   ->  Broadcast Motion 3:1  (slice11; segments: 3)
-                                         Output: t12_19.a
+                                   Output: t12_10.a
+                                   ->  Broadcast Motion 3:1  (slice8; segments: 3)
+                                         Output: t12_10.a
                                          ->  Append
-                                               ->  Seq Scan on public.t12 t12_19
-                                                     Output: t12_19.a
-                                               ->  Seq Scan on public.t111 t12_20
-                                                     Output: t12_20.a
-                     SubPlan 2 (copy 18)
-                       ->  Broadcast Motion 3:1  (slice12; segments: 3)
-                             Output: t12_22.a
-                             ->  Append
-                                   ->  Seq Scan on public.t12 t12_22
-                                         Output: t12_22.a
-                                   ->  Seq Scan on public.t111 t12_23
-                                         Output: t12_23.a
+                                               ->  Seq Scan on public.t12 t12_10
+                                                     Output: t12_10.a
+                                               ->  Seq Scan on public.t111 t12_11
+                                                     Output: t12_11.a
  Optimizer: Postgres query optimizer
  Settings: enable_mergejoin = 'on', enable_nestloop = 'on'
-(115 rows)
+(83 rows)
 
 UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
 NOTICE:  snooped value: 8  (seg0 slice4 127.0.0.1:40000 pid=26920)


### PR DESCRIPTION
1) Commit 41efb83 in the file src/test/regress/sql/subselect.sql added
new tests. Adapt them for the GPDB and add them to the ORCA.

2) Commit ad77039 in the file src/test/regress/sql/updatable_views.sql
added new tests. Add them to ORCA.

3) Commit 41efb83 in src/test/regress/expected/updatable_views.out
simplified the plans, while earlier GPDB-specific commits had already
added GPDB-specific output to the same places. Adapt ORCA as well.

4) Commit 41efb83 in src/test/regress/expected/insert_conflict.out
simplified the plan, while earlier GPDB-specific commits had already
added GPDB-specific output to the same location.