### PR TITLE
Fix test src/test/regress/expected/qp_misc_rio.out

### DIFF
--- a/src/test/regress/expected/qp_misc_rio.out
+++ b/src/test/regress/expected/qp_misc_rio.out
@@ -730,9 +730,9 @@ order by a;
 -- does. The fix was submitted to upstream PostgreSQL and fixed there in
 -- version 8.4.16 (commit 5c4eb9166e.)
 -- ----------------------------------------------------------------------
-select to_date('-4713-11-23', 'yyyy-mm-dd');
-ERROR:  date out of range: "-4713-11-23"
-select to_date('-4713-11-24', 'yyyy-mm-dd');
+select to_date('-4714-11-23', 'yyyy-mm-dd');
+ERROR:  date out of range: "-4714-11-23"
+select to_date('-4714-11-24', 'yyyy-mm-dd');
     to_date    
 ---------------
  11-24-4714 BC

--- a/src/test/regress/sql/qp_misc_rio.sql
+++ b/src/test/regress/sql/qp_misc_rio.sql
@@ -535,7 +535,7 @@ order by a;
 -- does. The fix was submitted to upstream PostgreSQL and fixed there in
 -- version 8.4.16 (commit 5c4eb9166e.)
 -- ----------------------------------------------------------------------
-select to_date('-4713-11-23', 'yyyy-mm-dd');
-select to_date('-4713-11-24', 'yyyy-mm-dd');
+select to_date('-4714-11-23', 'yyyy-mm-dd');
+select to_date('-4714-11-24', 'yyyy-mm-dd');
 select to_date('5874897-12-31', 'yyyy-mm-dd');
 select to_date('5874898-01-01', 'yyyy-mm-dd');


### PR DESCRIPTION
Commit 489c9c3407cbfd473c2f8d7863ffaaf6d2e8fcf8 changed the way negative
dates are handled, so GPDB-specific test that was relying on this should be
updated as well.