### PR TITLE
Fix optimizer output for expressions test

### DIFF
--- a/src/test/regress/expected/expressions_optimizer.out
+++ b/src/test/regress/expected/expressions_optimizer.out
@@ -125,7 +125,7 @@ select count(*) from date_tbl
   where f1 not between '1997-01-01' and '1998-01-01';
  count 
 -------
-    12
+    13
 (1 row)
 
 explain (costs off)
@@ -163,6 +163,6 @@ select count(*) from date_tbl
   where f1 not between symmetric '1997-01-01' and '1998-01-01';
  count 
 -------
-    12
+    13
 (1 row)
 


### PR DESCRIPTION
Commit 540612fa469eaae3345ede7a160b146dd903e7ee added a new row to the DATE_TBL
table. That change results in some queries in the expressions test. Fix the
output of these queries in the optimizer output file.