### PR TITLE
Fix test src/test/recovery/t/021_row_visibility.pl

### DIFF
--- a/src/test/recovery/t/021_row_visibility.pl
+++ b/src/test/recovery/t/021_row_visibility.pl
@@ -114,6 +114,10 @@ ok(send_query_and_wait(\%psql_standby,
 #
 # 5. Check that changes in prepared xacts is invisible
 #
+
+# GPDB: PREPARE TRANSACTION is not supported on GPDB, skip
+SKIP: {
+	skip "PREPARE TRANSACTION not implemented on GPDB", 4;
 ok(send_query_and_wait(\%psql_primary, q[
 DELETE from test_visibility; -- delete old data, so we start with clean slate
 BEGIN;
@@ -150,6 +154,7 @@ ok(send_query_and_wait(\%psql_standby,
 					   q[SELECT * FROM test_visibility ORDER BY data;],
 					   qr/will_commit.*\n\(1 row\)$/m),
    'finished prepared visible');
+} # end SKIP
 
 $node_primary->stop;
 $node_standby->stop;


### PR DESCRIPTION
Commit 7b28913bcab8d1bf3dbf59c9d8fb4b51cef57664 added new TAP test, however
GPDB does not support PREPARE TRANSACTION, so disable that part of the test.