### PR TITLE
Fix conflict in errors.sql

### DIFF
--- a/src/test/regress/expected/errors.out
+++ b/src/test/regress/expected/errors.out
@@ -452,20 +452,12 @@ NULL);
 ERROR:  syntax error at or near "NUL"
 LINE 16: ...L, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 I...
                                                               ^
-<<<<<<< HEAD
 -- Check that stack depth detection mechanism works and
 -- max_stack_depth is not set too high.  The full error report is not
 -- very stable, so show only SQLSTATE and primary error message.
 create function infinite_recurse() returns int as
 'select infinite_recurse()' language sql CONTAINS SQL;
 \set VERBOSITY sqlstate
--- start_matchsubs
--- # mpp-2756
--- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
--- s/\s+at\s+character.*//
--- m/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*/
--- s/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*//
--- end_matchsubs
 -- start_ignore
 select infinite_recurse();
 ERROR:  54001
@@ -478,5 +470,3 @@ select 1; -- test that this works
         1
 (1 row)
 
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d

--- a/src/test/regress/sql/errors.sql
+++ b/src/test/regress/sql/errors.sql
@@ -378,7 +378,6 @@ INT4
 UNIQUE
 NOT
 NULL);
-<<<<<<< HEAD
 
 -- Check that stack depth detection mechanism works and
 -- max_stack_depth is not set too high.  The full error report is not
@@ -386,17 +385,8 @@ NULL);
 create function infinite_recurse() returns int as
 'select infinite_recurse()' language sql CONTAINS SQL;
 \set VERBOSITY sqlstate
--- start_matchsubs
--- # mpp-2756
--- m/(ERROR|WARNING|CONTEXT|NOTICE):.*stack depth limit exceeded\s+at\s+character/
--- s/\s+at\s+character.*//
--- m/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*/
--- s/ERROR:.*GPDB exception. Aborting Pivotal Optimizer \(GPORCA\).*//
--- end_matchsubs
 -- start_ignore
 select infinite_recurse();
 -- end_ignore
 \echo :LAST_ERROR_MESSAGE
 select 1; -- test that this works
-=======
->>>>>>> f81e97d0475cd4bc597adc23b665bd84fbf79a0d


### PR DESCRIPTION
Commit 3c85535 changed VERBOSITY settings to sqlstate in errors.sql.
while commit 5212dba added matchsubs for test output for previous setting terse.