### PR TITLE
Fix tests in src/test/regress/expected/index_constraint_naming_partit…

### DIFF
--- a/src/test/regress/expected/index_constraint_naming_partition.out
+++ b/src/test/regress/expected/index_constraint_naming_partition.out
@@ -45,7 +45,8 @@ NOTICE:  function dependencies() does not exist, skipping
 CREATE FUNCTION dependencies() RETURNS TABLE( depname NAME, classtype "char", depnsoid OID,
                                               refname NAME, refclasstype "char", refnsoid OID,
                                               classid REGCLASS,  objid OID, objsubid INTEGER,
-                                              refclassid REGCLASS, refobjid OID, refobjsubid OID, deptype "char" )
+                                              refclassid REGCLASS, refobjid OID, refobjsubid OID,
+                                              deptype "char", refobjversion "text" )
   LANGUAGE SQL STABLE STRICT AS $fn$
 WITH RECURSIVE
   w AS (
@@ -55,7 +56,8 @@ WITH RECURSIVE
            refclassid::regclass,
            refobjid,
            refobjsubid,
-           deptype
+           deptype,
+           refobjversion
     FROM pg_depend d
     WHERE classid IN ('pg_constraint'::regclass, 'pg_class'::regclass)
       AND (objid > 16384 OR refobjid > 16384)

--- a/src/test/regress/sql/index_constraint_naming_partition.sql
+++ b/src/test/regress/sql/index_constraint_naming_partition.sql
@@ -45,7 +45,8 @@ DROP FUNCTION IF EXISTS dependencies();
 CREATE FUNCTION dependencies() RETURNS TABLE( depname NAME, classtype "char", depnsoid OID,
                                               refname NAME, refclasstype "char", refnsoid OID,
                                               classid REGCLASS,  objid OID, objsubid INTEGER,
-                                              refclassid REGCLASS, refobjid OID, refobjsubid OID, deptype "char" )
+                                              refclassid REGCLASS, refobjid OID, refobjsubid OID,
+                                              deptype "char", refobjversion "text" )
   LANGUAGE SQL STABLE STRICT AS $fn$
 WITH RECURSIVE
   w AS (
@@ -55,7 +56,8 @@ WITH RECURSIVE
            refclassid::regclass,
            refobjid,
            refobjsubid,
-           deptype
+           deptype,
+           refobjversion
     FROM pg_depend d
     WHERE classid IN ('pg_constraint'::regclass, 'pg_class'::regclass)
       AND (objid > 16384 OR refobjid > 16384)


### PR DESCRIPTION
Commit cd6f479 added the refobjversion column to the pg_depend catalog
table in src/include/catalog/pg_depend.h. Add it to the GPDB-specific
tests.