### PR TITLE
Fix tests in isolation2 lockmodes.out and regress partition_locking.out

### DIFF
--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1216,7 +1216,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		int32		relpages = get_rel_relpages(partRelid);
 
 		/* Partition is not analyzed */
-		if (relTuples <= 0.0)
+		if (relTuples < 0.0)
 		{
 			if (relid_exclude == InvalidOid)
 				ereport(elevel,

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1216,7 +1216,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		int32		relpages = get_rel_relpages(partRelid);
 
 		/* Partition is not analyzed */
-		if (relTuples == 0.0 && relpages == 0)
+		if (relTuples < 0.0)
 		{
 			if (relid_exclude == InvalidOid)
 				ereport(elevel,
@@ -1240,7 +1240,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		float4		relTuples = get_rel_reltuples(partRelid);
 
 		/* Partition is analyzed and we detect it is empty */
-		if (relTuples == 0.0)
+		if (relTuples < 0.0)
 			continue;
 
 		all_parts_empty = false;

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1216,7 +1216,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		int32		relpages = get_rel_relpages(partRelid);
 
 		/* Partition is not analyzed */
-		if (relTuples < 0.0)
+		if (relTuples <= 0.0)
 		{
 			if (relid_exclude == InvalidOid)
 				ereport(elevel,
@@ -1240,7 +1240,7 @@ leaf_parts_analyzed(Oid attrelid, Oid relid_exclude, List *va_cols, int elevel)
 		float4		relTuples = get_rel_reltuples(partRelid);
 
 		/* Partition is analyzed and we detect it is empty */
-		if (relTuples < 0.0)
+		if (relTuples <= 0.0)
 			continue;
 
 		all_parts_empty = false;

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1040,13 +1040,12 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                        
-----------+-----------------+---------+---------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
-(4 rows)
+ locktype | mode          | granted | relation                        
+----------+---------------+---------+---------------------------------
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+(3 rows)
 1: ROLLBACK;
 ROLLBACK
 
@@ -1094,13 +1093,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                        
-----------+-----------------+---------+---------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
-(4 rows)
+ locktype | mode          | granted | relation                        
+----------+---------------+---------+---------------------------------
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+(3 rows)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>
@@ -1111,11 +1109,10 @@ BEGIN
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                        
-----------+-----------------+---------+---------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
-(2 rows)
+ locktype | mode          | granted | relation                        
+----------+---------------+---------+---------------------------------
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+(1 row)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>
@@ -2148,9 +2145,8 @@ DELETE 10
 ----------+------------------+---------+---------------------------------
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
-(4 rows)
+(3 rows)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>
@@ -2165,9 +2161,8 @@ UPDATE 1
 ----------+------------------+---------+---------------------------------
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
-(4 rows)
+(3 rows)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>
@@ -2180,9 +2175,8 @@ DELETE 10
 1: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
-(2 rows)
+(1 row)
 1: ROLLBACK;
 ROLLBACK
 1q: ... <quitting>

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -272,12 +272,11 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |    node    
 -------------------+------------------+----------+------------
- partlockt         | AccessShareLock  | relation | n segments
  partlockt         | RowExclusiveLock | relation | n segments
  partlockt_1_prt_1 | RowExclusiveLock | relation | 1 segment
  partlockt_1_prt_2 | RowExclusiveLock | relation | 1 segment
  partlockt_1_prt_3 | RowExclusiveLock | relation | 1 segment
-(5 rows)
+(4 rows)
 
 commit;
 -- drop
@@ -440,10 +439,9 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    
 -------------------+------------------+----------+-----------
- partlockt         | AccessShareLock  | relation | 1 segment
  partlockt         | RowExclusiveLock | relation | 1 segment
  partlockt_1_prt_3 | RowExclusiveLock | relation | 1 segment
-(3 rows)
+(2 rows)
 
 commit;
 -- delete locking
@@ -451,22 +449,20 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |  node  
--------------------------+-----------------+----------+--------
- partlockt               | AccessShareLock | relation | master
- partlockt               | ExclusiveLock   | relation | master
- partlockt_1_prt_4       | ExclusiveLock   | relation | master
- partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | master
-(4 rows)
+        coalesce         |     mode      | locktype |  node  
+-------------------------+---------------+----------+--------
+ partlockt               | ExclusiveLock | relation | master
+ partlockt_1_prt_4       | ExclusiveLock | relation | master
+ partlockt_1_prt_4_i_idx | ExclusiveLock | relation | master
+(3 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |   node    
--------------------------+-----------------+----------+-----------
- partlockt               | AccessShareLock | relation | 1 segment
- partlockt               | ExclusiveLock   | relation | 1 segment
- partlockt_1_prt_4       | ExclusiveLock   | relation | 1 segment
- partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | 1 segment
-(4 rows)
+        coalesce         |     mode      | locktype |   node    
+-------------------------+---------------+----------+-----------
+ partlockt               | ExclusiveLock | relation | 1 segment
+ partlockt_1_prt_4       | ExclusiveLock | relation | 1 segment
+ partlockt_1_prt_4_i_idx | ExclusiveLock | relation | 1 segment
+(3 rows)
 
 commit;
 -- drop index

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -272,12 +272,11 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |    node    
 -------------------+------------------+----------+------------
- partlockt         | AccessShareLock  | relation | n segments
  partlockt         | RowExclusiveLock | relation | n segments
  partlockt_1_prt_1 | RowExclusiveLock | relation | 1 segment
  partlockt_1_prt_2 | RowExclusiveLock | relation | 1 segment
  partlockt_1_prt_3 | RowExclusiveLock | relation | 1 segment
-(5 rows)
+(4 rows)
 
 commit;
 -- drop
@@ -443,10 +442,9 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    
 -------------------+------------------+----------+-----------
- partlockt         | AccessShareLock  | relation | 1 segment
  partlockt         | RowExclusiveLock | relation | 1 segment
  partlockt_1_prt_3 | RowExclusiveLock | relation | 1 segment
-(3 rows)
+(2 rows)
 
 commit;
 -- delete locking
@@ -457,25 +455,23 @@ delete from partlockt where i = 4;
 -- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the pruned partitions
 -- end_ignore
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |  node  
--------------------------+-----------------+----------+--------
- partlockt               | AccessShareLock | relation | master
- partlockt               | ExclusiveLock   | relation | master
- partlockt_1_prt_4       | ExclusiveLock   | relation | master
- partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | master
-(4 rows)
+        coalesce         |     mode      | locktype |  node  
+-------------------------+---------------+----------+--------
+ partlockt               | ExclusiveLock | relation | master
+ partlockt_1_prt_4       | ExclusiveLock | relation | master
+ partlockt_1_prt_4_i_idx | ExclusiveLock | relation | master
+(3 rows)
 
 -- start_ignore
 -- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the root table
 -- end_ignore
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |   node    
--------------------------+-----------------+----------+-----------
- partlockt               | AccessShareLock | relation | 1 segment
- partlockt               | ExclusiveLock   | relation | 1 segment
- partlockt_1_prt_4       | ExclusiveLock   | relation | 1 segment
- partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | 1 segment
-(4 rows)
+        coalesce         |     mode      | locktype |   node    
+-------------------------+---------------+----------+-----------
+ partlockt               | ExclusiveLock | relation | 1 segment
+ partlockt_1_prt_4       | ExclusiveLock | relation | 1 segment
+ partlockt_1_prt_4_i_idx | ExclusiveLock | relation | 1 segment
+(3 rows)
 
 commit;
 -- drop index


### PR DESCRIPTION
1) Commit 2000b6c in src/backend/executor/execMain.c in the
InitResultRelInfo function removed the call to the
RelationGetPartitionQual function. This prevented the AccessShareLock
lock from being acquired on the root partition when working with
partitioned tables (in RelationGetPartitionQual ->
generate_partition_qual). Remove this from the GPDB-specific tests.

2) Commit 3d351d9 redefined pg_class.reltuples to be -1 before the
first VACUUM or ANALYZE. Fix this in the leaf_parts_analyzed function.