### PR TITLE
Fix test src/test/regress/expected/gporca.out

### DIFF
--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14373,7 +14373,7 @@ from (select (min(i) over (order by j)) as i, j from window_agg_test) tt
 where t.j = tt.j;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Update on window_agg_test t  (cost=3699.81..185385.16 rows=0 width=50)
+ Update on window_agg_test t  (cost=3699.81..185385.16 rows=0 width=0)
    ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3699.81..185385.16 rows=2471070 width=50)
          ->  Hash Join  (cost=3699.81..135963.76 rows=2471070 width=50)
                Hash Cond: (tt.j = t.j)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14373,7 +14373,7 @@ from (select (min(i) over (order by j)) as i, j from window_agg_test) tt
 where t.j = tt.j;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Update on window_agg_test t  (cost=3699.81..185385.16 rows=2471070 width=50)
+ Update on window_agg_test t  (cost=3699.81..185385.16 rows=0 width=50)
    ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3699.81..185385.16 rows=2471070 width=50)
          ->  Hash Join  (cost=3699.81..135963.76 rows=2471070 width=50)
                Hash Cond: (tt.j = t.j)


### PR DESCRIPTION
Commit f0f13a3a08b2757997410f3a1c38bdc22973c525 changed the output rows
estimate for UPDATE without RETURNING to 0. Most tests weren't affected,
since single-line EXPLAIN ignores cost diffs anyway. This test seems to be
the only multi-line EXPLAIN in the test suite where these diffs matter.