### PR TITLE
CI-5852 Add build for ubuntu 24

### DIFF
--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -14,13 +14,14 @@ COPY gpMgmt/bin/gpload_test/pytest_requirement.txt ./
 RUN set -eux; \
     ./README.ubuntu.bash; \
     rm README.ubuntu.bash; \
-    if [ "$(lsb_release -sr)" = "22.04" ]; then \
+    UBUNTU_VERSION="$(lsb_release -sr)"; \
+    if [ "$UBUNTU_VERSION" = "22.04" ]; then \
       wget $adb_python3; \
       apt-get install -y ./*.deb; \
       rm ./*.deb; \
-    fi; \
 # Set Python 2 as default when needed
-    test "$(lsb_release -sr)" == "22.04" && ln -s python2 /usr/bin/python; \
+    ln -s python2 /usr/bin/python; \
+    fi; \
 # Install pg_bsd_indent used by pgindent utility
     wget --progress=dot:giga --no-hsts https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz -O - | tar -xzf -; \
     make install -C pg_bsd_indent; \
@@ -39,9 +40,9 @@ RUN set -eux; \
 # ADCC extension dependencies
     $adb_python3_bin -m pip install --no-cache-dir protobuf==3.20.0 && \
 # Install isolation2 tests dependencies (psutil/wheel/installer provided by apt on 24.04+)
-    if [ "$(lsb_release -sr)" = "22.04" ]; then \
+    if [ "$UBUNTU_VERSION" = "22.04" ]; then \
       $adb_python3_bin -m pip install --no-cache-dir psutil==5.7.0 wheel installer; \
-    fi && \
+    fi ; \
 # Cleanup to reduce image size
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/man/

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -6,24 +6,12 @@ WORKDIR /home/gpadmin
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
-ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
-ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
-ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
-ARG OS_CODENAME=jammy
-
 ARG adb_python3=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/adb6-python_3.9.18-3304_all.deb
 ARG adb_python3_bin=/opt/adb6-python3.9/bin/python3
 
 COPY README.ubuntu.bash ./
 COPY gpMgmt/bin/gpload_test/pytest_requirement.txt ./
 RUN set -eux; \
-    sed -i \
-      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME} |${UBUNTU_MAIN_MIRROR}/ ${OS_CODENAME} |g" \
-      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-updates |${UBUNTU_UPDATES_MIRROR}/ ${OS_CODENAME}-updates |g" \
-      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-backports |${UBUNTU_BACKPORTS_MIRROR}/ ${OS_CODENAME}-backports |g" \
-      -e "s|http://security.ubuntu.com/ubuntu/ ${OS_CODENAME}-security |${UBUNTU_SECURITY_MIRROR}/ ${OS_CODENAME}-security |g" \
-      /etc/apt/sources.list; \
     ./README.ubuntu.bash; \
     rm README.ubuntu.bash; \
     if [ "$(lsb_release -sr)" = "22.04" ]; then \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -6,32 +6,18 @@ WORKDIR /home/gpadmin
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
-ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
-ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
-ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
-ARG OS_CODENAME=jammy
-
 ARG adb_python3=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/adb6-python_3.9.18-3304_all.deb
 ARG adb_python3_bin=/opt/adb6-python3.9/bin/python3
 
 COPY README.ubuntu.bash ./
 COPY gpMgmt/bin/gpload_test/pytest_requirement.txt ./
 RUN set -eux; \
-    sed -i \
-      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME} |${UBUNTU_MAIN_MIRROR}/ ${OS_CODENAME} |g" \
-      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-updates |${UBUNTU_UPDATES_MIRROR}/ ${OS_CODENAME}-updates |g" \
-      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-backports |${UBUNTU_BACKPORTS_MIRROR}/ ${OS_CODENAME}-backports |g" \
-      -e "s|http://security.ubuntu.com/ubuntu/ ${OS_CODENAME}-security |${UBUNTU_SECURITY_MIRROR}/ ${OS_CODENAME}-security |g" \
-      /etc/apt/sources.list; \
     ./README.ubuntu.bash; \
     rm README.ubuntu.bash; \
     if [ "$(lsb_release -sr)" = "22.04" ]; then \
       wget $adb_python3; \
       apt-get install -y ./*.deb; \
       rm ./*.deb; \
-    else \
-      mkdir -p "$(dirname $adb_python3_bin)" && ln -sf "$(which python3)" $adb_python3_bin; \
     fi; \
 # Set Python 2 as default when needed
     test "$(lsb_release -sr)" == "22.04" && ln -s python2 /usr/bin/python; \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -10,25 +10,29 @@ ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
 ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
 ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
 ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
+ARG OS_CODENAME=jammy
 
 ARG adb_python3=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/adb6-python_3.9.18-3304_all.deb
-
 ARG adb_python3_bin=/opt/adb6-python3.9/bin/python3
 
 COPY README.ubuntu.bash ./
 COPY gpMgmt/bin/gpload_test/pytest_requirement.txt ./
 RUN set -eux; \
     sed -i \
-      -e "s|http://archive.ubuntu.com/ubuntu/ jammy |${UBUNTU_MAIN_MIRROR}/ jammy |g" \
-      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-updates |${UBUNTU_UPDATES_MIRROR}/ jammy-updates |g" \
-      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-backports |${UBUNTU_BACKPORTS_MIRROR}/ jammy-backports |g" \
-      -e "s|http://security.ubuntu.com/ubuntu/ jammy-security |${UBUNTU_SECURITY_MIRROR}/ jammy-security |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME} |${UBUNTU_MAIN_MIRROR}/ ${OS_CODENAME} |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-updates |${UBUNTU_UPDATES_MIRROR}/ ${OS_CODENAME}-updates |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-backports |${UBUNTU_BACKPORTS_MIRROR}/ ${OS_CODENAME}-backports |g" \
+      -e "s|http://security.ubuntu.com/ubuntu/ ${OS_CODENAME}-security |${UBUNTU_SECURITY_MIRROR}/ ${OS_CODENAME}-security |g" \
       /etc/apt/sources.list; \
     ./README.ubuntu.bash; \
     rm README.ubuntu.bash; \
-    wget $adb_python3; \
-    apt install -y ./*.deb; \
-    rm ./*.deb; \
+    if [ "$(lsb_release -sr)" = "22.04" ]; then \
+      wget $adb_python3; \
+      apt-get install -y ./*.deb; \
+      rm ./*.deb; \
+    else \
+      mkdir -p "$(dirname $adb_python3_bin)" && ln -sf "$(which python3)" $adb_python3_bin; \
+    fi; \
 # Set Python 2 as default when needed
     test "$(lsb_release -sr)" == "22.04" && ln -s python2 /usr/bin/python; \
 # Install pg_bsd_indent used by pgindent utility
@@ -48,8 +52,10 @@ RUN set -eux; \
     rm pytest_requirement.txt && \
 # ADCC extension dependencies
     $adb_python3_bin -m pip install --no-cache-dir protobuf==3.20.0 && \
-# Install isolation2 tests dependencies
-    $adb_python3_bin -m pip install --no-cache-dir psutil==5.7.0 wheel installer && \
+# Install isolation2 tests dependencies (psutil/wheel/installer provided by apt on 24.04+)
+    if [ "$(lsb_release -sr)" = "22.04" ]; then \
+      $adb_python3_bin -m pip install --no-cache-dir psutil==5.7.0 wheel installer; \
+    fi && \
 # Cleanup to reduce image size
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/man/

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -6,12 +6,24 @@ WORKDIR /home/gpadmin
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
+ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
+ARG OS_CODENAME=jammy
+
 ARG adb_python3=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/adb6-python_3.9.18-3304_all.deb
 ARG adb_python3_bin=/opt/adb6-python3.9/bin/python3
 
 COPY README.ubuntu.bash ./
 COPY gpMgmt/bin/gpload_test/pytest_requirement.txt ./
 RUN set -eux; \
+    sed -i \
+      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME} |${UBUNTU_MAIN_MIRROR}/ ${OS_CODENAME} |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-updates |${UBUNTU_UPDATES_MIRROR}/ ${OS_CODENAME}-updates |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ ${OS_CODENAME}-backports |${UBUNTU_BACKPORTS_MIRROR}/ ${OS_CODENAME}-backports |g" \
+      -e "s|http://security.ubuntu.com/ubuntu/ ${OS_CODENAME}-security |${UBUNTU_SECURITY_MIRROR}/ ${OS_CODENAME}-security |g" \
+      /etc/apt/sources.list; \
     ./README.ubuntu.bash; \
     rm README.ubuntu.bash; \
     if [ "$(lsb_release -sr)" = "22.04" ]; then \


### PR DESCRIPTION
## Add build for ubuntu 24 (#2702)

- remove ubuntu mirrors to use internal mirror via --add-host arg;
- install psutil only for ubuntu 22.

Task: CI-5852