### PR TITLE
Fix tests after reltuples changes

### DIFF
--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -243,12 +243,12 @@ select relpages, reltuples from pg_class where oid = 'rankpart_1_prt_5'::regclas
 select relpages, reltuples from pg_class where oid = 'rankpart_1_prt_6'::regclass;
  relpages | reltuples 
 ----------+-----------
- 0        | 0         
+ 0        | -1        
 (1 row)
 select relpages, reltuples from pg_class where oid = 'rankpart'::regclass;
  relpages | reltuples 
 ----------+-----------
- 0        | 0         
+ 0        | -1        
 (1 row)
 
 
@@ -362,7 +362,7 @@ SELECT count(*) FROM pg_statistic where starelid = 'anaabort'::regclass;
 select relpages, reltuples from pg_class where oid = 'anaabort'::regclass;
  relpages | reltuples 
 ----------+-----------
- 0        | 0         
+ 0        | -1        
 (1 row)
 
 1: END;

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -30,7 +30,7 @@ select relname, reltuples from pg_class where relname='autostats_test';
 LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
     relname     | reltuples 
 ----------------+-----------
- autostats_test |         0
+ autostats_test |        -1
 (1 row)
 
 -- Try it with gp_autostats_allow_nonowner GUC enabled, but as a non-owner
@@ -48,7 +48,7 @@ select relname, reltuples from pg_class where relname='autostats_test';
 LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
     relname     | reltuples 
 ----------------+-----------
- autostats_test |         0
+ autostats_test |        -1
 (1 row)
 
 reset role;
@@ -60,7 +60,7 @@ set role=autostats_nonowner;
 LOG:  statement: set role=autostats_nonowner;
 insert into autostats_test select generate_series(11, 20);
 LOG:  statement: insert into autostats_test select generate_series(11, 20);
-LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(XXXXX,XXXXX) modifying 10 tuples caused Auto-ANALYZE.
+LOG:  In mode on_change, command INSERT on (dboid,tableoid)=(72126,72259) modifying 10 tuples caused Auto-ANALYZE.
 select relname, reltuples from pg_class where relname='autostats_test';
 LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';
     relname     | reltuples 

--- a/src/test/regress/expected/btree_index.out
+++ b/src/test/regress/expected/btree_index.out
@@ -377,7 +377,7 @@ INSERT INTO btree_stats_tbl VALUES (1, 'aa', 1001, 101), (2, 'bb', 1002, 102);
 SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
  reltuples 
 -----------
-         0
+        -1
 (1 row)
 
 -- inspect the state of the stats on segments

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2967,7 +2967,7 @@ select relname, reltuples, relpages from pg_class where relname like 'tbl6833_an
 ------------------------+-----------+----------
  tbl6833_anl_1_prt_bb_1 |         0 |        1
  tbl6833_anl_1_prt_bb_2 |         0 |        1
- tbl6833_anl            |         0 |        0
+ tbl6833_anl            |        -1 |        0
 (3 rows)
 
 create table qp_misc_jiras.tbl6833_vac(a int, b int, c int) distributed by (a) partition by range (b) (partition bb start (0) end (2) every (1));
@@ -2987,7 +2987,7 @@ select relname, reltuples, relpages from pg_class where relname like 'tbl6833_va
 ------------------------+-----------+----------
  tbl6833_vac_1_prt_bb_1 |         0 |        1
  tbl6833_vac_1_prt_bb_2 |         0 |        1
- tbl6833_vac            |         0 |        0
+ tbl6833_vac            |        -1 |        0
 (3 rows)
 
 drop table qp_misc_jiras.tbl6833_anl;

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2963,7 +2963,7 @@ select relname, reltuples, relpages from pg_class where relname like 'tbl6833_an
 ------------------------+-----------+----------
  tbl6833_anl_1_prt_bb_1 |         0 |        1
  tbl6833_anl_1_prt_bb_2 |         0 |        1
- tbl6833_anl            |         0 |        0
+ tbl6833_anl            |        -1 |        0
 (3 rows)
 
 create table qp_misc_jiras.tbl6833_vac(a int, b int, c int) distributed by (a) partition by range (b) (partition bb start (0) end (2) every (1));
@@ -2980,7 +2980,7 @@ explain select * from qp_misc_jiras.tbl6833_vac; -- should not hit cdbRelSize();
 select relname, reltuples, relpages from pg_class where relname like 'tbl6833_vac%'; -- should show relpages = 1.0
         relname         | reltuples | relpages 
 ------------------------+-----------+----------
- tbl6833_vac            |         0 |        0
+ tbl6833_vac            |        -1 |        0
  tbl6833_vac_1_prt_bb_1 |         0 |        1
  tbl6833_vac_1_prt_bb_2 |         0 |        1
 (3 rows)

--- a/src/test/regress/expected/uao_compaction/index_stats.out
+++ b/src/test/regress/expected/uao_compaction/index_stats.out
@@ -59,9 +59,9 @@ vacuum mytab2;
 SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
  gp_segment_id |     relname     | reltuples 
 ---------------+-----------------+-----------
-             0 | mytab2_int_idx1 |         0
-             1 | mytab2_int_idx1 |         0
-             2 | mytab2_int_idx1 |         0
+             0 | mytab2_int_idx1 |        -1
+             1 | mytab2_int_idx1 |        -1
+             2 | mytab2_int_idx1 |        -1
 (3 rows)
 
 -- second vacuum update index stat with table stat
@@ -93,7 +93,7 @@ insert into mytab3 values(1,'aa',1001,101),(2,'bb',1002,102);
 select reltuples from pg_class where relname='mytab3';
  reltuples 
 -----------
-         0
+        -1
 (1 row)
 
 -- inspect the state of the stats on segments

--- a/src/test/regress/expected/uaocs_compaction/index_stats.out
+++ b/src/test/regress/expected/uaocs_compaction/index_stats.out
@@ -64,9 +64,9 @@ vacuum uaocs_index_stats2;
 SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
  gp_segment_id |           relname           | reltuples 
 ---------------+-----------------------------+-----------
-             0 | uaocs_index_stats2_int_idx1 |         0
-             1 | uaocs_index_stats2_int_idx1 |         0
-             2 | uaocs_index_stats2_int_idx1 |         0
+             1 | uaocs_index_stats2_int_idx1 |        -1
+             0 | uaocs_index_stats2_int_idx1 |        -1
+             2 | uaocs_index_stats2_int_idx1 |        -1
 (3 rows)
 
 -- second vacuum update index stat with table stat
@@ -98,7 +98,7 @@ insert into uaocs_index_stats3 values(1,'aa',1001,101),(2,'bb',1002,102);
 select reltuples from pg_class where relname='uaocs_index_stats3';
  reltuples 
 -----------
-         0
+        -1
 (1 row)
 
 -- inspect the state of the stats on segments

--- a/src/test/regress/expected/vacuum_full_heap.out
+++ b/src/test/regress/expected/vacuum_full_heap.out
@@ -84,7 +84,7 @@ select relname, relpages, reltuples from gp_dist_random('pg_class') where (oid =
  relname | relpages | reltuples 
 ---------+----------+-----------
  vfheap  |        0 |         0
- ivfheap |        1 |         0
+ ivfheap |        0 |        -1
 (2 rows)
 
 -- again, but delete second half

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -289,16 +289,16 @@ INSERT INTO vacuum_gp_pt SELECT 0, 6 FROM generate_series(1, 12);
 SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
        relname        | reltuples | relpages 
 ----------------------+-----------+----------
- vacuum_gp_pt         |         0 |        0
- vacuum_gp_pt_1_prt_1 |         0 |        0
- vacuum_gp_pt_1_prt_2 |         0 |        0
+ vacuum_gp_pt         |        -1 |        0
+ vacuum_gp_pt_1_prt_1 |        -1 |        0
+ vacuum_gp_pt_1_prt_2 |        -1 |        0
 (3 rows)
 
 ANALYZE vacuum_gp_pt;
 SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
        relname        | reltuples | relpages 
 ----------------------+-----------+----------
- vacuum_gp_pt         |         0 |        0
+ vacuum_gp_pt         |        -1 |        0
  vacuum_gp_pt_1_prt_1 |         0 |        1
  vacuum_gp_pt_1_prt_2 |        12 |        1
 (3 rows)
@@ -307,7 +307,7 @@ VACUUM vacuum_gp_pt;
 SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
        relname        | reltuples | relpages 
 ----------------------+-----------+----------
- vacuum_gp_pt         |         0 |        0
+ vacuum_gp_pt         |        -1 |        0
  vacuum_gp_pt_1_prt_1 |         0 |        1
  vacuum_gp_pt_1_prt_2 |        12 |        1
 (3 rows)
@@ -316,7 +316,7 @@ VACUUM ANALYZE vacuum_gp_pt;
 SELECT relname, reltuples, relpages FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp_pt%';
        relname        | reltuples | relpages 
 ----------------------+-----------+----------
- vacuum_gp_pt         |         0 |        0
+ vacuum_gp_pt         |        -1 |        0
  vacuum_gp_pt_1_prt_1 |         0 |        1
  vacuum_gp_pt_1_prt_2 |        12 |        1
 (3 rows)

--- a/src/test/regress/output/uao_ddl/analyze_ao_table_every_dml.source
+++ b/src/test/regress/output/uao_ddl/analyze_ao_table_every_dml.source
@@ -22,7 +22,7 @@ select count(*)  from sto_uao_city_analyze_everydml;
 select relname, reltuples from pg_class where oid='sto_uao_city_analyze_everydml'::regclass;
             relname            | reltuples 
 -------------------------------+-----------
- sto_uao_city_analyze_everydml |         0
+ sto_uao_city_analyze_everydml |        -1
 (1 row)
 
 SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND


### PR DESCRIPTION
Commit 3d351d9 redefined pg_class.reltuples to be -1 before the first
VACUUM or ANALYZE. Adapt the output of GPDB-specific tests

- src/test/isolation2/expected/autovacuum-analyze.out
- src/test/regress/expected/btree_index.out
- src/test/regress/expected/vacuum_gp.out
- src/test/regress/expected/qp_misc_jiras.out
- src/test/regress/expected/uao_compaction/index_stats.out
- src/test/regress/expected/uaocs_compaction/index_stats.out
- src/test/regress/expected/uao_ddl/analyze_ao_table_every_dml_row.out
- src/test/regress/expected/uao_ddl/analyze_ao_table_every_dml_column.out
- src/test/regress/expected/vacuum_full_heap.out
- src/test/regress/expected/autostats.out