### PR TITLE
Fix detected write past chunk end warning

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -263,10 +263,6 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 	resultRelInfo->ri_RelationDesc = aorel;
 	resultRelInfo->ri_TrigDesc = NULL;	/* we don't fire triggers */
 	ExecOpenIndices(resultRelInfo, false);
-	if (estate->es_result_relations == NULL)
-		estate->es_result_relations = (ResultRelInfo **)
-			palloc0(estate->es_range_table_size * sizeof(ResultRelInfo *));
-	estate->es_result_relations[resultRelInfo->ri_RangeTableIndex - 1] = resultRelInfo;
 
 	/*
 	 * We don't want uniqueness checks to be performed while "insert"ing tuples

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -445,10 +445,6 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	resultRelInfo->ri_RelationDesc = aorel;
 	resultRelInfo->ri_TrigDesc = NULL;	/* we don't fire triggers */
 	ExecOpenIndices(resultRelInfo, false);
-	if (estate->es_result_relations == NULL)
-		estate->es_result_relations = (ResultRelInfo **)
-			palloc0(estate->es_range_table_size * sizeof(ResultRelInfo *));
-	estate->es_result_relations[resultRelInfo->ri_RangeTableIndex - 1] = resultRelInfo;
 
 	/*
 	 * We don't want uniqueness checks to be performed while "insert"ing tuples


### PR DESCRIPTION
Commit 9ca7bae incorrectly fixed the compilation of the
aocs_compaction.c and appendonly_compaction.c files, which resulted in
similar warnings being generated for AO tables in many tests: problem
in alloc set TopTransactionContext: detected write past chunk end in
block 0x615ef0207560, chunk 0x615ef0207dc8. Remove unnecessary
allocation and assignment.