### PR TITLE
Fix test src/test/regress/expected/rangefuncs.out

### DIFF
--- a/src/test/regress/expected/rangefuncs.out
+++ b/src/test/regress/expected/rangefuncs.out
@@ -2094,17 +2094,20 @@ select * from testrngfunc();
 ----------------------------------------------------------
  Subquery Scan on "*SELECT*"
    Output: "*SELECT*"."?column?", "*SELECT*"."?column?_1"
-   ->  Unique
+   ->  Sort
          Output: (1), (2)
-         ->  Sort
+         Sort Key: (1)
+         ->  HashAggregate
                Output: (1), (2)
-               Sort Key: (1), (2)
+               Group Key: (1), (2)
                ->  Append
                      ->  Result
                            Output: 1, 2
                      ->  Result
                            Output: 3, 4
-(12 rows)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(15 rows)
 
 select * from testrngfunc();
     f1    |  f2  

--- a/src/test/regress/expected/rangefuncs_optimizer.out
+++ b/src/test/regress/expected/rangefuncs_optimizer.out
@@ -2083,6 +2083,57 @@ select * from testrngfunc();
  7.136178 | 7.14
 (1 row)
 
+create or replace function testrngfunc() returns setof rngfunc_type as $$
+  select 1, 2 union select 3, 4 order by 1;
+$$ language sql immutable;
+explain (verbose, costs off)
+select testrngfunc();
+              QUERY PLAN               
+---------------------------------------
+ ProjectSet
+   Output: testrngfunc()
+   ->  Result
+         Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select testrngfunc();
+   testrngfunc   
+-----------------
+ (1.000000,2.00)
+ (3.000000,4.00)
+(2 rows)
+
+explain (verbose, costs off)
+select * from testrngfunc();
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on public.testrngfunc
+   Output: f1, f2
+   Function Call: testrngfunc()
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from testrngfunc();
+    f1    |  f2  
+----------+------
+ 1.000000 | 2.00
+ 3.000000 | 4.00
+(2 rows)
+
+-- Check a couple of error cases while we're here
+select * from testrngfunc() as t(f1 int8,f2 int8);  -- fail, composite result
+ERROR:  a column definition list is redundant for a function returning a named composite type
+LINE 1: select * from testrngfunc() as t(f1 int8,f2 int8);
+                                         ^
+select * from pg_get_keywords() as t(f1 int8,f2 int8);  -- fail, OUT params
+ERROR:  a column definition list is redundant for a function with OUT parameters
+LINE 1: select * from pg_get_keywords() as t(f1 int8,f2 int8);
+                                             ^
+select * from sin(3) as t(f1 int8,f2 int8);  -- fail, scalar result type
+ERROR:  a column definition list is only allowed for functions returning "record"
+LINE 1: select * from sin(3) as t(f1 int8,f2 int8);
+                                  ^
 drop type rngfunc_type cascade;
 NOTICE:  drop cascades to function testrngfunc()
 --


### PR DESCRIPTION
1. Commit c8ab9701791e22f7a8e1badf362654db179c9703 added new test, adapt
its plan for GPDB and add the output for ORCA.

2. Commit ce90f075f0d831ca4085ba73891b7da2a2f7047e added new test, add the
output for ORCA.