### PR TITLE
Fix test src/test/regress/expected/incremental_analyze.out

### DIFF
--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -30,20 +30,20 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -82,21 +82,21 @@ WARNING:  skipping "p3_sales_1_prt_2" --- cannot analyze a mid-level partition. 
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -128,21 +128,21 @@ analyze p3_sales_1_prt_2_2_prt_2_3_prt_usa;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -179,20 +179,20 @@ analyze;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -230,20 +230,20 @@ vacuum analyze;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -287,21 +287,21 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -339,21 +339,21 @@ WARNING:  skipping "p3_sales_1_prt_2" --- cannot analyze a non-root partition us
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -386,21 +386,21 @@ WARNING:  skipping "p3_sales_1_prt_2_2_prt_2_3_prt_usa" --- cannot analyze a non
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -432,20 +432,20 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -488,21 +488,21 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -539,20 +539,20 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -605,21 +605,21 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -656,21 +656,21 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
@@ -707,20 +707,20 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
@@ -768,21 +768,21 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        0
- p3_sales_1_prt_2                                                |         0 |        0
- p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
- p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        0
- p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        0
- p3_sales_1_prt_outlying_years                                   |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
- p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        0
+ p3_sales                                                        |        -1 |        0
+ p3_sales_1_prt_2                                                |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |        -1 |        0
+ p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months                             |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |        -1 |        0
+ p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |        -1 |        0
+ p3_sales_1_prt_outlying_years                                   |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |        -1 |        0
+ p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |        -1 |        0
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1893,7 +1893,7 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
 SELECT relname, relpages, reltuples FROM pg_class WHERE relname LIKE 'incr_analyze_test%' ORDER BY relname;
           relname          | relpages | reltuples 
 ---------------------------+----------+-----------
- incr_analyze_test         |        0 |         0
+ incr_analyze_test         |        0 |        -1
  incr_analyze_test_1_prt_1 |        1 |         1
  incr_analyze_test_1_prt_2 |        2 |      1000
  incr_analyze_test_1_prt_3 |        1 |         0

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -1902,7 +1902,7 @@ SELECT tablename, attname, null_frac, n_distinct, most_common_vals, most_common_
 SELECT relname, relpages, reltuples FROM pg_class WHERE relname LIKE 'incr_analyze_test%' ORDER BY relname;
           relname          | relpages | reltuples 
 ---------------------------+----------+-----------
- incr_analyze_test         |        0 |         0
+ incr_analyze_test         |        0 |        -1
  incr_analyze_test_1_prt_1 |        1 |         1
  incr_analyze_test_1_prt_2 |        2 |      1000
  incr_analyze_test_1_prt_3 |        1 |         0


### PR DESCRIPTION
Commit 3d351d916b20534f973eda760cde17d96545d4c4 redefined pg_class.reltuples
to be -1 before the first VACUUM or ANALYZE. Adapt the output of
GPDB-specific tests previously missed.

---

P.S. #2676 is also necessary for this test to pass