### PR TITLE
Fix synchronous replication on the coordinator

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -173,9 +173,13 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	 * described in SyncRepUpdateSyncStandbysDefined(). On the other
 	 * hand, if it's false, the lock is not necessary because we don't touch
 	 * the queue.
+	 *
+	 * GGDB: the coordinator should be able to commit even if standby is not
+	 * available. Therefore, at the coordinator, we make a separate check below
+	 * about whether synchronous replication is currently available or not.
 	 */
-	if (!SyncRepRequested() ||
-		!((volatile WalSndCtlData *) WalSndCtl)->sync_standbys_defined)
+	if (!IS_QUERY_DISPATCHER() && (!SyncRepRequested() ||
+		!((volatile WalSndCtlData *) WalSndCtl)->sync_standbys_defined))
 		return;
 
 	/* Cap the level for anything other than commit to remote flush only. */


### PR DESCRIPTION
Commit be9788e9989a0744ba60ab100153340fd123b786 added a fast path for
SyncRepWaitForLSN, but it relies on the synchronous_standby_names GUC, which is
always empty on the coordinator.
Fix it by disabling the fast path on the coordinator.