### PR TITLE
Fix tests in update_gp.out, qp_misc.out and qp_subquery.out

### DIFF
--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -820,7 +820,7 @@ ExecInitSubPlan(SubPlan *subplan, PlanState *parent)
 	 * This check can fail if the planner mistakenly puts a parallel-unsafe
 	 * subplan into a parallelized subquery; see ExecSerializePlan.
 	 */
-	if (sstate->planstate == NULL)
+	if (Gp_role != GP_ROLE_EXECUTE && sstate->planstate == NULL)
 		elog(ERROR, "subplan \"%s\" was not initialized",
 			 subplan->plan_name);
 


### PR DESCRIPTION
Commit 92f8718 in src/backend/executor/nodeSubplan.c added a
conditional error message in the ExecInitSubPlan function, which is
inappropriate for the GPDB query executor.