### PR TITLE
Fix assert with unregistered callback

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -172,6 +172,8 @@ static Oid	namespaceUser = InvalidOid;
 /* The above four values are valid only if baseSearchPathValid */
 static bool baseSearchPathValid = true;
 
+static bool before_shmem_exit_callback_registered = false;
+
 /* Override requests are remembered in a stack of OverrideStackEntry structs */
 
 typedef struct
@@ -4305,10 +4307,14 @@ ResetTempNamespace(void)
 
 	/*
 	 * MPP-19973: The shmem exit callback to remove a temp
-	 * namespace is registered. We need to remove it here as the
+	 * namespace may be registered. We need to remove it here as the
 	 * namespace has already been reseted. 
 	 */
-	cancel_before_shmem_exit(RemoveTempRelationsCallback, 0);
+	if (before_shmem_exit_callback_registered)
+	{
+		before_shmem_exit_callback_registered = false;
+		cancel_before_shmem_exit(RemoveTempRelationsCallback, 0);
+	}
 
 	myTempNamespace = InvalidOid;
 	myTempToastNamespace = InvalidOid;
@@ -4335,7 +4341,10 @@ AtEOXact_Namespace(bool isCommit, bool parallel)
 	if (myTempNamespaceSubID != InvalidSubTransactionId && !parallel)
 	{
 		if (isCommit)
+		{
 			before_shmem_exit(RemoveTempRelationsCallback, 0);
+			before_shmem_exit_callback_registered = true;
+		}
 		else
 		{
 			myTempNamespace = InvalidOid;
@@ -4518,6 +4527,8 @@ RemoveSchemaById(Oid schemaOid)
 static void
 RemoveTempRelationsCallback(int code, Datum arg)
 {
+	before_shmem_exit_callback_registered = false;
+
 	if (DistributedTransactionContext == DTX_CONTEXT_QE_PREPARED)
 	{
 		/*

--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -422,8 +422,13 @@ cancel_before_shmem_exit(pg_on_exit_callback function, Datum arg)
 		before_shmem_exit_list[before_shmem_exit_index - 1].arg == arg)
 		--before_shmem_exit_index;
 	else
+	{
+		for (int i = before_shmem_exit_index; i >= 0; i--)
+			elog(WARNING, "before_shmem_exit callback (%p,0x%llx)",
+				 before_shmem_exit_list[i].function, (long long) before_shmem_exit_list[i].arg);
 		elog(ERROR, "before_shmem_exit callback (%p,0x%llx) is not the latest entry",
 			 function, (long long) arg);
+	}
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -422,13 +422,8 @@ cancel_before_shmem_exit(pg_on_exit_callback function, Datum arg)
 		before_shmem_exit_list[before_shmem_exit_index - 1].arg == arg)
 		--before_shmem_exit_index;
 	else
-	{
-		for (int i = before_shmem_exit_index; i >= 0; i--)
-			elog(WARNING, "before_shmem_exit callback (%p,0x%llx)",
-				 before_shmem_exit_list[i].function, (long long) before_shmem_exit_list[i].arg);
 		elog(ERROR, "before_shmem_exit callback (%p,0x%llx) is not the latest entry",
 			 function, (long long) arg);
-	}
 }
 
 /* ----------------------------------------------------------------


### PR DESCRIPTION
The c9ae5cb commit in src/backend/storage/ipc/ipc.c added a conditional
error to the cancel_before_shmem_exit function, while an earlier commit
1617960 had already added a call to this function for
RemoveTempRelationsCallback. If this callback has not even been
registered yet (which happens conditionally in the AtEOXact_Namespace
function), then an error results in an assertion, for example, in the
instr_in_shmem_terminate test. Add a global variable
before_shmem_exit_callback_registered and check it when canceling the
callback.