### PR TITLE
Fix pg_upgrade collation version restore

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -20002,10 +20002,12 @@ appendIndexCollationVersion(PQExpBuffer buffer, IndxInfo *indxinfo, int enc,
 	if (coll_unknown)
 	{
 		appendPQExpBuffer(buffer,
-						  "\n-- For binary upgrade, clobber new index's collation versions\n");
+						  "\n-- For binary upgrade, clobber new index's collation versions\n"
+						  "SET allow_system_table_mods = true;\n");
 		appendPQExpBuffer(buffer,
 						  "UPDATE pg_catalog.pg_depend SET refobjversion = 'unknown' WHERE objid = '%u'::pg_catalog.oid AND refclassid = 'pg_catalog.pg_collation'::regclass AND refobjversion IS NOT NULL;\n",
 						  indxinfo->dobj.catId.oid);
+		appendPQExpBuffer(buffer, "RESET allow_system_table_mods");
 	}
 
 	/* Restore the versions that were recorded by the old cluster (if any). */
@@ -20019,7 +20021,8 @@ appendIndexCollationVersion(PQExpBuffer buffer, IndxInfo *indxinfo, int enc,
 
 	if (ninddependcollnames > 0)
 		appendPQExpBufferStr(buffer,
-							 "\n-- For binary upgrade, restore old index's collation versions\n");
+							 "\n-- For binary upgrade, restore old index's collation versions\n"
+							 "SET allow_system_table_mods = true;\n");
 	for (int i = 0; i < ninddependcollnames; i++)
 	{
 		/*
@@ -20033,6 +20036,9 @@ appendIndexCollationVersion(PQExpBuffer buffer, IndxInfo *indxinfo, int enc,
 		appendStringLiteralAH(buffer,inddependcollnamesarray[i], fout);
 		appendPQExpBuffer(buffer, "::regcollation;\n");
 	}
+
+	if (ninddependcollnames > 0)
+		appendPQExpBufferStr(buffer, "RESET allow_system_table_mods;\n");
 
 	if (inddependcollnamesarray)
 		free(inddependcollnamesarray);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -20007,7 +20007,7 @@ appendIndexCollationVersion(PQExpBuffer buffer, IndxInfo *indxinfo, int enc,
 		appendPQExpBuffer(buffer,
 						  "UPDATE pg_catalog.pg_depend SET refobjversion = 'unknown' WHERE objid = '%u'::pg_catalog.oid AND refclassid = 'pg_catalog.pg_collation'::regclass AND refobjversion IS NOT NULL;\n",
 						  indxinfo->dobj.catId.oid);
-		appendPQExpBuffer(buffer, "RESET allow_system_table_mods");
+		appendPQExpBuffer(buffer, "RESET allow_system_table_mods;\n");
 	}
 
 	/* Restore the versions that were recorded by the old cluster (if any). */


### PR DESCRIPTION
Commit 257836a75585934cc05ed7a80bccf8190d41e056 added restoring of the collation
versions, but in the ggdb modification of the catalog tables requires enabling
allow_system_table_mods GUC.