### PR TITLE
Fix tests in partition.out, partition1.out and partition_indexing.out

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -4530,8 +4530,8 @@ create table tc
         default partition d,
         start (0) inclusive end(100) inclusive every (50)
     );
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "tc" lacks column "b" which is part of the partition key.
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
 create table cc
     (a int primary key, b int, c int)
     distributed by (a)
@@ -4540,8 +4540,8 @@ create table cc
         default partition d,
         start (0) inclusive end(100) inclusive every (50)
     );
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "cc" lacks column "b" which is part of the partition key.
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
 create table at
     (a int, b int, c int)
     distributed by (a)
@@ -4552,8 +4552,8 @@ create table at
     );
 alter table at
     add primary key (a);
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "at" lacks column "b" which is part of the partition key.
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
 -- MPP-14471 end
 -- MPP-17606 (using table "at" from above)
 alter table at
@@ -4619,6 +4619,8 @@ create table plst2
         partition p3 values ( CAST('(1,2)' as plst2_partkey) )
     );
 ERROR:  partition "plst2_1_prt_p3" would overlap partition "plst2_1_prt_p1"
+LINE 11:         partition p3 values ( CAST('(1,2)' as plst2_partkey)...
+                                            ^
 -- postive; make sure inner part duplicates are accepted and quietly removed.
 drop table if exists plst2;
 NOTICE:  table "plst2" does not exist, skipping
@@ -4655,6 +4657,8 @@ Distributed by: (d)
 -- negative; make sure conflicting alters fail.
 alter table plst2 add partition p6 values (CAST('(7,8)' as plst2_partkey), CAST('(2,1)' as plst2_partkey));
 ERROR:  partition "plst2_1_prt_p6" would overlap partition "plst2_1_prt_p5"
+LINE 1: alter table plst2 add partition p6 values (CAST('(7,8)' as p...
+                                          ^
 drop table if exists plst2;
 -- MPP-17814 end
 -- MPP-18441

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -311,6 +311,8 @@ partition by list (rankgender)
  partition bb values (CAST ('(1,M)' AS rank_partkey))
 );
 ERROR:  partition "rank_1_prt_bb" would overlap partition "rank_1_prt_1"
+LINE 10:  partition bb values (CAST ('(1,M)' AS rank_partkey))
+                                     ^
 -- RANGE validation
 -- legal if end of aa not inclusive
 create table ggg (a char(1), b date, d char(3))
@@ -2411,7 +2413,7 @@ PARTITION BY list (b)
  PARTITION t2 values (2));
 -- the following statement should fail because index cols does not contain part key
 CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(a);
-ERROR:  insufficient columns in UNIQUE constraint definition
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  UNIQUE constraint on table "t_idx_col_contain_partkey" lacks column "b" which is part of the partition key.
 -- the following statement should work
 CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(a, b);
@@ -2443,7 +2445,7 @@ SUBPARTITION BY LIST (r_name) SUBPARTITION TEMPLATE
 );
 -- should fail, must contain all the partition keys of all levels
 CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(r_regionkey);
-ERROR:  insufficient columns in UNIQUE constraint definition
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  UNIQUE constraint on table "t_idx_col_contain_partkey_1_prt_region1" lacks column "r_name" which is part of the partition key.
 -- should work
 CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(r_regionkey, r_name);

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -167,7 +167,7 @@ CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 ERROR:  UNIQUE index must contain all columns in the table's distribution key
 DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
-ERROR:  insufficient columns in UNIQUE constraint definition
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  UNIQUE constraint on table "mpp3033b_1_prt_aa" lacks column "unique2" which is part of the partition key.
 CREATE UNIQUE INDEX mpp3033b_unique2 ON mpp3033b (unique2);
 ERROR:  UNIQUE index must contain all columns in the table's distribution key
@@ -435,7 +435,7 @@ CREATE UNIQUE INDEX mpp3033a_stringu1 ON mpp3033a (stringu1);
 ERROR:  UNIQUE index must contain all columns in the table's distribution key
 DETAIL:  Distribution key column "unique1" is not included in the constraint.
 CREATE UNIQUE INDEX mpp3033b_unique1 ON mpp3033b (unique1);
-ERROR:  insufficient columns in UNIQUE constraint definition
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  UNIQUE constraint on table "mpp3033b_1_prt_1" lacks column "unique2" which is part of the partition key.
 CREATE UNIQUE INDEX mpp3033b_unique2 ON mpp3033b (unique2);
 ERROR:  UNIQUE index must contain all columns in the table's distribution key

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -4531,8 +4531,8 @@ create table tc
         default partition d,
         start (0) inclusive end(100) inclusive every (50)
     );
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "tc" lacks column "b" which is part of the partition key.
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
 create table cc
     (a int primary key, b int, c int)
     distributed by (a)
@@ -4541,8 +4541,8 @@ create table cc
         default partition d,
         start (0) inclusive end(100) inclusive every (50)
     );
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "cc" lacks column "b" which is part of the partition key.
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
 create table at
     (a int, b int, c int)
     distributed by (a)
@@ -4553,8 +4553,8 @@ create table at
     );
 alter table at
     add primary key (a);
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "at" lacks column "b" which is part of the partition key.
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
 -- MPP-14471 end
 -- MPP-17606 (using table "at" from above)
 alter table at
@@ -4620,6 +4620,8 @@ create table plst2
         partition p3 values ( CAST('(1,2)' as plst2_partkey) )
     );
 ERROR:  partition "plst2_1_prt_p3" would overlap partition "plst2_1_prt_p1"
+LINE 11:         partition p3 values ( CAST('(1,2)' as plst2_partkey)...
+                                            ^
 -- postive; make sure inner part duplicates are accepted and quietly removed.
 drop table if exists plst2;
 NOTICE:  table "plst2" does not exist, skipping
@@ -4656,6 +4658,8 @@ Distributed by: (d)
 -- negative; make sure conflicting alters fail.
 alter table plst2 add partition p6 values (CAST('(7,8)' as plst2_partkey), CAST('(2,1)' as plst2_partkey));
 ERROR:  partition "plst2_1_prt_p6" would overlap partition "plst2_1_prt_p5"
+LINE 1: alter table plst2 add partition p6 values (CAST('(7,8)' as p...
+                                          ^
 drop table if exists plst2;
 -- MPP-17814 end
 -- MPP-18441


### PR DESCRIPTION
1) Commit 9fc2122 in src/backend/commands/indexcmds.c changed the error
message in the DefineIndex function. Change this in the GPDB-specific
test outputs.

2) Commit 6b2c4e5 in src/backend/partitioning/partbounds.c changed the
error position display in the check_new_partition_bound function. Add
the error position display in the GPDB-specific test outputs.