### PR TITLE
Fix test src/test/regress/output/external_table.source

### DIFF
--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -42,7 +42,7 @@ FORMAT 'text' (delimiter '|');
 
 -- Only tables with custom protocol should create dependency, due to a bug there
 -- used to be entries created for non custom protocol tables with refobjid=0.
-SELECT * FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
+SELECT count(*) FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
 
 -- drop tables
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -39,10 +39,11 @@ location ('file://@hostname@@abs_srcdir@/data/region.tbl' )
 FORMAT 'text' (delimiter '|');
 -- Only tables with custom protocol should create dependency, due to a bug there
 -- used to be entries created for non custom protocol tables with refobjid=0.
-SELECT * FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
- classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype 
----------+-------+----------+------------+----------+-------------+---------
-(0 rows)
+SELECT count(*) FROM pg_depend WHERE refclassid = 'pg_extprotocol'::regclass and refobjid = 0;
+ count 
+-------
+     0
+(1 row)
 
 -- drop tables
 DROP EXTERNAL TABLE EXT_NATION;


### PR DESCRIPTION
Commit cd6f479e79f3a33ef7a919c6b6c0c498c790f154 added new column refobjversion
to pg_depend. However, there is a GPDB-specific test that does SELECT * FROM
pg_depend. Since it's the only test doing that, and it doesn't actually need
the output data, just replace it with count(*) to avoid future problems.