### PR TITLE
Fix "gpcheckcat should report and repair extra entries with non-oid primary keys" scenario

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/add_operator.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/add_operator.sql
@@ -2,4 +2,4 @@
 CREATE FUNCTION my_pk_schema.is_zero(int) RETURNS TABLE(f1 boolean)
 AS $$ select $1 = 0 $$  LANGUAGE SQL;
 
-CREATE OPERATOR my_pk_schema.!# (PROCEDURE = my_pk_schema.is_zero,LEFTARG = integer);
+CREATE OPERATOR my_pk_schema.!# (PROCEDURE = my_pk_schema.is_zero,RIGHTARG = integer);


### PR DESCRIPTION
This test uses a postfix operator that is no longer supported.
Fix it by using another operator type.