### PR TITLE
Fix test src/test/regress/expected/join.out

### DIFF
--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6297,6 +6297,8 @@ drop table join_ut1;
 -- test estimation behavior with multi-column foreign key and constant qual
 --
 begin;
+-- GPDB: persuade the planner to choose same plan as in upstream.
+set local enable_nestloop=on;
 create table fkest (x integer, x10 integer, x10b integer, x100 integer);
 insert into fkest select x, x/10, x/10, x/100 from generate_series(1,1000) x;
 create unique index on fkest(x, x10, x100);
@@ -6306,19 +6308,21 @@ select * from fkest f1
   join fkest f2 on (f1.x = f2.x and f1.x10 = f2.x10b and f1.x100 = f2.x100)
   join fkest f3 on f1.x = f3.x
   where f1.x100 = 2;
-                        QUERY PLAN                         
------------------------------------------------------------
- Nested Loop
-   ->  Hash Join
-         Hash Cond: ((f2.x = f1.x) AND (f2.x10b = f1.x10))
-         ->  Seq Scan on fkest f2
-               Filter: (x100 = 2)
-         ->  Hash
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         ->  Hash Join
+               Hash Cond: ((f1.x = f2.x) AND (f1.x10 = f2.x10b))
                ->  Seq Scan on fkest f1
                      Filter: (x100 = 2)
-   ->  Index Scan using fkest_x_x10_x100_idx on fkest f3
-         Index Cond: (x = f1.x)
-(10 rows)
+               ->  Hash
+                     ->  Seq Scan on fkest f2
+                           Filter: (x100 = 2)
+         ->  Index Scan using fkest_x_x10_x100_idx on fkest f3
+               Index Cond: (x = f1.x)
+ Optimizer: Postgres query optimizer
+(12 rows)
 
 alter table fkest add constraint fk
   foreign key (x, x10b, x100) references fkest (x, x10, x100);
@@ -6327,20 +6331,22 @@ select * from fkest f1
   join fkest f2 on (f1.x = f2.x and f1.x10 = f2.x10b and f1.x100 = f2.x100)
   join fkest f3 on f1.x = f3.x
   where f1.x100 = 2;
-                     QUERY PLAN                      
------------------------------------------------------
- Hash Join
-   Hash Cond: ((f2.x = f1.x) AND (f2.x10b = f1.x10))
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
-         Hash Cond: (f3.x = f2.x)
-         ->  Seq Scan on fkest f3
+         Hash Cond: ((f1.x = f2.x) AND (f1.x10 = f2.x10b))
+         ->  Hash Join
+               Hash Cond: (f3.x = f1.x)
+               ->  Seq Scan on fkest f3
+               ->  Hash
+                     ->  Seq Scan on fkest f1
+                           Filter: (x100 = 2)
          ->  Hash
                ->  Seq Scan on fkest f2
                      Filter: (x100 = 2)
-   ->  Hash
-         ->  Seq Scan on fkest f1
-               Filter: (x100 = 2)
-(11 rows)
+ Optimizer: Postgres query optimizer
+(13 rows)
 
 rollback;
 --

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -6337,6 +6337,64 @@ ERROR:  could not devise a query plan for the given query (pathnode.c:275)
 drop table join_pt1;
 drop table join_ut1;
 --
+-- test estimation behavior with multi-column foreign key and constant qual
+--
+begin;
+-- GPDB: persuade the planner to choose same plan as in upstream.
+set local enable_nestloop=on;
+create table fkest (x integer, x10 integer, x10b integer, x100 integer);
+insert into fkest select x, x/10, x/10, x/100 from generate_series(1,1000) x;
+create unique index on fkest(x, x10, x100);
+analyze fkest;
+explain (costs off)
+select * from fkest f1
+  join fkest f2 on (f1.x = f2.x and f1.x10 = f2.x10b and f1.x100 = f2.x100)
+  join fkest f3 on f1.x = f3.x
+  where f1.x100 = 2;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((fkest_1.x = fkest_2.x) AND (fkest_1.x10b = fkest_2.x10) AND (fkest_1.x100 = fkest_2.x100))
+         ->  Hash Join
+               Hash Cond: (fkest.x = fkest_1.x)
+               ->  Seq Scan on fkest
+               ->  Hash
+                     ->  Index Scan using fkest_x_x10_x100_idx on fkest fkest_1
+                           Index Cond: (x100 = 2)
+         ->  Hash
+               ->  Index Scan using fkest_x_x10_x100_idx on fkest fkest_2
+                     Index Cond: (x100 = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+alter table fkest add constraint fk
+  foreign key (x, x10b, x100) references fkest (x, x10, x100);
+WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
+explain (costs off)
+select * from fkest f1
+  join fkest f2 on (f1.x = f2.x and f1.x10 = f2.x10b and f1.x100 = f2.x100)
+  join fkest f3 on f1.x = f3.x
+  where f1.x100 = 2;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((fkest_1.x = fkest_2.x) AND (fkest_1.x10b = fkest_2.x10) AND (fkest_1.x100 = fkest_2.x100))
+         ->  Hash Join
+               Hash Cond: (fkest.x = fkest_1.x)
+               ->  Seq Scan on fkest
+               ->  Hash
+                     ->  Index Scan using fkest_x_x10_x100_idx on fkest fkest_1
+                           Index Cond: (x100 = 2)
+         ->  Hash
+               ->  Index Scan using fkest_x_x10_x100_idx on fkest fkest_2
+                     Index Cond: (x100 = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+rollback;
+--
 -- test that foreign key join estimation performs sanely for outer joins
 --
 begin;

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -2043,6 +2043,9 @@ drop table join_ut1;
 
 begin;
 
+-- GPDB: persuade the planner to choose same plan as in upstream.
+set local enable_nestloop=on;
+
 create table fkest (x integer, x10 integer, x10b integer, x100 integer);
 insert into fkest select x, x/10, x/10, x/100 from generate_series(1,1000) x;
 create unique index on fkest(x, x10, x100);


### PR DESCRIPTION
Commit ad1c36b0709e47cdb3cc4abd6c939fe64279b63f added new test, adapt
it for GPDB and add its output to ORCA. Use enable_nestloop to achieve plans
that better match upstream.
