### PR TITLE
Fix tests in src/pl/plperl/expected/plperl_call.out

### DIFF
--- a/src/pl/plperl/expected/plperl_call.out
+++ b/src/pl/plperl/expected/plperl_call.out
@@ -64,7 +64,7 @@ BEGIN
   RAISE NOTICE '_a: %, _b: %', _a, _b;
 END
 $$;
-NOTICE:  a: 10, b: 
+NOTICE:  a: 10, b:
 NOTICE:  _a: 10, _b: 20
 DROP PROCEDURE test_proc1;
 DROP PROCEDURE test_proc2;


### PR DESCRIPTION
Commit 2453ea1 added new tests to src/pl/plperl/sql/plperl_call.sql.
However, the GPDB consumes trailing spaces when logging.