### PR TITLE
Fix sslinfo test behavior and increase info size

### DIFF
--- a/contrib/sslinfo/expected/sslinfo.out
+++ b/contrib/sslinfo/expected/sslinfo.out
@@ -38,15 +38,15 @@ SELECT ssl_client_serial();
 (1 row)
 
 SELECT ssl_client_dn();
-                                   ssl_client_dn                                    
-------------------------------------------------------------------------------------
- /CN=client.example.com/C=CN/ST=Qingdao/L=ClientLocality/O=SSLINFO-Client/OU=Client
+                          ssl_client_dn                          
+-----------------------------------------------------------------
+ /CN=client.example.com/C=CN/ST=Qingdao/L=ClientLocality/O=SSLIN
 (1 row)
 
 SELECT ssl_issuer_dn();
-                               ssl_issuer_dn                               
----------------------------------------------------------------------------
- /CN=root.example.com/C=CN/ST=Beijing/L=RootLocality/O=SSLINFO-dev/OU=Test
+                          ssl_issuer_dn                          
+-----------------------------------------------------------------
+ /CN=root.example.com/C=CN/ST=Beijing/L=RootLocality/O=SSLINFO-d
 (1 row)
 
 SELECT ssl_client_dn_field('CN') AS client_dn_CN;

--- a/contrib/sslinfo/sslinfo.c
+++ b/contrib/sslinfo/sslinfo.c
@@ -297,12 +297,12 @@ PG_FUNCTION_INFO_V1(ssl_client_dn);
 Datum
 ssl_client_dn(PG_FUNCTION_ARGS)
 {
-	char		subject[2 * NAMEDATALEN];
+	char		subject[NAMEDATALEN];
 
 	if (!MyProcPort->ssl_in_use || !MyProcPort->peer_cert_valid)
 		PG_RETURN_NULL();
 
-	be_tls_get_peer_subject_name(MyProcPort, subject, sizeof(subject));
+	be_tls_get_peer_subject_name(MyProcPort, subject, NAMEDATALEN);
 
 	if (!*subject)
 		PG_RETURN_NULL();
@@ -324,12 +324,12 @@ PG_FUNCTION_INFO_V1(ssl_issuer_dn);
 Datum
 ssl_issuer_dn(PG_FUNCTION_ARGS)
 {
-	char		issuer[2 * NAMEDATALEN];
+	char		issuer[NAMEDATALEN];
 
 	if (!MyProcPort->ssl_in_use || !MyProcPort->peer_cert_valid)
 		PG_RETURN_NULL();
 
-	be_tls_get_peer_issuer_name(MyProcPort, issuer, sizeof(issuer));
+	be_tls_get_peer_issuer_name(MyProcPort, issuer, NAMEDATALEN);
 
 	if (!*issuer)
 		PG_RETURN_NULL();

--- a/contrib/sslinfo/sslinfo.c
+++ b/contrib/sslinfo/sslinfo.c
@@ -297,12 +297,12 @@ PG_FUNCTION_INFO_V1(ssl_client_dn);
 Datum
 ssl_client_dn(PG_FUNCTION_ARGS)
 {
-	char		subject[NAMEDATALEN];
+	char		subject[2 * NAMEDATALEN];
 
 	if (!MyProcPort->ssl_in_use || !MyProcPort->peer_cert_valid)
 		PG_RETURN_NULL();
 
-	be_tls_get_peer_subject_name(MyProcPort, subject, NAMEDATALEN);
+	be_tls_get_peer_subject_name(MyProcPort, subject, sizeof(subject));
 
 	if (!*subject)
 		PG_RETURN_NULL();
@@ -324,12 +324,12 @@ PG_FUNCTION_INFO_V1(ssl_issuer_dn);
 Datum
 ssl_issuer_dn(PG_FUNCTION_ARGS)
 {
-	char		issuer[NAMEDATALEN];
+	char		issuer[2 * NAMEDATALEN];
 
 	if (!MyProcPort->ssl_in_use || !MyProcPort->peer_cert_valid)
 		PG_RETURN_NULL();
 
-	be_tls_get_peer_issuer_name(MyProcPort, issuer, NAMEDATALEN);
+	be_tls_get_peer_issuer_name(MyProcPort, issuer, sizeof(issuer));
 
 	if (!*issuer)
 		PG_RETURN_NULL();


### PR DESCRIPTION
Commit 5d1833f statrted to use be_tls_* API for SSL information in sslinfo
in extensions functions. It trims expected string produced by
X509_get_subject_name at NAMEDATALEN (64) length. Vanila postgres does not have
tests for sslinfo at all, they were introduced in GPDB. Since the behaviour is documented,
we adjust GPDB tests.
