### PR TITLE
Fix tests in src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -176,7 +176,13 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	 */
 	if (!SyncRepRequested() ||
 		!((volatile WalSndCtlData *) WalSndCtl)->sync_standbys_defined)
+	{
+#ifdef FAULT_INJECTOR
+		/* Simulate the case that the standby / mirror is lagging behind. */
+		if (SIMPLE_FAULT_INJECTOR("syncrep_skip_return") != FaultInjectorTypeSkip)
+#endif
 		return;
+	}
 
 	/* Cap the level for anything other than commit to remote flush only. */
 	if (commit)

--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -21,6 +21,11 @@ select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segm
 --------------------------
  Success:                 
 (1 row)
+select gp_inject_fault_infinite('syncrep_skip_return', 'skip', dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
 
 begin;
 BEGIN
@@ -54,6 +59,11 @@ select datname, wait_event, query from pg_stat_activity where wait_event = 'Sync
  isolation2test | SyncRep    | create table commit_blocking_on_standby_t1 (a int) distributed by (a); 
 (1 row)
 
+select gp_inject_fault('syncrep_skip_return', 'reset', dbid) from gp_segment_configuration where content=-1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 select gp_inject_fault('walrecv_skip_flush', 'reset', dbid) from gp_segment_configuration where content=-1 and role='m';
  gp_inject_fault 
 -----------------
@@ -93,6 +103,11 @@ select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid) from g
 
 -- Inject fault on standby to skip WAL flush.
 select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid) from gp_segment_configuration where content=-1 and role='m';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+select gp_inject_fault_infinite('syncrep_skip_return', 'skip', dbid) from gp_segment_configuration where content=-1 and role='p';
  gp_inject_fault_infinite 
 --------------------------
  Success:                 

--- a/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
@@ -14,6 +14,8 @@ select application_name, state from pg_stat_replication;
 -- Inject fault on standby to skip WAL flush.
 select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid)
 from gp_segment_configuration where content=-1 and role='m';
+select gp_inject_fault_infinite('syncrep_skip_return', 'skip', dbid)
+from gp_segment_configuration where content=-1 and role='p';
 
 begin;
 create or replace function wait_for_pg_stat_activity(timeout_secs int)
@@ -53,6 +55,8 @@ select wait_for_pg_stat_activity(60);
 select datname, wait_event, query from pg_stat_activity
 where wait_event = 'SyncRep';
 
+select gp_inject_fault('syncrep_skip_return', 'reset', dbid)
+from gp_segment_configuration where content=-1 and role='p';
 select gp_inject_fault('walrecv_skip_flush', 'reset', dbid)
 from gp_segment_configuration where content=-1 and role='m';
 
@@ -84,6 +88,8 @@ select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid)
 -- Inject fault on standby to skip WAL flush.
 select gp_inject_fault_infinite('walrecv_skip_flush', 'skip', dbid)
        from gp_segment_configuration where content=-1 and role='m';
+select gp_inject_fault_infinite('syncrep_skip_return', 'skip', dbid)
+       from gp_segment_configuration where content=-1 and role='p';
 
 -- Kill existing walsender.  WAL sender and WAL receiver processes
 -- will be restarted and new connection will be established.  Note


### PR DESCRIPTION
Commit be9788e in src/backend/replication/syncrep.c in the
SyncRepWaitForLSN function moved the conditional return higher and
added another return condition. The GPDB-specific test
src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql is
incompatible with this new return condition.