### PR TITLE
Fix test src/test/regress/expected/eagerfree.out

### DIFF
--- a/src/test/regress/expected/eagerfree.out
+++ b/src/test/regress/expected/eagerfree.out
@@ -1885,19 +1885,15 @@ explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as du
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Seq Scan on pg_class c  (cost=10000000000.00..10003029725.25 rows=15124 width=206) (actual time=24.734..41.952 rows=6569 loops=1)
-   SubPlan 1
-     ->  Index Only Scan using pg_class_oid_index on pg_class  (cost=0.29..200.30 rows=1 width=0) (never executed)
-           Index Cond: (oid = c.oid)
-           Heap Fetches: 0
    SubPlan 2
-     ->  Index Only Scan using pg_class_oid_index on pg_class pg_class_1  (cost=0.29..21127.15 rows=15124 width=4) (actual time=0.075..18.903 rows=6569 loops=1)
+     ->  Index Only Scan using pg_class_oid_index on pg_class  (cost=0.29..21127.15 rows=15124 width=4) (actual time=0.075..18.903 rows=6569 loops=1)
            Heap Fetches: 20272
  Planning time: 5.919 ms
    (slice0)    Executor memory: 937K bytes.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 43.318 ms
-(13 rows)
+(9 rows)
 
 -- BitmapScan
 -- start_ignore

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -1899,19 +1899,15 @@ explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as du
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Seq Scan on pg_class c  (cost=10000000000.00..10003029725.25 rows=15124 width=206) (actual time=24.734..41.952 rows=6569 loops=1)
-   SubPlan 1
-     ->  Index Only Scan using pg_class_oid_index on pg_class  (cost=0.29..200.30 rows=1 width=0) (never executed)
-           Index Cond: (oid = c.oid)
-           Heap Fetches: 0
    SubPlan 2
-     ->  Index Only Scan using pg_class_oid_index on pg_class pg_class_1  (cost=0.29..21127.15 rows=15124 width=4) (actual time=0.075..18.903 rows=6569 loops=1)
+     ->  Index Only Scan using pg_class_oid_index on pg_class  (cost=0.29..21127.15 rows=15124 width=4) (actual time=0.075..18.903 rows=6569 loops=1)
            Heap Fetches: 20272
  Planning time: 5.919 ms
    (slice0)    Executor memory: 937K bytes.
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
  Execution time: 43.318 ms
-(13 rows)
+(9 rows)
 
 -- BitmapScan
 -- start_ignore


### PR DESCRIPTION
Commit 41efb8340877e8ffd0023bb6b2ef22ffd1ca014d removed unused subplans
from various plans, update this GPDB-specific test too.
