### PR TITLE
Fix test src/test/isolation2/input/resgroup/resgroup_cpuset.source

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpuset.source
@@ -170,11 +170,11 @@ CREATE VIEW busy AS
     bigtable t3,
     bigtable t4,
     bigtable t5
-    WHERE 0 = (t1.c1 % 2 + 10000)!
-      AND 0 = (t2.c1 % 2 + 10000)!
-      AND 0 = (t3.c1 % 2 + 10000)!
-      AND 0 = (t4.c1 % 2 + 10000)!
-      AND 0 = (t5.c1 % 2 + 10000)!
+    WHERE 0 = factorial(t1.c1 % 2 + 10000)
+      AND 0 = factorial(t2.c1 % 2 + 10000)
+      AND 0 = factorial(t3.c1 % 2 + 10000)
+      AND 0 = factorial(t4.c1 % 2 + 10000)
+      AND 0 = factorial(t5.c1 % 2 + 10000)
     ;
 
 CREATE VIEW cancel_all AS

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -39,7 +39,7 @@ CREATE
 CREATE TABLE bigtable AS SELECT i AS c1, 'abc' AS c2 FROM generate_series(1,50000) i;
 CREATE 50000
 
-CREATE VIEW busy AS SELECT count(*) FROM bigtable t1, bigtable t2, bigtable t3, bigtable t4, bigtable t5 WHERE 0 = (t1.c1 % 2 + 10000)! AND 0 = (t2.c1 % 2 + 10000)! AND 0 = (t3.c1 % 2 + 10000)! AND 0 = (t4.c1 % 2 + 10000)! AND 0 = (t5.c1 % 2 + 10000)! ;
+CREATE VIEW busy AS SELECT count(*) FROM bigtable t1, bigtable t2, bigtable t3, bigtable t4, bigtable t5 WHERE 0 = factorial(t1.c1 % 2 + 10000) AND 0 = factorial(t2.c1 % 2 + 10000) AND 0 = factorial(t3.c1 % 2 + 10000) AND 0 = factorial(t4.c1 % 2 + 10000) AND 0 = factorial(t5.c1 % 2 + 10000) ;
 CREATE
 
 CREATE VIEW cancel_all AS SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * FROM busy%';


### PR DESCRIPTION
Commit 76f412ab310554acb970a0b73c8d1f37f35548c6 removed factorial operators,
leaving only the factorial() function. Replace in GPDB-specific tests.
